### PR TITLE
[POAE7-2335] CiderBatch Refactor for Better Null Allocation

### DIFF
--- a/cider/exec/module/batch/CiderArrowBufferHolder.cpp
+++ b/cider/exec/module/batch/CiderArrowBufferHolder.cpp
@@ -28,6 +28,7 @@ CiderArrowArrayBufferHolder::CiderArrowArrayBufferHolder(size_t buffer_num,
                                                          size_t children_num,
                                                          bool dict)
     : buffers_(buffer_num, nullptr)
+    , buffers_bytes_(buffer_num, 0)
     , children_ptr_(children_num, nullptr)
     , children_and_dict_(children_num + (dict ? 1 : 0))
     , has_dict_(dict) {
@@ -67,12 +68,9 @@ ArrowArray* CiderArrowArrayBufferHolder::getDictPtr() {
   return has_dict_ ? &children_and_dict_.back() : nullptr;
 }
 
-CiderArrowSchemaBufferHolder::CiderArrowSchemaBufferHolder(size_t children_num,
-                                                           bool null_vector,
-                                                           bool dict)
+CiderArrowSchemaBufferHolder::CiderArrowSchemaBufferHolder(size_t children_num, bool dict)
     : children_ptr_(children_num, nullptr)
     , children_and_dict_(children_num + (dict ? 1 : 0))
-    , null_vector_(null_vector)
     , has_dict_(dict) {
   for (size_t i = 0; i < children_num; ++i) {
     children_ptr_[i] = &children_and_dict_[i];

--- a/cider/exec/module/batch/CiderArrowBufferHolder.h
+++ b/cider/exec/module/batch/CiderArrowBufferHolder.h
@@ -50,6 +50,7 @@ class CiderArrowArrayBufferHolder {
   void relaseBuffer(size_t index);
 
   std::vector<void*> buffers_;
+  std::vector<size_t> buffers_bytes_;  // Used for allocator.
   std::vector<ArrowArray*> children_ptr_;
   std::vector<ArrowArray> children_and_dict_;
   const bool has_dict_;
@@ -57,18 +58,15 @@ class CiderArrowArrayBufferHolder {
 
 class CiderArrowSchemaBufferHolder {
  public:
-  CiderArrowSchemaBufferHolder(size_t children_num, bool null_vector, bool dict);
+  CiderArrowSchemaBufferHolder(size_t children_num, bool dict);
 
   ArrowSchema** getChildrenPtrs() { return children_ptr_.data(); }
 
   ArrowSchema* getDictPtr();
 
-  bool needNullVector() const { return null_vector_; }
-
  private:
   std::vector<ArrowSchema*> children_ptr_;
   std::vector<ArrowSchema> children_and_dict_;
-  const bool null_vector_;
   const bool has_dict_;
 };
 

--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -213,7 +213,6 @@ ArrowSchema* convertCiderTypeInfoToArrowSchema(const SQLTypeInfo& sql_info) {
 
         CiderArrowSchemaBufferHolder* holder =
             new CiderArrowSchemaBufferHolder(info.getChildrenNum(),
-                                             !info.get_notnull(),
                                              false);  // TODO: Dictionary support is TBD;
         schema->children = holder->getChildrenPtrs();
         schema->dictionary = holder->getDictPtr();

--- a/cider/exec/operator/aggregate/CiderAggTargetColExtractor.h
+++ b/cider/exec/operator/aggregate/CiderAggTargetColExtractor.h
@@ -40,6 +40,7 @@ class CiderAggTargetColExtractor {
   const std::string name_;
   const size_t col_index_;
   size_t null_offset_;
+  bool null_;
 };
 
 #endif

--- a/cider/exec/operator/aggregate/CiderAggTargetColExtractorTmpl.h
+++ b/cider/exec/operator/aggregate/CiderAggTargetColExtractorTmpl.h
@@ -46,6 +46,7 @@ class SimpleAggExtractor : public CiderAggTargetColExtractor {
                                   : hashtable->getTargetNullVectorOffset();
     index_in_null_vector_ =
         colInfo.is_key ? col_index_ : col_index_ - hashtable->getKeyColNum();
+    null_ = !colInfo.sql_type_info.get_notnull();
   }
 
   void extract(const std::vector<const int8_t*>& rowAddrs, int8_t* outAddrs) override {
@@ -65,7 +66,7 @@ class SimpleAggExtractor : public CiderAggTargetColExtractor {
 
     CHECK(scalarOutput->resizeBatch(rowNum, true));
     TT* buffer = scalarOutput->getMutableRawData();
-    uint8_t* nulls = scalarOutput->getMutableNulls();
+    uint8_t* nulls = null_ ? scalarOutput->getMutableNulls() : nullptr;
 
     if (nulls) {
       int64_t null_count = 0;
@@ -148,6 +149,7 @@ class AVGAggExtractor : public CiderAggTargetColExtractor {
 
     sum_offset_ = sumColInfo.slot_offset;
     count_offset_ = countColInfo.slot_offset;
+    null_ = !sumColInfo.sql_type_info.get_notnull();
   }
 
   void extract(const std::vector<const int8_t*>& rowAddrs, int8_t* outAddr) override {
@@ -169,7 +171,7 @@ class AVGAggExtractor : public CiderAggTargetColExtractor {
 
     CHECK(scalarOutput->resizeBatch(rowNum, true));
     AVGT* buffer = scalarOutput->getMutableRawData();
-    uint8_t* nulls = scalarOutput->getMutableNulls();
+    uint8_t* nulls = null_ ? scalarOutput->getMutableNulls() : nullptr;
 
     if (nulls) {
       int64_t null_count = 0;

--- a/cider/include/cider/batch/ScalarBatch.h
+++ b/cider/include/cider/batch/ScalarBatch.h
@@ -42,22 +42,6 @@ class ScalarBatch final : public CiderBatch {
     checkArrowEntries();
   }
 
-  bool resizeBatch(int64_t size, bool default_not_null = false) override {
-    CHECK(!isMoved());
-    if (!permitBufferAllocate()) {
-      return false;
-    }
-
-    auto array_holder = reinterpret_cast<CiderArrowArrayBufferHolder*>(getArrayPrivate());
-
-    array_holder->allocBuffer(1, sizeof(T) * size);
-    bool ret = resizeNullVector(0, size, default_not_null);
-
-    setLength(size);
-
-    return ret;
-  }
-
   T* getMutableRawData() {
     CHECK(!isMoved());
     return reinterpret_cast<T*>(const_cast<void*>(getBuffersPtr()[1]));
@@ -66,6 +50,21 @@ class ScalarBatch final : public CiderBatch {
   const T* getRawData() const {
     CHECK(!isMoved());
     return reinterpret_cast<const T*>(getBuffersPtr()[1]);
+  }
+
+ protected:
+  bool resizeData(int64_t size) override {
+    CHECK(!isMoved());
+    if (!permitBufferAllocate()) {
+      return false;
+    }
+
+    auto array_holder = reinterpret_cast<CiderArrowArrayBufferHolder*>(getArrayPrivate());
+
+    array_holder->allocBuffer(1, sizeof(T) * size);
+    setLength(size);
+
+    return true;
   }
 
  private:

--- a/cider/include/cider/batch/StructBatch.h
+++ b/cider/include/cider/batch/StructBatch.h
@@ -41,16 +41,16 @@ class StructBatch final : public CiderBatch {
     checkArrowEntries();
   }
 
-  bool resizeBatch(int64_t size, bool default_not_null = false) override {
+ protected:
+  bool resizeData(int64_t size) override {
     CHECK(!isMoved());
     if (!permitBufferAllocate()) {
       return false;
     }
 
-    bool ret = resizeNullVector(0, size, default_not_null);
     setLength(size);
 
-    return ret;
+    return true;
   }
 
  private:

--- a/cider/tests/CiderAggTestHelper.h
+++ b/cider/tests/CiderAggTestHelper.h
@@ -260,19 +260,17 @@ void runTest(const std::string& test_name,
   for (size_t i = 0; i < input_batch->getChildrenNum(); ++i) {
     auto child = input_batch->getChildAt(i);
     const uint8_t* given_nulls = nulls[i].as<uint8_t>();
-    if (child->isNullable()) {
-      uint8_t* child_nulls = child->getMutableNulls();
-      int64_t null_count = 0;
-      for (size_t j = 0; j < child->getLength(); ++j) {
-        if (CiderBitUtils::isBitSetAt(given_nulls, j)) {
-          CiderBitUtils::setBitAt(child_nulls, j);
-        } else {
-          CiderBitUtils::clearBitAt(child_nulls, j);
-          ++null_count;
-        }
+    uint8_t* child_nulls = child->getMutableNulls();
+    int64_t null_count = 0;
+    for (size_t j = 0; j < child->getLength(); ++j) {
+      if (CiderBitUtils::isBitSetAt(given_nulls, j)) {
+        CiderBitUtils::setBitAt(child_nulls, j);
+      } else {
+        CiderBitUtils::clearBitAt(child_nulls, j);
+        ++null_count;
       }
-      child->setNullCount(null_count);
     }
+    child->setNullCount(null_count);
   }
 
   for (size_t i = 0; i < 10; ++i) {

--- a/cider/tests/CiderArrowBatchTest.cpp
+++ b/cider/tests/CiderArrowBatchTest.cpp
@@ -42,8 +42,7 @@ void runScalarBatchTest(ScalarBatch<T>* batch,
 
   EXPECT_TRUE(batch->resizeBatch(data.size()));
   EXPECT_EQ(batch->getLength(), data.size());
-  EXPECT_EQ(batch->getNullCount(), not_null.empty() ? 0 : (int64_t)data.size());
-
+  EXPECT_EQ(batch->getNullCount(), 0);
   {
     auto raw_data = batch->getMutableRawData();
     EXPECT_NE(raw_data, nullptr);
@@ -52,14 +51,15 @@ void runScalarBatchTest(ScalarBatch<T>* batch,
     }
   }
 
-  int64_t null_count = data.size();
+  int64_t null_count = 0;
   if (!not_null.empty()) {
     auto not_null_data = batch->getMutableNulls();
+    EXPECT_EQ(batch->getNullCount(), 0);
     EXPECT_NE(not_null_data, nullptr);
     for (size_t i = 0; i < not_null.size(); ++i) {
-      if (not_null[i]) {
-        CiderBitUtils::setBitAt(not_null_data, i);
-        --null_count;
+      if (!not_null[i]) {
+        CiderBitUtils::clearBitAt(not_null_data, i);
+        ++null_count;
       }
     }
     batch->setNullCount(null_count);
@@ -199,7 +199,7 @@ TEST_F(CiderArrowBatchTest, StructBatchTest) {
     EXPECT_TRUE(batch->isRootOwner());
     EXPECT_TRUE(batch->resizeBatch(10));
     EXPECT_EQ(batch->getLength(), 10);
-    EXPECT_EQ(batch->getNullCount(), 10);
+    EXPECT_EQ(batch->getNullCount(), 0);
     EXPECT_EQ(batch->getChildrenNum(), 8);
 
     {

--- a/cider/tests/CiderNongroupbyAggTestHelper.h
+++ b/cider/tests/CiderNongroupbyAggTestHelper.h
@@ -314,16 +314,14 @@ void runTest(const std::string& test_name,
   for (size_t i = 0; i < input_batch->getChildrenNum(); ++i) {
     auto child = input_batch->getChildAt(i);
     const uint8_t* given_nulls = nulls[i].as<uint8_t>();
-    if (child->isNullable()) {
-      uint8_t* child_nulls = child->getMutableNulls();
-      int64_t null_count = 0;
-      for (size_t j = 0; j < child->getLength(); ++j) {
-        if (!all_null && CiderBitUtils::isBitSetAt(given_nulls, j)) {
-          CiderBitUtils::setBitAt(child_nulls, j);
-        } else {
-          CiderBitUtils::clearBitAt(child_nulls, j);
-          ++null_count;
-        }
+    uint8_t* child_nulls = child->getMutableNulls();
+    int64_t null_count = 0;
+    for (size_t j = 0; j < child->getLength(); ++j) {
+      if (!all_null && CiderBitUtils::isBitSetAt(given_nulls, j)) {
+        CiderBitUtils::setBitAt(child_nulls, j);
+      } else {
+        CiderBitUtils::clearBitAt(child_nulls, j);
+        ++null_count;
       }
       child->setNullCount(null_count);
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://wiki.ith.intel.com/display/MOIN/How+to+contribute#Howtocontribute-CodeDevelopment&Review
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][POAE7-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation MIP, please add the link. https://wiki.ith.intel.com/display/MOIN/MIP+template
  4. If there is a discussion in the mailing list, please add the link.
-->

Change null allocation procedure in new CiderBatch.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To make the null allocation in CiderBatch on demand.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

- ```resizeBatch``` will not (re-)allocate nulls automatically unless the nulls exists.
- ```getMutableNulls``` will has a side effect to allocate nulls.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UTs

### Which label does this PR belong to?
<!-- 
If the label supposed to be bug, coderefactor or infra. Please use the UPPER case of these three words. For other labels: 
veloxIntegration, cider, documentation, CICD, test, benchmark, publicApi,  they are not need to be specified here. And try to ensure that the capitalization of the above three words does not appear in the PR as much as possible.
-->
Infra

Pls take a review. @jikunshang @xieqi @winningsix 
