### PR TITLE
[POAE7-2328] code refactor with CiderAllocator

### DIFF
--- a/cider-velox/src/ArrowConvertorUtils.cpp
+++ b/cider-velox/src/ArrowConvertorUtils.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "ArrowConvertorUtils.h"
+#include <cstdint>
 #include "BitUtils.h"
 #include "TypeConversions.h"
 
@@ -28,10 +29,11 @@ namespace facebook::velox::plugin {
 template <typename T>
 int8_t* convertToCiderImpl(const ArrowSchema& arrowSchema,
                            const ArrowArray& arrowArray,
-                           int num_rows) {
+                           int num_rows,
+                           std::shared_ptr<CiderAllocator> allocator) {
   const uint64_t* nulls = static_cast<const uint64_t*>(arrowArray.buffers[0]);
   // cannot directly change arrow buffers as const array, need memcpy
-  T* column = (T*)std::malloc(sizeof(T) * num_rows);
+  T* column = reinterpret_cast<T*>(allocator->allocate(sizeof(T) * num_rows));
   memcpy(column, arrowArray.buffers[1], sizeof(T) * num_rows);
   // set null value
   T nullValue = getNullValue<T>();
@@ -49,12 +51,13 @@ int8_t* convertToCiderImpl(const ArrowSchema& arrowSchema,
 int8_t* convertTimestamp(const char* arrow_type,
                          const ArrowSchema& arrowSchema,
                          const ArrowArray& arrowArray,
-                         int num_rows) {
+                         int num_rows,
+                         std::shared_ptr<CiderAllocator> allocator) {
   if (arrow_type[1] == 't') {
     if (arrow_type[2] == 's' || arrow_type[2] == 'm') {
-      return convertToCiderImpl<int32_t>(arrowSchema, arrowArray, num_rows);
+      return convertToCiderImpl<int32_t>(arrowSchema, arrowArray, num_rows, allocator);
     } else if (arrow_type[2] == 'u' || arrow_type[2] == 'n') {
-      return convertToCiderImpl<int64_t>(arrowSchema, arrowArray, num_rows);
+      return convertToCiderImpl<int64_t>(arrowSchema, arrowArray, num_rows, allocator);
     }
   }
   VELOX_UNSUPPORTED("Conversion is not supported yet, arrow_type is {}", arrow_type);
@@ -62,26 +65,27 @@ int8_t* convertTimestamp(const char* arrow_type,
 
 int8_t* convertToCider(const ArrowSchema& arrowSchema,
                        const ArrowArray& arrowArray,
-                       int num_rows) {
+                       int num_rows,
+                       std::shared_ptr<CiderAllocator> allocator) {
   const char* arrow_type = arrowSchema.format;
   switch (arrow_type[0]) {
     case 'b':
-      return convertToCiderImpl<bool>(arrowSchema, arrowArray, num_rows);
+      return convertToCiderImpl<bool>(arrowSchema, arrowArray, num_rows, allocator);
     case 'c':
-      return convertToCiderImpl<int8_t>(arrowSchema, arrowArray, num_rows);
+      return convertToCiderImpl<int8_t>(arrowSchema, arrowArray, num_rows, allocator);
     case 's':
-      return convertToCiderImpl<int16_t>(arrowSchema, arrowArray, num_rows);
+      return convertToCiderImpl<int16_t>(arrowSchema, arrowArray, num_rows, allocator);
     case 'i':
-      return convertToCiderImpl<int32_t>(arrowSchema, arrowArray, num_rows);
+      return convertToCiderImpl<int32_t>(arrowSchema, arrowArray, num_rows, allocator);
     case 'l':
     case 'd':  // decimal
-      return convertToCiderImpl<int64_t>(arrowSchema, arrowArray, num_rows);
+      return convertToCiderImpl<int64_t>(arrowSchema, arrowArray, num_rows, allocator);
     case 'f':
-      return convertToCiderImpl<float>(arrowSchema, arrowArray, num_rows);
+      return convertToCiderImpl<float>(arrowSchema, arrowArray, num_rows, allocator);
     case 'g':
-      return convertToCiderImpl<double>(arrowSchema, arrowArray, num_rows);
+      return convertToCiderImpl<double>(arrowSchema, arrowArray, num_rows, allocator);
     case 't':
-      return convertTimestamp(arrow_type, arrowSchema, arrowArray, num_rows);
+      return convertTimestamp(arrow_type, arrowSchema, arrowArray, num_rows, allocator);
     default:
       VELOX_UNSUPPORTED("Conversion is not supported yet, arrow_type is {}", arrow_type);
   }
@@ -99,9 +103,13 @@ static void releaseArray(ArrowArray* array) {
 }
 
 template <typename T>
-void convertToArrowImpl(ArrowArray& arrowArray, const int8_t* data_buffer, int num_rows) {
+void convertToArrowImpl(ArrowArray& arrowArray,
+                        const int8_t* data_buffer,
+                        int num_rows,
+                        std::shared_ptr<CiderAllocator> allocator) {
   int64_t nullCount = 0;
-  uint64_t* nulls = (uint64_t*)std::malloc(sizeof(uint64_t*) * num_rows);
+  uint64_t* nulls =
+      reinterpret_cast<uint64_t*>(allocator->allocate(sizeof(uint64_t*) * num_rows));
   const T* srcValues = reinterpret_cast<const T*>(data_buffer);
   T nullValue = getNullValue<T>();
   for (auto pos = 0; pos < num_rows; pos++) {
@@ -114,7 +122,8 @@ void convertToArrowImpl(ArrowArray& arrowArray, const int8_t* data_buffer, int n
   }
   // 2 for null buffer and value buffer
   arrowArray.n_buffers = 2;
-  const void** buffers = (const void**)malloc(sizeof(void*) * arrowArray.n_buffers);
+  const void** buffers = reinterpret_cast<const void**>(
+      allocator->allocate(sizeof(void*) * arrowArray.n_buffers));
   buffers[0] = (nullCount == 0) ? nullptr : (const void*)nulls;
   buffers[1] = (num_rows == 0) ? nullptr : (const void*)srcValues;
   arrowArray.buffers = buffers;
@@ -137,12 +146,13 @@ static void releaseSchema(ArrowSchema* arrowSchema) {
 void convertTimestamp(const char* arrow_type,
                       ArrowArray& arrowArray,
                       const int8_t* data_buffer,
-                      int num_rows) {
+                      int num_rows,
+                      std::shared_ptr<CiderAllocator> allocator) {
   if (arrow_type[1] == 't') {
     if (arrow_type[2] == 's' || arrow_type[2] == 'm') {
-      convertToArrowImpl<int32_t>(arrowArray, data_buffer, num_rows);
+      convertToArrowImpl<int32_t>(arrowArray, data_buffer, num_rows, allocator);
     } else if (arrow_type[2] == 'u' || arrow_type[2] == 'n') {
-      convertToArrowImpl<int64_t>(arrowArray, data_buffer, num_rows);
+      convertToArrowImpl<int64_t>(arrowArray, data_buffer, num_rows, allocator);
     }
   }
 }
@@ -151,7 +161,8 @@ void convertToArrow(ArrowArray& arrowArray,
                     ArrowSchema& arrowSchema,
                     const int8_t* data_buffer,
                     ::substrait::Type col_type,
-                    int num_rows) {
+                    int num_rows,
+                    std::shared_ptr<CiderAllocator> allocator) {
   arrowSchema = {
       getArrowFormat(col_type),
       nullptr,
@@ -165,22 +176,22 @@ void convertToArrow(ArrowArray& arrowArray,
   const char* arrow_type = arrowSchema.format;
   switch (arrow_type[0]) {
     case 'b':
-      return convertToArrowImpl<bool>(arrowArray, data_buffer, num_rows);
+      return convertToArrowImpl<bool>(arrowArray, data_buffer, num_rows, allocator);
     case 'c':
-      return convertToArrowImpl<int8_t>(arrowArray, data_buffer, num_rows);
+      return convertToArrowImpl<int8_t>(arrowArray, data_buffer, num_rows, allocator);
     case 's':
-      return convertToArrowImpl<int16_t>(arrowArray, data_buffer, num_rows);
+      return convertToArrowImpl<int16_t>(arrowArray, data_buffer, num_rows, allocator);
     case 'i':
-      return convertToArrowImpl<int32_t>(arrowArray, data_buffer, num_rows);
+      return convertToArrowImpl<int32_t>(arrowArray, data_buffer, num_rows, allocator);
     case 'l':
     case 'd':  // decimal
-      return convertToArrowImpl<int64_t>(arrowArray, data_buffer, num_rows);
+      return convertToArrowImpl<int64_t>(arrowArray, data_buffer, num_rows, allocator);
     case 'f':
-      return convertToArrowImpl<float>(arrowArray, data_buffer, num_rows);
+      return convertToArrowImpl<float>(arrowArray, data_buffer, num_rows, allocator);
     case 'g':
-      return convertToArrowImpl<double>(arrowArray, data_buffer, num_rows);
+      return convertToArrowImpl<double>(arrowArray, data_buffer, num_rows, allocator);
     case 't':
-      return convertTimestamp(arrow_type, arrowArray, data_buffer, num_rows);
+      return convertTimestamp(arrow_type, arrowArray, data_buffer, num_rows, allocator);
     default:
       VELOX_UNSUPPORTED("Conversion is not supported yet, arrow_type is {}", arrow_type);
   }

--- a/cider-velox/src/ArrowConvertorUtils.cpp
+++ b/cider-velox/src/ArrowConvertorUtils.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "ArrowConvertorUtils.h"
-#include <cstdint>
 #include "BitUtils.h"
 #include "TypeConversions.h"
 
@@ -30,10 +29,10 @@ template <typename T>
 int8_t* convertToCiderImpl(const ArrowSchema& arrowSchema,
                            const ArrowArray& arrowArray,
                            int num_rows,
-                           std::shared_ptr<CiderAllocator> allocator) {
+                           memory::MemoryPool* pool) {
   const uint64_t* nulls = static_cast<const uint64_t*>(arrowArray.buffers[0]);
   // cannot directly change arrow buffers as const array, need memcpy
-  T* column = reinterpret_cast<T*>(allocator->allocate(sizeof(T) * num_rows));
+  T* column = reinterpret_cast<T*>(pool->allocate(sizeof(T) * num_rows));
   memcpy(column, arrowArray.buffers[1], sizeof(T) * num_rows);
   // set null value
   T nullValue = getNullValue<T>();
@@ -52,12 +51,12 @@ int8_t* convertTimestamp(const char* arrow_type,
                          const ArrowSchema& arrowSchema,
                          const ArrowArray& arrowArray,
                          int num_rows,
-                         std::shared_ptr<CiderAllocator> allocator) {
+                         memory::MemoryPool* pool) {
   if (arrow_type[1] == 't') {
     if (arrow_type[2] == 's' || arrow_type[2] == 'm') {
-      return convertToCiderImpl<int32_t>(arrowSchema, arrowArray, num_rows, allocator);
+      return convertToCiderImpl<int32_t>(arrowSchema, arrowArray, num_rows, pool);
     } else if (arrow_type[2] == 'u' || arrow_type[2] == 'n') {
-      return convertToCiderImpl<int64_t>(arrowSchema, arrowArray, num_rows, allocator);
+      return convertToCiderImpl<int64_t>(arrowSchema, arrowArray, num_rows, pool);
     }
   }
   VELOX_UNSUPPORTED("Conversion is not supported yet, arrow_type is {}", arrow_type);
@@ -66,26 +65,26 @@ int8_t* convertTimestamp(const char* arrow_type,
 int8_t* convertToCider(const ArrowSchema& arrowSchema,
                        const ArrowArray& arrowArray,
                        int num_rows,
-                       std::shared_ptr<CiderAllocator> allocator) {
+                       memory::MemoryPool* pool) {
   const char* arrow_type = arrowSchema.format;
   switch (arrow_type[0]) {
     case 'b':
-      return convertToCiderImpl<bool>(arrowSchema, arrowArray, num_rows, allocator);
+      return convertToCiderImpl<bool>(arrowSchema, arrowArray, num_rows, pool);
     case 'c':
-      return convertToCiderImpl<int8_t>(arrowSchema, arrowArray, num_rows, allocator);
+      return convertToCiderImpl<int8_t>(arrowSchema, arrowArray, num_rows, pool);
     case 's':
-      return convertToCiderImpl<int16_t>(arrowSchema, arrowArray, num_rows, allocator);
+      return convertToCiderImpl<int16_t>(arrowSchema, arrowArray, num_rows, pool);
     case 'i':
-      return convertToCiderImpl<int32_t>(arrowSchema, arrowArray, num_rows, allocator);
+      return convertToCiderImpl<int32_t>(arrowSchema, arrowArray, num_rows, pool);
     case 'l':
     case 'd':  // decimal
-      return convertToCiderImpl<int64_t>(arrowSchema, arrowArray, num_rows, allocator);
+      return convertToCiderImpl<int64_t>(arrowSchema, arrowArray, num_rows, pool);
     case 'f':
-      return convertToCiderImpl<float>(arrowSchema, arrowArray, num_rows, allocator);
+      return convertToCiderImpl<float>(arrowSchema, arrowArray, num_rows, pool);
     case 'g':
-      return convertToCiderImpl<double>(arrowSchema, arrowArray, num_rows, allocator);
+      return convertToCiderImpl<double>(arrowSchema, arrowArray, num_rows, pool);
     case 't':
-      return convertTimestamp(arrow_type, arrowSchema, arrowArray, num_rows, allocator);
+      return convertTimestamp(arrow_type, arrowSchema, arrowArray, num_rows, pool);
     default:
       VELOX_UNSUPPORTED("Conversion is not supported yet, arrow_type is {}", arrow_type);
   }
@@ -106,10 +105,10 @@ template <typename T>
 void convertToArrowImpl(ArrowArray& arrowArray,
                         const int8_t* data_buffer,
                         int num_rows,
-                        std::shared_ptr<CiderAllocator> allocator) {
+                        memory::MemoryPool* pool) {
   int64_t nullCount = 0;
   uint64_t* nulls =
-      reinterpret_cast<uint64_t*>(allocator->allocate(sizeof(uint64_t*) * num_rows));
+      reinterpret_cast<uint64_t*>(pool->allocate(sizeof(uint64_t*) * num_rows));
   const T* srcValues = reinterpret_cast<const T*>(data_buffer);
   T nullValue = getNullValue<T>();
   for (auto pos = 0; pos < num_rows; pos++) {
@@ -123,7 +122,7 @@ void convertToArrowImpl(ArrowArray& arrowArray,
   // 2 for null buffer and value buffer
   arrowArray.n_buffers = 2;
   const void** buffers = reinterpret_cast<const void**>(
-      allocator->allocate(sizeof(void*) * arrowArray.n_buffers));
+      pool->allocate(sizeof(void*) * arrowArray.n_buffers));
   buffers[0] = (nullCount == 0) ? nullptr : (const void*)nulls;
   buffers[1] = (num_rows == 0) ? nullptr : (const void*)srcValues;
   arrowArray.buffers = buffers;
@@ -147,12 +146,12 @@ void convertTimestamp(const char* arrow_type,
                       ArrowArray& arrowArray,
                       const int8_t* data_buffer,
                       int num_rows,
-                      std::shared_ptr<CiderAllocator> allocator) {
+                      memory::MemoryPool* pool) {
   if (arrow_type[1] == 't') {
     if (arrow_type[2] == 's' || arrow_type[2] == 'm') {
-      convertToArrowImpl<int32_t>(arrowArray, data_buffer, num_rows, allocator);
+      convertToArrowImpl<int32_t>(arrowArray, data_buffer, num_rows, pool);
     } else if (arrow_type[2] == 'u' || arrow_type[2] == 'n') {
-      convertToArrowImpl<int64_t>(arrowArray, data_buffer, num_rows, allocator);
+      convertToArrowImpl<int64_t>(arrowArray, data_buffer, num_rows, pool);
     }
   }
 }
@@ -162,7 +161,7 @@ void convertToArrow(ArrowArray& arrowArray,
                     const int8_t* data_buffer,
                     ::substrait::Type col_type,
                     int num_rows,
-                    std::shared_ptr<CiderAllocator> allocator) {
+                    memory::MemoryPool* pool) {
   arrowSchema = {
       getArrowFormat(col_type),
       nullptr,
@@ -176,22 +175,22 @@ void convertToArrow(ArrowArray& arrowArray,
   const char* arrow_type = arrowSchema.format;
   switch (arrow_type[0]) {
     case 'b':
-      return convertToArrowImpl<bool>(arrowArray, data_buffer, num_rows, allocator);
+      return convertToArrowImpl<bool>(arrowArray, data_buffer, num_rows, pool);
     case 'c':
-      return convertToArrowImpl<int8_t>(arrowArray, data_buffer, num_rows, allocator);
+      return convertToArrowImpl<int8_t>(arrowArray, data_buffer, num_rows, pool);
     case 's':
-      return convertToArrowImpl<int16_t>(arrowArray, data_buffer, num_rows, allocator);
+      return convertToArrowImpl<int16_t>(arrowArray, data_buffer, num_rows, pool);
     case 'i':
-      return convertToArrowImpl<int32_t>(arrowArray, data_buffer, num_rows, allocator);
+      return convertToArrowImpl<int32_t>(arrowArray, data_buffer, num_rows, pool);
     case 'l':
     case 'd':  // decimal
-      return convertToArrowImpl<int64_t>(arrowArray, data_buffer, num_rows, allocator);
+      return convertToArrowImpl<int64_t>(arrowArray, data_buffer, num_rows, pool);
     case 'f':
-      return convertToArrowImpl<float>(arrowArray, data_buffer, num_rows, allocator);
+      return convertToArrowImpl<float>(arrowArray, data_buffer, num_rows, pool);
     case 'g':
-      return convertToArrowImpl<double>(arrowArray, data_buffer, num_rows, allocator);
+      return convertToArrowImpl<double>(arrowArray, data_buffer, num_rows, pool);
     case 't':
-      return convertTimestamp(arrow_type, arrowArray, data_buffer, num_rows, allocator);
+      return convertTimestamp(arrow_type, arrowArray, data_buffer, num_rows, pool);
     default:
       VELOX_UNSUPPORTED("Conversion is not supported yet, arrow_type is {}", arrow_type);
   }

--- a/cider-velox/src/ArrowConvertorUtils.h
+++ b/cider-velox/src/ArrowConvertorUtils.h
@@ -41,7 +41,7 @@ namespace facebook::velox::plugin {
 int8_t* convertToCider(const ArrowSchema& arrowSchema,
                        const ArrowArray& arrowArray,
                        int num_rows,
-                       std::shared_ptr<CiderAllocator> allocator);
+                       memory::MemoryPool* pool);
 
 /// Convert cider data buffer to ArrowArray and ArrowSchema.
 /// As ArrowArray has null buffer for null data while cider only has one
@@ -53,6 +53,6 @@ void convertToArrow(ArrowArray& arrowArray,
                     const int8_t* data_buffer,
                     ::substrait::Type col_type,
                     int num_rows,
-                    std::shared_ptr<CiderAllocator> allocator = nullptr);
+                    memory::MemoryPool* pool);
 
 }  // namespace facebook::velox::plugin

--- a/cider-velox/src/ArrowConvertorUtils.h
+++ b/cider-velox/src/ArrowConvertorUtils.h
@@ -40,7 +40,8 @@ namespace facebook::velox::plugin {
 /// including integral and floating points.
 int8_t* convertToCider(const ArrowSchema& arrowSchema,
                        const ArrowArray& arrowArray,
-                       int num_rows);
+                       int num_rows,
+                       std::shared_ptr<CiderAllocator> allocator);
 
 /// Convert cider data buffer to ArrowArray and ArrowSchema.
 /// As ArrowArray has null buffer for null data while cider only has one
@@ -51,6 +52,7 @@ void convertToArrow(ArrowArray& arrowArray,
                     ArrowSchema& arrowSchema,
                     const int8_t* data_buffer,
                     ::substrait::Type col_type,
-                    int num_rows);
+                    int num_rows,
+                    std::shared_ptr<CiderAllocator> allocator = nullptr);
 
 }  // namespace facebook::velox::plugin

--- a/cider-velox/src/ArrowDataConvertor.cpp
+++ b/cider-velox/src/ArrowDataConvertor.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "ArrowDataConvertor.h"
-#include <memory>
 #include "ArrowConvertorUtils.h"
 #include "velox/vector/arrow/Bridge.h"
 

--- a/cider-velox/src/ArrowDataConvertor.h
+++ b/cider-velox/src/ArrowDataConvertor.h
@@ -33,6 +33,8 @@ class ArrowDataConvertor : public DataConvertor {
  public:
   ArrowDataConvertor() {}
 
+  ArrowDataConvertor(std::shared_ptr<CiderAllocator> allocator);
+
   CiderBatch convertToCider(RowVectorPtr input,
                             int num_rows,
                             std::chrono::microseconds* timer) override;
@@ -40,6 +42,9 @@ class ArrowDataConvertor : public DataConvertor {
   RowVectorPtr convertToRowVector(const CiderBatch& input,
                                   const CiderTableSchema& schema,
                                   memory::MemoryPool* pool) override;
+
+ private:
+  std::shared_ptr<CiderAllocator> allocator_;
 };
 
 }  // namespace facebook::velox::plugin

--- a/cider-velox/src/ArrowDataConvertor.h
+++ b/cider-velox/src/ArrowDataConvertor.h
@@ -33,7 +33,7 @@ class ArrowDataConvertor : public DataConvertor {
  public:
   ArrowDataConvertor() {}
 
-  ArrowDataConvertor(std::shared_ptr<CiderAllocator> allocator);
+  explicit ArrowDataConvertor(std::shared_ptr<CiderAllocator> allocator);
 
   CiderBatch convertToCider(RowVectorPtr input,
                             int num_rows,

--- a/cider-velox/src/ArrowDataConvertor.h
+++ b/cider-velox/src/ArrowDataConvertor.h
@@ -33,18 +33,14 @@ class ArrowDataConvertor : public DataConvertor {
  public:
   ArrowDataConvertor() {}
 
-  explicit ArrowDataConvertor(std::shared_ptr<CiderAllocator> allocator);
-
   CiderBatch convertToCider(RowVectorPtr input,
                             int num_rows,
-                            std::chrono::microseconds* timer) override;
+                            std::chrono::microseconds* timer,
+                            memory::MemoryPool* pool) override;
 
   RowVectorPtr convertToRowVector(const CiderBatch& input,
                                   const CiderTableSchema& schema,
                                   memory::MemoryPool* pool) override;
-
- private:
-  std::shared_ptr<CiderAllocator> allocator_;
 };
 
 }  // namespace facebook::velox::plugin

--- a/cider-velox/src/CiderOperator.cpp
+++ b/cider-velox/src/CiderOperator.cpp
@@ -51,7 +51,7 @@ CiderOperator::CiderOperator(int32_t operatorId,
     auto exec_option = CiderExecutionOption::defaults();
     auto compile_option = CiderCompilationOption::defaults();
 
-    ciderCompileModule_ = CiderCompileModule::Make();
+    ciderCompileModule_ = CiderCompileModule::Make(allocator);
     auto ciderCompileResult =
         ciderCompileModule_->compile(plan, compile_option, exec_option);
     ciderRuntimeModule_ = std::make_shared<CiderRuntimeModule>(
@@ -117,7 +117,8 @@ exec::BlockingReason CiderOperator::isBlocked(ContinueFuture* future) {
       buildSideEmpty_ = true;
     }
 
-    ciderCompileModule_ = CiderCompileModule::Make();
+    auto allocator = std::make_shared<PoolAllocator>(operatorCtx_->pool());
+    ciderCompileModule_ = CiderCompileModule::Make(allocator);
 
     // TODO: add vector<RowVectorPtr> -> CiderBatch converter
     auto buildBatch = dataConvertor_->convertToCider(buildData_->data()[0],
@@ -130,7 +131,6 @@ exec::BlockingReason CiderOperator::isBlocked(ContinueFuture* future) {
 
     auto compile_option = CiderCompilationOption::defaults();
     auto exec_option = CiderExecutionOption::defaults();
-    auto allocator = std::make_shared<PoolAllocator>(operatorCtx_->pool());
     ciderRuntimeModule_ = std::make_shared<CiderRuntimeModule>(
         compileResult, compile_option, exec_option, allocator);
 

--- a/cider-velox/src/DataConvertor.cpp
+++ b/cider-velox/src/DataConvertor.cpp
@@ -19,7 +19,6 @@
  * under the License.
  */
 #include "DataConvertor.h"
-#include <memory>
 
 #include "ArrowDataConvertor.h"
 #include "RawDataConvertor.h"

--- a/cider-velox/src/DataConvertor.cpp
+++ b/cider-velox/src/DataConvertor.cpp
@@ -19,20 +19,23 @@
  * under the License.
  */
 #include "DataConvertor.h"
+#include <memory>
 
 #include "ArrowDataConvertor.h"
 #include "RawDataConvertor.h"
 
 namespace facebook::velox::plugin {
 
-std::shared_ptr<DataConvertor> DataConvertor::create(CONVERT_TYPE type) {
+std::shared_ptr<DataConvertor> DataConvertor::create(
+    CONVERT_TYPE type,
+    std::shared_ptr<CiderAllocator> allocator) {
   std::shared_ptr<DataConvertor> convertor;
   switch (type) {
     case CONVERT_TYPE::DIRECT:
-      convertor = std::make_shared<RawDataConvertor>();
+      convertor = std::make_shared<RawDataConvertor>(allocator);
       return convertor;
     case CONVERT_TYPE::ARROW:
-      convertor = std::make_shared<ArrowDataConvertor>();
+      convertor = std::make_shared<ArrowDataConvertor>(allocator);
       return convertor;
     default:
       VELOX_USER_FAIL("invalid input");

--- a/cider-velox/src/DataConvertor.cpp
+++ b/cider-velox/src/DataConvertor.cpp
@@ -26,16 +26,14 @@
 
 namespace facebook::velox::plugin {
 
-std::shared_ptr<DataConvertor> DataConvertor::create(
-    CONVERT_TYPE type,
-    std::shared_ptr<CiderAllocator> allocator) {
+std::shared_ptr<DataConvertor> DataConvertor::create(CONVERT_TYPE type) {
   std::shared_ptr<DataConvertor> convertor;
   switch (type) {
     case CONVERT_TYPE::DIRECT:
-      convertor = std::make_shared<RawDataConvertor>(allocator);
+      convertor = std::make_shared<RawDataConvertor>();
       return convertor;
     case CONVERT_TYPE::ARROW:
-      convertor = std::make_shared<ArrowDataConvertor>(allocator);
+      convertor = std::make_shared<ArrowDataConvertor>();
       return convertor;
     default:
       VELOX_USER_FAIL("invalid input");

--- a/cider-velox/src/DataConvertor.h
+++ b/cider-velox/src/DataConvertor.h
@@ -51,7 +51,8 @@ class DataConvertor {
  public:
   DataConvertor() {}
 
-  static std::shared_ptr<DataConvertor> create(CONVERT_TYPE type);
+  static std::shared_ptr<DataConvertor> create(CONVERT_TYPE type,
+                                               std::shared_ptr<CiderAllocator> allocator);
 
   virtual CiderBatch convertToCider(RowVectorPtr input,
                                     int num_rows,

--- a/cider-velox/src/DataConvertor.h
+++ b/cider-velox/src/DataConvertor.h
@@ -51,12 +51,12 @@ class DataConvertor {
  public:
   DataConvertor() {}
 
-  static std::shared_ptr<DataConvertor> create(CONVERT_TYPE type,
-                                               std::shared_ptr<CiderAllocator> allocator);
+  static std::shared_ptr<DataConvertor> create(CONVERT_TYPE type);
 
   virtual CiderBatch convertToCider(RowVectorPtr input,
                                     int num_rows,
-                                    std::chrono::microseconds* timer) = 0;
+                                    std::chrono::microseconds* timer,
+                                    memory::MemoryPool* pool) = 0;
 
   virtual RowVectorPtr convertToRowVector(const CiderBatch& input,
                                           const CiderTableSchema& schema,

--- a/cider-velox/src/RawDataConvertor.cpp
+++ b/cider-velox/src/RawDataConvertor.cpp
@@ -22,6 +22,7 @@
 #include "RawDataConvertor.h"
 #include <cmath>
 #include <cstdint>
+#include <memory>
 #include "TypeConversions.h"
 #include "cider/batch/CiderBatch.h"
 #include "substrait/type.pb.h"
@@ -36,8 +37,15 @@
 #include "velox/vector/tests/VectorTestBase.h"
 
 namespace facebook::velox::plugin {
+
+RawDataConvertor::RawDataConvertor(std::shared_ptr<CiderAllocator> allocator)
+    : allocator_(allocator) {}
+
 template <TypeKind kind>
-int8_t* toCiderImpl(VectorPtr& child, int idx, int num_rows) {
+int8_t* toCiderImpl(VectorPtr& child,
+                    int idx,
+                    int num_rows,
+                    std::shared_ptr<CiderAllocator> allocator) {
   using T = typename TypeTraits<kind>::NativeType;
   auto childVal = child->asFlatVector<T>();
   auto* rawValues = childVal->mutableRawValues();
@@ -55,11 +63,13 @@ int8_t* toCiderImpl(VectorPtr& child, int idx, int num_rows) {
 }
 
 template <TypeKind kind>
-int8_t* toCiderImplWithDictEncoding(VectorPtr& child, int idx, int num_rows) {
+int8_t* toCiderImplWithDictEncoding(VectorPtr& child,
+                                    int idx,
+                                    int num_rows,
+                                    std::shared_ptr<CiderAllocator> allocator) {
   using T = typename TypeTraits<kind>::NativeType;
   auto dict = dynamic_cast<const DictionaryVector<T>*>(child.get());
-  // TODO(YantingTao1315): new allocator API will be used in the future.
-  T* column = (T*)std::malloc(sizeof(T) * num_rows);
+  T* column = reinterpret_cast<T*>(allocator->allocate(sizeof(T) * num_rows));
   for (auto i = 0; i < num_rows; i++) {
     if (dict->isNullAt(i)) {
       T nullValue = getNullValue<T>();
@@ -72,10 +82,13 @@ int8_t* toCiderImplWithDictEncoding(VectorPtr& child, int idx, int num_rows) {
 }
 
 template <>
-int8_t* toCiderImpl<TypeKind::BOOLEAN>(VectorPtr& child, int idx, int num_rows) {
+int8_t* toCiderImpl<TypeKind::BOOLEAN>(VectorPtr& child,
+                                       int idx,
+                                       int num_rows,
+                                       std::shared_ptr<CiderAllocator> allocator) {
   auto childVal = child->asFlatVector<bool>();
   uint64_t* rawValues = childVal->mutableRawValues<uint64_t>();
-  int8_t* column = (int8_t*)std::malloc(sizeof(int8_t) * num_rows);
+  int8_t* column = allocator->allocate(sizeof(int8_t) * num_rows);
   auto nulls = child->rawNulls();
   for (auto pos = 0; pos < num_rows; pos++) {
     if (child->mayHaveNulls() && bits::isBitNull(nulls, pos)) {
@@ -88,11 +101,14 @@ int8_t* toCiderImpl<TypeKind::BOOLEAN>(VectorPtr& child, int idx, int num_rows) 
 }
 
 template <>
-int8_t* toCiderImpl<TypeKind::VARCHAR>(VectorPtr& child, int idx, int num_rows) {
+int8_t* toCiderImpl<TypeKind::VARCHAR>(VectorPtr& child,
+                                       int idx,
+                                       int num_rows,
+                                       std::shared_ptr<CiderAllocator> allocator) {
   auto childVal = child->asFlatVector<StringView>();
   auto* rawValues = childVal->mutableRawValues();
-  CiderByteArray* column =
-      (CiderByteArray*)std::malloc(sizeof(CiderByteArray) * num_rows);
+  CiderByteArray* column = reinterpret_cast<CiderByteArray*>(
+      allocator->allocate(sizeof(CiderByteArray) * num_rows));
   auto nulls = child->rawNulls();
   for (auto i = 0; i < num_rows; i++) {
     if (child->mayHaveNulls() && bits::isBitNull(nulls, i)) {
@@ -100,8 +116,8 @@ int8_t* toCiderImpl<TypeKind::VARCHAR>(VectorPtr& child, int idx, int num_rows) 
       column[i].ptr = nullptr;
     } else {
       column[i].len = rawValues[i].size();
-      // TODO: new allocator API will be used in the future.
-      column[i].ptr = (uint8_t*)std::malloc(sizeof(uint8_t) * column[i].len);
+      column[i].ptr = reinterpret_cast<uint8_t*>(
+          allocator->allocate(sizeof(uint8_t) * column[i].len));
       std::memcpy((void*)column[i].ptr, rawValues[i].data(), column[i].len);
     }
   }
@@ -109,12 +125,14 @@ int8_t* toCiderImpl<TypeKind::VARCHAR>(VectorPtr& child, int idx, int num_rows) 
 }
 
 template <>
-int8_t* toCiderImplWithDictEncoding<TypeKind::VARCHAR>(VectorPtr& child,
-                                                       int idx,
-                                                       int num_rows) {
+int8_t* toCiderImplWithDictEncoding<TypeKind::VARCHAR>(
+    VectorPtr& child,
+    int idx,
+    int num_rows,
+    std::shared_ptr<CiderAllocator> allocator) {
   auto dict = dynamic_cast<const DictionaryVector<StringView>*>(child.get());
-  CiderByteArray* column =
-      (CiderByteArray*)std::malloc(sizeof(CiderByteArray) * num_rows);
+  CiderByteArray* column = reinterpret_cast<CiderByteArray*>(
+      allocator->allocate(sizeof(CiderByteArray) * num_rows));
   for (auto i = 0; i < num_rows; i++) {
     if (dict->isNullAt(i)) {
       column[i].len = 0;
@@ -122,8 +140,8 @@ int8_t* toCiderImplWithDictEncoding<TypeKind::VARCHAR>(VectorPtr& child,
     } else {
       auto stringViewTemp = dict->valueAt(i);
       column[i].len = stringViewTemp.size();
-      // TODO(YantingTao1315): new allocator API will be used in the future.
-      column[i].ptr = (uint8_t*)std::malloc(sizeof(uint8_t) * column[i].len);
+      column[i].ptr = reinterpret_cast<uint8_t*>(
+          allocator->allocate(sizeof(uint8_t) * column[i].len));
       std::memcpy((void*)column[i].ptr, stringViewTemp.data(), column[i].len);
     }
   }
@@ -131,30 +149,39 @@ int8_t* toCiderImplWithDictEncoding<TypeKind::VARCHAR>(VectorPtr& child,
 }
 
 template <>
-int8_t* toCiderImplWithDictEncoding<TypeKind::VARBINARY>(VectorPtr& child,
-                                                         int idx,
-                                                         int num_rows) {
+int8_t* toCiderImplWithDictEncoding<TypeKind::VARBINARY>(
+    VectorPtr& child,
+    int idx,
+    int num_rows,
+    std::shared_ptr<CiderAllocator> allocator) {
   VELOX_NYI(" {} conversion is not supported with dictionary encoding",
             child->typeKind());
 }
 
 template <>
-int8_t* toCiderImpl<TypeKind::VARBINARY>(VectorPtr& child, int idx, int num_rows) {
+int8_t* toCiderImpl<TypeKind::VARBINARY>(VectorPtr& child,
+                                         int idx,
+                                         int num_rows,
+                                         std::shared_ptr<CiderAllocator> allocator) {
   VELOX_NYI(" {} conversion is not supported yet");
 }
 
 template <>
-int8_t* toCiderImplWithDictEncoding<TypeKind::INTERVAL_DAY_TIME>(VectorPtr& child,
-                                                                 int idx,
-                                                                 int num_rows) {
+int8_t* toCiderImplWithDictEncoding<TypeKind::INTERVAL_DAY_TIME>(
+    VectorPtr& child,
+    int idx,
+    int num_rows,
+    std::shared_ptr<CiderAllocator> allocator) {
   VELOX_NYI(" {} conversion is not supported with dictionary encoding",
             child->typeKind());
 }
 
 template <>
-int8_t* toCiderImpl<TypeKind::INTERVAL_DAY_TIME>(VectorPtr& child,
-                                                 int idx,
-                                                 int num_rows) {
+int8_t* toCiderImpl<TypeKind::INTERVAL_DAY_TIME>(
+    VectorPtr& child,
+    int idx,
+    int num_rows,
+    std::shared_ptr<CiderAllocator> allocator) {
   VELOX_NYI(" {} conversion is not supported yet");
 }
 
@@ -164,18 +191,24 @@ static constexpr int64_t kMilliSecsPerSec = 1000;
 static constexpr int64_t kSecsPerSec = 1;
 
 template <>
-int8_t* toCiderImplWithDictEncoding<TypeKind::TIMESTAMP>(VectorPtr& child,
-                                                         int idx,
-                                                         int num_rows) {
+int8_t* toCiderImplWithDictEncoding<TypeKind::TIMESTAMP>(
+    VectorPtr& child,
+    int idx,
+    int num_rows,
+    std::shared_ptr<CiderAllocator> allocator) {
   VELOX_NYI(" {} conversion is not supported with dictionary encoding",
             child->typeKind());
 }
 
 template <>
-int8_t* toCiderImpl<TypeKind::TIMESTAMP>(VectorPtr& child, int idx, int num_rows) {
+int8_t* toCiderImpl<TypeKind::TIMESTAMP>(VectorPtr& child,
+                                         int idx,
+                                         int num_rows,
+                                         std::shared_ptr<CiderAllocator> allocator) {
   auto childVal = child->asFlatVector<Timestamp>();
   auto* rawValues = childVal->mutableRawValues();
-  int64_t* column = (int64_t*)std::malloc(sizeof(int64_t) * num_rows);
+  int64_t* column =
+      reinterpret_cast<int64_t*>(allocator->allocate(sizeof(int64_t) * num_rows));
   auto nulls = child->rawNulls();
   for (auto pos = 0; pos < num_rows; pos++) {
     if (child->mayHaveNulls() && bits::isBitNull(nulls, pos)) {
@@ -190,18 +223,24 @@ int8_t* toCiderImpl<TypeKind::TIMESTAMP>(VectorPtr& child, int idx, int num_rows
 }
 
 template <>
-int8_t* toCiderImplWithDictEncoding<TypeKind::DATE>(VectorPtr& child,
-                                                    int idx,
-                                                    int num_rows) {
+int8_t* toCiderImplWithDictEncoding<TypeKind::DATE>(
+    VectorPtr& child,
+    int idx,
+    int num_rows,
+    std::shared_ptr<CiderAllocator> allocator) {
   VELOX_NYI(" {} conversion is not supported yet with dictionary encoding",
             child->typeKind());
 }
 
 template <>
-int8_t* toCiderImpl<TypeKind::DATE>(VectorPtr& child, int idx, int num_rows) {
+int8_t* toCiderImpl<TypeKind::DATE>(VectorPtr& child,
+                                    int idx,
+                                    int num_rows,
+                                    std::shared_ptr<CiderAllocator> allocator) {
   auto childVal = child->asFlatVector<Date>();
   auto* rawValues = childVal->mutableRawValues();
-  int64_t* column = (int64_t*)std::malloc(sizeof(int64_t) * num_rows);
+  int64_t* column =
+      reinterpret_cast<int64_t*>(allocator->allocate(sizeof(int64_t) * num_rows));
   auto nulls = child->rawNulls();
   for (auto pos = 0; pos < num_rows; pos++) {
     if (child->mayHaveNulls() && bits::isBitNull(nulls, pos)) {
@@ -213,15 +252,22 @@ int8_t* toCiderImpl<TypeKind::DATE>(VectorPtr& child, int idx, int num_rows) {
   return reinterpret_cast<int8_t*>(column);
 }
 
-int8_t* toCiderResult(VectorPtr& child, int idx, int num_rows) {
+int8_t* toCiderResult(VectorPtr& child,
+                      int idx,
+                      int num_rows,
+                      std::shared_ptr<CiderAllocator> allocator) {
   switch (child->encoding()) {
     case VectorEncoding::Simple::FLAT:
     case VectorEncoding::Simple::LAZY:
       return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          toCiderImpl, child->typeKind(), child, idx, num_rows);
+          toCiderImpl, child->typeKind(), child, idx, num_rows, allocator);
     case VectorEncoding::Simple::DICTIONARY:
-      return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          toCiderImplWithDictEncoding, child->typeKind(), child, idx, num_rows);
+      return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(toCiderImplWithDictEncoding,
+                                                child->typeKind(),
+                                                child,
+                                                idx,
+                                                num_rows,
+                                                allocator);
     default:
       VELOX_NYI(" {} conversion is not supported yet", child->encoding());
   }
@@ -239,7 +285,7 @@ CiderBatch RawDataConvertor::convertToCider(RowVectorPtr input,
     switch (child->encoding()) {
       case VectorEncoding::Simple::FLAT:
       case VectorEncoding::Simple::DICTIONARY:
-        table_ptr.push_back(toCiderResult(child, idx, num_rows));
+        table_ptr.push_back(toCiderResult(child, idx, num_rows, allocator_));
         break;
       case VectorEncoding::Simple::LAZY: {
         // For LazyVector, we will load it here and use as TypeVector to use.
@@ -249,7 +295,7 @@ CiderBatch RawDataConvertor::convertToCider(RowVectorPtr input,
         if (timer) {
           *timer += std::chrono::duration_cast<std::chrono::microseconds>(toc - tic);
         }
-        table_ptr.push_back(toCiderResult(vec, idx, num_rows));
+        table_ptr.push_back(toCiderResult(vec, idx, num_rows, allocator_));
         break;
       }
       default:

--- a/cider-velox/src/RawDataConvertor.cpp
+++ b/cider-velox/src/RawDataConvertor.cpp
@@ -22,7 +22,6 @@
 #include "RawDataConvertor.h"
 #include <cmath>
 #include <cstdint>
-#include <memory>
 #include "TypeConversions.h"
 #include "cider/batch/CiderBatch.h"
 #include "substrait/type.pb.h"

--- a/cider-velox/src/RawDataConvertor.h
+++ b/cider-velox/src/RawDataConvertor.h
@@ -33,7 +33,7 @@ class RawDataConvertor : public DataConvertor {
  public:
   RawDataConvertor() {}
 
-  RawDataConvertor(std::shared_ptr<CiderAllocator> allocator);
+  explicit RawDataConvertor(std::shared_ptr<CiderAllocator> allocator);
 
   CiderBatch convertToCider(RowVectorPtr input,
                             int num_rows,

--- a/cider-velox/src/RawDataConvertor.h
+++ b/cider-velox/src/RawDataConvertor.h
@@ -33,18 +33,14 @@ class RawDataConvertor : public DataConvertor {
  public:
   RawDataConvertor() {}
 
-  explicit RawDataConvertor(std::shared_ptr<CiderAllocator> allocator);
-
   CiderBatch convertToCider(RowVectorPtr input,
                             int num_rows,
-                            std::chrono::microseconds* timer) override;
+                            std::chrono::microseconds* timer,
+                            memory::MemoryPool* pool) override;
 
   RowVectorPtr convertToRowVector(const CiderBatch& input,
                                   const CiderTableSchema& schema,
                                   memory::MemoryPool* pool) override;
-
- private:
-  std::shared_ptr<CiderAllocator> allocator_;
 };
 
 }  // namespace facebook::velox::plugin

--- a/cider-velox/src/RawDataConvertor.h
+++ b/cider-velox/src/RawDataConvertor.h
@@ -33,6 +33,8 @@ class RawDataConvertor : public DataConvertor {
  public:
   RawDataConvertor() {}
 
+  RawDataConvertor(std::shared_ptr<CiderAllocator> allocator);
+
   CiderBatch convertToCider(RowVectorPtr input,
                             int num_rows,
                             std::chrono::microseconds* timer) override;
@@ -40,6 +42,9 @@ class RawDataConvertor : public DataConvertor {
   RowVectorPtr convertToRowVector(const CiderBatch& input,
                                   const CiderTableSchema& schema,
                                   memory::MemoryPool* pool) override;
+
+ private:
+  std::shared_ptr<CiderAllocator> allocator_;
 };
 
 }  // namespace facebook::velox::plugin

--- a/cider-velox/test/AggWithRandomDataTest.cpp
+++ b/cider-velox/test/AggWithRandomDataTest.cpp
@@ -177,7 +177,8 @@ TEST_F(AggWithRandomDataTest, AVG_Partial_Test) {
   auto substraitPlan =
       v2SPlanFragmentConvertor_->toSubstraitPlan(veloxPlan, veloxPlan->sources()[0]);
 
-  auto ciderCompileModule = CiderCompileModule::Make();
+  auto ciderCompileModule =
+      CiderCompileModule::Make(std::make_shared<CiderDefaultAllocator>());
   auto result = ciderCompileModule->compile(substraitPlan);
 
   auto outputSchema = result->getOutputCiderTableSchema();

--- a/cider-velox/test/ArrowUtilsTest.cpp
+++ b/cider-velox/test/ArrowUtilsTest.cpp
@@ -26,6 +26,9 @@
 
 using namespace facebook::velox::plugin;
 
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
+
 class ArrowUtilsTest : public testing::Test {
  public:
   template <typename T>
@@ -36,7 +39,7 @@ class ArrowUtilsTest : public testing::Test {
                        int32_t dimen = 0) {
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
-    convertToArrow(arrowArray, arrowSchema, data_buffer, col_type, num_rows);
+    convertToArrow(arrowArray, arrowSchema, data_buffer, col_type, num_rows, allocator);
     EXPECT_EQ(num_rows, arrowArray.length);
     EXPECT_EQ(null_count, arrowArray.null_count);
     EXPECT_EQ(2, arrowArray.n_buffers);
@@ -69,8 +72,9 @@ class ArrowUtilsTest : public testing::Test {
                       const std::vector<std::optional<T>>& data_buffer) {
     int num_rows = data_buffer.size();
     int64_t nullCount = 0;
-    uint64_t* nulls = (uint64_t*)std::malloc(sizeof(uint64_t*) * num_rows);
-    T* srcValues = (T*)std::malloc(sizeof(T) * num_rows);
+    uint64_t* nulls =
+        reinterpret_cast<uint64_t*>(allocator->allocate(sizeof(uint64_t*) * num_rows));
+    T* srcValues = reinterpret_cast<T*>(allocator->allocate(sizeof(T) * num_rows));
     T nullValue = getNullValue<T>();
     for (int i = 0; i < num_rows; i++) {
       if (data_buffer[i] == std::nullopt) {
@@ -82,7 +86,8 @@ class ArrowUtilsTest : public testing::Test {
       }
     }
     int64_t n_buffers = 2;
-    const void** buffers = (const void**)malloc(sizeof(void*) * n_buffers);
+    const void** buffers =
+        reinterpret_cast<const void**>(allocator->allocate(sizeof(void*) * n_buffers));
     buffers[0] = (nullCount == 0) ? nullptr : (const void*)nulls;
     buffers[1] = (num_rows == 0) ? nullptr : (const void*)srcValues;
 
@@ -110,7 +115,7 @@ class ArrowUtilsTest : public testing::Test {
         nullptr,
     };
 
-    int8_t* results = convertToCider(arrowSchema, arrowArray, num_rows);
+    int8_t* results = convertToCider(arrowSchema, arrowArray, num_rows, allocator);
     T* col = reinterpret_cast<T*>(results);
     for (auto idx = 0; idx < num_rows; idx++) {
       if (data_buffer[idx] == std::nullopt) {
@@ -123,7 +128,7 @@ class ArrowUtilsTest : public testing::Test {
 };
 
 TEST_F(ArrowUtilsTest, toArrowInteger) {
-  int32_t* col = (int32_t*)std::malloc(sizeof(int32_t) * 10);
+  int32_t* col = reinterpret_cast<int32_t*>(allocator->allocate(sizeof(int32_t) * 10));
   int num_rows = 10;
   for (int i = 0; i < num_rows; i++) {
     col[i] = i;
@@ -148,7 +153,7 @@ TEST_F(ArrowUtilsTest, toArrowInteger) {
 }
 
 TEST_F(ArrowUtilsTest, toArrowDouble) {
-  double* col = (double*)std::malloc(sizeof(double) * 10);
+  double* col = reinterpret_cast<double*>(allocator->allocate(sizeof(double) * 10));
   int num_rows = 10;
   for (int i = 0; i < num_rows; i++) {
     col[i] = i * 3.14;
@@ -173,7 +178,7 @@ TEST_F(ArrowUtilsTest, toArrowDouble) {
 }
 
 TEST_F(ArrowUtilsTest, toArrowTimestamp) {
-  int64_t* col = (int64_t*)std::malloc(sizeof(int64_t) * 10);
+  int64_t* col = reinterpret_cast<int64_t*>(allocator->allocate(sizeof(int64_t) * 10));
   int num_rows = 10;
   for (int i = 0; i < num_rows; i++) {
     col[i] = i + 86400000000;
@@ -199,7 +204,7 @@ TEST_F(ArrowUtilsTest, toArrowTimestamp) {
 }
 
 TEST_F(ArrowUtilsTest, toArrowDecimal) {
-  int64_t* col = (int64_t*)std::malloc(sizeof(int64_t) * 10);
+  int64_t* col = reinterpret_cast<int64_t*>(allocator->allocate(sizeof(int64_t) * 10));
   int num_rows = 10;
   for (int i = 0; i < num_rows; i++) {
     col[i] = i * 1.00;

--- a/cider-velox/test/expression/CiderComparisonConjunct.cpp
+++ b/cider-velox/test/expression/CiderComparisonConjunct.cpp
@@ -45,9 +45,6 @@ using namespace facebook::velox::test;
 using namespace facebook::velox::functions;
 using namespace facebook::velox::plugin;
 
-static const std::shared_ptr<CiderAllocator> ciderAllocator =
-    std::make_shared<CiderDefaultAllocator>();
-
 namespace {
 
 class ComparisonBenchmark : public functions::test::FunctionBenchmarkBase {
@@ -153,10 +150,10 @@ class ComparisonBenchmark : public functions::test::FunctionBenchmarkBase {
         std::make_shared<CiderRuntimeModule>(result);
 
     // Convert data to CiderBatch
-    auto batchConvertor = DataConvertor::create(CONVERT_TYPE::DIRECT, ciderAllocator);
+    auto batchConvertor = DataConvertor::create(CONVERT_TYPE::DIRECT);
     std::chrono::microseconds convertorInternalCounter;
     auto inBatch = batchConvertor->convertToCider(
-        rowVector_, vectorSize_, &convertorInternalCounter);
+        rowVector_, vectorSize_, &convertorInternalCounter, execCtx_.pool());
 
     suspender.dismiss();
 

--- a/cider-velox/test/expression/CiderComparisonConjunct.cpp
+++ b/cider-velox/test/expression/CiderComparisonConjunct.cpp
@@ -45,6 +45,9 @@ using namespace facebook::velox::test;
 using namespace facebook::velox::functions;
 using namespace facebook::velox::plugin;
 
+static const std::shared_ptr<CiderAllocator> ciderAllocator =
+    std::make_shared<CiderDefaultAllocator>();
+
 namespace {
 
 class ComparisonBenchmark : public functions::test::FunctionBenchmarkBase {
@@ -150,7 +153,7 @@ class ComparisonBenchmark : public functions::test::FunctionBenchmarkBase {
         std::make_shared<CiderRuntimeModule>(result);
 
     // Convert data to CiderBatch
-    auto batchConvertor = DataConvertor::create(CONVERT_TYPE::DIRECT);
+    auto batchConvertor = DataConvertor::create(CONVERT_TYPE::DIRECT, ciderAllocator);
     std::chrono::microseconds convertorInternalCounter;
     auto inBatch = batchConvertor->convertToCider(
         rowVector_, vectorSize_, &convertorInternalCounter);

--- a/cider-velox/test/expression/CiderComparisonConjunct.cpp
+++ b/cider-velox/test/expression/CiderComparisonConjunct.cpp
@@ -23,6 +23,7 @@
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 
+#include "Allocator.h"
 #include "DataConvertor.h"
 #include "ExprEvalUtils.h"
 #include "cider/CiderRuntimeModule.h"
@@ -44,7 +45,8 @@ using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
 using namespace facebook::velox::functions;
 using namespace facebook::velox::plugin;
-
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
 namespace {
 
 class ComparisonBenchmark : public functions::test::FunctionBenchmarkBase {
@@ -126,7 +128,7 @@ class ComparisonBenchmark : public functions::test::FunctionBenchmarkBase {
         getEU(expression, std::dynamic_pointer_cast<const RowType>(inputType_));
 
     // Prepare runtime module
-    auto ciderCompileModule = CiderCompileModule::Make();
+    auto ciderCompileModule = CiderCompileModule::Make(allocator);
     std::vector<InputTableInfo> queryInfos = ExprEvalUtils::buildInputTableInfo();
 
     suspender.dismiss();
@@ -143,7 +145,7 @@ class ComparisonBenchmark : public functions::test::FunctionBenchmarkBase {
         getEU(expression, std::dynamic_pointer_cast<const RowType>(inputType_));
 
     // Prepare runtime module
-    auto ciderCompileModule = CiderCompileModule::Make();
+    auto ciderCompileModule = CiderCompileModule::Make(allocator);
     std::vector<InputTableInfo> queryInfos = ExprEvalUtils::buildInputTableInfo();
     auto result = ciderCompileModule->compile((void*)&relAlgEU, (void*)&queryInfos);
     std::shared_ptr<CiderRuntimeModule> ciderRuntimeModule =

--- a/cider-velox/test/expression/CiderSimpleArithmetic.cpp
+++ b/cider-velox/test/expression/CiderSimpleArithmetic.cpp
@@ -22,6 +22,7 @@
 #include <folly/Benchmark.h>
 #include <gflags/gflags.h>
 
+#include "Allocator.h"
 #include "DataConvertor.h"
 #include "ExprEvalUtils.h"
 #include "cider/CiderCompileModule.h"
@@ -44,6 +45,8 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
 using namespace facebook::velox::plugin;
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
 
 namespace {
 
@@ -113,7 +116,7 @@ class CiderSimpleArithmeticBenchmark : public functions::test::FunctionBenchmark
     auto typedExpr = core::Expressions::inferTypes(untyped, inputType_, execCtx_.pool());
     auto rowType = std::dynamic_pointer_cast<const RowType>(inputType_);
     auto relAlgEU = ExprEvalUtils::getMockedRelAlgEU(typedExpr, rowType, "arithmetic");
-    auto ciderCompileModule = CiderCompileModule::Make();
+    auto ciderCompileModule = CiderCompileModule::Make(allocator);
     std::vector<InputTableInfo> queryInfos = ExprEvalUtils::buildInputTableInfo();
     suspender.dismiss();
     auto result = ciderCompileModule->compile((void*)&relAlgEU, (void*)&queryInfos);
@@ -130,7 +133,7 @@ class CiderSimpleArithmeticBenchmark : public functions::test::FunctionBenchmark
     auto typedExpr = core::Expressions::inferTypes(untyped, type, pool);
     auto rowType = std::dynamic_pointer_cast<const RowType>(type);
     auto relAlgEU = ExprEvalUtils::getMockedRelAlgEU(typedExpr, rowType, euType);
-    auto ciderCompileModule = CiderCompileModule::Make();
+    auto ciderCompileModule = CiderCompileModule::Make(allocator);
     std::vector<InputTableInfo> queryInfos = ExprEvalUtils::buildInputTableInfo();
     auto result = ciderCompileModule->compile((void*)&relAlgEU, (void*)&queryInfos);
     auto ciderRuntimeModule = std::make_shared<CiderRuntimeModule>(result);

--- a/cider-velox/test/expression/CiderSimpleArithmetic.cpp
+++ b/cider-velox/test/expression/CiderSimpleArithmetic.cpp
@@ -44,6 +44,9 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
 using namespace facebook::velox::plugin;
+
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
 namespace {
 
 // simple multiply function.
@@ -143,14 +146,15 @@ class CiderSimpleArithmeticBenchmark : public functions::test::FunctionBenchmark
     auto ciderRuntimeModule =
         getCiderRuntimeModule(expression, inputType_, execCtx_.pool(), "arithmetic");
     // convert data to CiderBatch
-    auto batchConvertor = DataConvertor::create(CONVERT_TYPE::DIRECT);
+    auto batchConvertor = DataConvertor::create(CONVERT_TYPE::DIRECT, allocator);
     std::chrono::microseconds convertorInternalCounter;
     auto inBatch = batchConvertor->convertToCider(
         rowVector_, vectorSize_, &convertorInternalCounter);
     // TODO :process the batch and return result
     size_t max_out = inBatch.row_num();
     std::vector<const int8_t*> col_buffer;
-    double* col_0 = (double*)std::malloc(sizeof(double) * max_out * 2);
+    double* col_0 =
+        reinterpret_cast<double*>(allocator->allocate(sizeof(double) * max_out * 2));
     int num_rows = max_out;
     col_buffer.push_back(reinterpret_cast<const int8_t*>(col_0));
     CiderBatch outBatch(num_rows, col_buffer);

--- a/cider-velox/test/expression/CiderSimpleArithmetic.cpp
+++ b/cider-velox/test/expression/CiderSimpleArithmetic.cpp
@@ -45,8 +45,6 @@ using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
 using namespace facebook::velox::plugin;
 
-static const std::shared_ptr<CiderAllocator> allocator =
-    std::make_shared<CiderDefaultAllocator>();
 namespace {
 
 // simple multiply function.
@@ -146,15 +144,15 @@ class CiderSimpleArithmeticBenchmark : public functions::test::FunctionBenchmark
     auto ciderRuntimeModule =
         getCiderRuntimeModule(expression, inputType_, execCtx_.pool(), "arithmetic");
     // convert data to CiderBatch
-    auto batchConvertor = DataConvertor::create(CONVERT_TYPE::DIRECT, allocator);
+    auto batchConvertor = DataConvertor::create(CONVERT_TYPE::DIRECT);
     std::chrono::microseconds convertorInternalCounter;
     auto inBatch = batchConvertor->convertToCider(
-        rowVector_, vectorSize_, &convertorInternalCounter);
+        rowVector_, vectorSize_, &convertorInternalCounter, execCtx_.pool());
     // TODO :process the batch and return result
     size_t max_out = inBatch.row_num();
     std::vector<const int8_t*> col_buffer;
-    double* col_0 =
-        reinterpret_cast<double*>(allocator->allocate(sizeof(double) * max_out * 2));
+    double* col_0 = reinterpret_cast<double*>(
+        execCtx_.pool()->allocate(sizeof(double) * max_out * 2));
     int num_rows = max_out;
     col_buffer.push_back(reinterpret_cast<const int8_t*>(col_0));
     CiderBatch outBatch(num_rows, col_buffer);

--- a/cider/examples/CiderRuntimeModuleExample.cpp
+++ b/cider/examples/CiderRuntimeModuleExample.cpp
@@ -64,15 +64,16 @@ int main(int argc, char** argv) {
   auto exec_option = CiderExecutionOption::defaults();
   auto compile_option = CiderCompilationOption::defaults();
 
-  auto ciderCompileModule = CiderCompileModule::Make();
+  // Construct an allocator
+  auto allocator = std::make_shared<UserAllocator>();
+
+  auto ciderCompileModule = CiderCompileModule::Make(allocator);
   auto result = ciderCompileModule->compile({add_expr},
                                             *schema,
                                             builder->funcsInfo(),
                                             generator::ExprType::ProjectExpr,
                                             compile_option,
                                             exec_option);
-  // Construct an allocator
-  auto allocator = std::make_shared<UserAllocator>();
   // Create runtimemodule
   auto runner = std::make_shared<CiderRuntimeModule>(
       result, compile_option, exec_option, allocator);

--- a/cider/examples/ExpressionEvalExample.cpp
+++ b/cider/examples/ExpressionEvalExample.cpp
@@ -56,8 +56,12 @@ int main(int argc, char** argv) {
                           .setRowNum(2)
                           .addColumn<int64_t>("0", CREATE_SUBSTRAIT_TYPE(I64), {8, 15})
                           .build();
-  CiderExprEvaluator evaluator(
-      {add_expr}, builder->funcsInfo(), schema, generator::ExprType::ProjectExpr);
+  auto allocator = std::make_shared<CiderDefaultAllocator>();
+  CiderExprEvaluator evaluator({add_expr},
+                               builder->funcsInfo(),
+                               schema,
+                               allocator,
+                               generator::ExprType::ProjectExpr);
   auto out_batch = evaluator.eval(input_batch);
   // Verify result
   assert(CiderBatchChecker::checkEq(std::make_shared<CiderBatch>(expect_batch),
@@ -85,6 +89,7 @@ int main(int argc, char** argv) {
   CiderExprEvaluator evaluator1({add_expr1},
                                 inc_builder->funcsInfo(),
                                 inc_schema,
+                                allocator,
                                 generator::ExprType::ProjectExpr);
   auto out_batch1 = evaluator1.eval(input_batch);
   // Verify result

--- a/cider/exec/module/CiderCompileModule.cpp
+++ b/cider/exec/module/CiderCompileModule.cpp
@@ -88,9 +88,9 @@ CiderTableSchema CiderCompilationResult::getOutputCiderTableSchema() const {
 
 class CiderCompileModule::Impl {
  public:
-  Impl() {
+  Impl(std::shared_ptr<CiderAllocator> allocator) {
     executor_ = Executor::getExecutor(Executor::UNITARY_EXECUTOR_ID, nullptr, nullptr);
-    ciderStringDictionaryProxy_ = initStringDictionaryProxy();
+    ciderStringDictionaryProxy_ = initStringDictionaryProxy(allocator);
     executor_->setCiderStringDictionaryProxy(ciderStringDictionaryProxy_.get());
   }
   ~Impl() {}
@@ -456,11 +456,12 @@ class CiderCompileModule::Impl {
 
     return query_infos;
   }
-  std::shared_ptr<StringDictionaryProxy> initStringDictionaryProxy() {
+  std::shared_ptr<StringDictionaryProxy> initStringDictionaryProxy(
+      std::shared_ptr<CiderAllocator> allocator) {
     std::shared_ptr<StringDictionaryProxy> stringDictionaryProxy;
     const DictRef dict_ref(-1, 1);
     std::shared_ptr<StringDictionary> tsd =
-        std::make_shared<StringDictionary>(dict_ref, "", false, true);
+        std::make_shared<StringDictionary>(dict_ref, "", allocator, false, true);
     stringDictionaryProxy.reset(new StringDictionaryProxy(tsd, 0, 0));
 
     return stringDictionaryProxy;
@@ -480,7 +481,7 @@ class CiderCompileModule::Impl {
 };
 
 CiderCompileModule::CiderCompileModule() {
-  impl_.reset(new Impl());
+  impl_.reset(new Impl(allocator_));
 }
 
 CiderCompileModule::~CiderCompileModule() {}

--- a/cider/exec/module/CiderCompileModule.cpp
+++ b/cider/exec/module/CiderCompileModule.cpp
@@ -480,14 +480,16 @@ class CiderCompileModule::Impl {
   }
 };
 
-CiderCompileModule::CiderCompileModule() {
-  impl_.reset(new Impl(allocator_));
+CiderCompileModule::CiderCompileModule(std::shared_ptr<CiderAllocator> allocator) {
+  impl_.reset(new Impl(allocator));
 }
 
 CiderCompileModule::~CiderCompileModule() {}
 
-std::shared_ptr<CiderCompileModule> CiderCompileModule::Make() {
-  auto ciderCompileModule = std::shared_ptr<CiderCompileModule>(new CiderCompileModule());
+std::shared_ptr<CiderCompileModule> CiderCompileModule::Make(
+    std::shared_ptr<CiderAllocator> allocator) {
+  auto ciderCompileModule =
+      std::shared_ptr<CiderCompileModule>(new CiderCompileModule(allocator));
   return ciderCompileModule;
 }
 

--- a/cider/exec/module/CiderCompileModule.cpp
+++ b/cider/exec/module/CiderCompileModule.cpp
@@ -88,7 +88,7 @@ CiderTableSchema CiderCompilationResult::getOutputCiderTableSchema() const {
 
 class CiderCompileModule::Impl {
  public:
-  Impl(std::shared_ptr<CiderAllocator> allocator) {
+  explicit Impl(std::shared_ptr<CiderAllocator> allocator) {
     executor_ = Executor::getExecutor(Executor::UNITARY_EXECUTOR_ID, nullptr, nullptr);
     ciderStringDictionaryProxy_ = initStringDictionaryProxy(allocator);
     executor_->setCiderStringDictionaryProxy(ciderStringDictionaryProxy_.get());

--- a/cider/exec/module/CiderExprEvaluator.cpp
+++ b/cider/exec/module/CiderExprEvaluator.cpp
@@ -26,12 +26,14 @@ CiderExprEvaluator::CiderExprEvaluator(
     std::vector<::substrait::extensions::SimpleExtensionDeclaration_ExtensionFunction*>
         funcs_info,
     ::substrait::NamedStruct* schema,
-    const generator::ExprType& expr_type) {
+    std::shared_ptr<CiderAllocator> allocator,
+    const generator::ExprType& expr_type)
+    : allocator_(allocator) {
   // Set up exec option and compilation option
   auto exec_option = CiderExecutionOption::defaults();
   auto compile_option = CiderCompilationOption::defaults();
 
-  auto ciderCompileModule = CiderCompileModule::Make();
+  auto ciderCompileModule = CiderCompileModule::Make(allocator_);
   auto result = ciderCompileModule->compile(
       exprs, *schema, funcs_info, expr_type, compile_option, exec_option);
   runner_ = std::make_shared<CiderRuntimeModule>(result, compile_option, exec_option);

--- a/cider/exec/module/CiderExprEvaluator.h
+++ b/cider/exec/module/CiderExprEvaluator.h
@@ -39,11 +39,13 @@ class CiderExprEvaluator {
       std::vector<::substrait::extensions::SimpleExtensionDeclaration_ExtensionFunction*>
           funcs_info,
       ::substrait::NamedStruct* schema,
+      std::shared_ptr<CiderAllocator> allocator,
       const generator::ExprType& expr_type);
 
   CiderBatch eval(const CiderBatch& in_batch);
 
  private:
   std::shared_ptr<CiderRuntimeModule> runner_;
+  std::shared_ptr<CiderAllocator> allocator_;
 };
 #endif  // CIDER_CIDEREXPREVALUATOR_H

--- a/cider/exec/module/CiderRuntimeModule.cpp
+++ b/cider/exec/module/CiderRuntimeModule.cpp
@@ -19,8 +19,6 @@
  * under the License.
  */
 
-#include <cstdint>
-#include <memory>
 #define CIDERBATCH_WITH_ARROW
 
 #include "cider/CiderRuntimeModule.h"
@@ -206,6 +204,7 @@ void CiderRuntimeModule::processNextBatch(const CiderBatch& in_batch) {
     if (hoist_literals_) {
       if (is_group_by_) {
         CiderBitUtils::CiderBitVector<> row_skip_mask(
+            allocator_,
             use_cider_data_format ? in_batch.getLength() : in_batch.row_num());
         multifrag_cols_ptr[1] = row_skip_mask.as<const int8_t*>();
 
@@ -416,7 +415,6 @@ void CiderRuntimeModule::extract_varchar_column_from_dict(int32_t start_row,
     int64_t key = flattened_out[cur_col_offset];
     std::string s =
         ciderCompilationResult_->impl_->ciderStringDictionaryProxy_->getString(key);
-    // uint8_t* ptr = (uint8_t*)std::malloc(s.length());  // memleak
     uint8_t* ptr = reinterpret_cast<uint8_t*>(allocator_->allocate(s.length()));
     std::memcpy(ptr, s.c_str(), s.length());
     col_out_buffer[i].ptr = reinterpret_cast<const uint8_t*>(ptr);

--- a/cider/exec/module/batch/CiderArrowBufferHolder.cpp
+++ b/cider/exec/module/batch/CiderArrowBufferHolder.cpp
@@ -50,22 +50,23 @@ CiderArrowArrayBufferHolder::~CiderArrowArrayBufferHolder() {
   }
 }
 
-// TODO: qiuyangshen Replace with CiderAllocator
-// Unable to determine reallocated memory size
-// refactoring code by LiJiang
 void CiderArrowArrayBufferHolder::allocBuffer(size_t index, size_t bytes) {
   if (buffers_[index]) {
-    buffers_[index] = std::realloc(buffers_[index], bytes);
+    buffers_[index] = allocator_->reallocate(
+        reinterpret_cast<int8_t*>(buffers_[index]), buffers_bytes_[index], bytes);
+    buffers_bytes_[index] = bytes;
   } else {
-    buffers_[index] = std::malloc(bytes);
+    buffers_[index] = allocator_->allocate(bytes);
+    buffers_bytes_[index] = bytes;
   }
 }
 
-// TODO: qiuyangshen Replace with CiderAllocator
 void CiderArrowArrayBufferHolder::relaseBuffer(size_t index) {
   if (buffers_[index]) {
-    std::free(buffers_[index]);
+    allocator_->deallocate(reinterpret_cast<int8_t*>(buffers_[index]),
+                           buffers_bytes_[index]);
     buffers_[index] = nullptr;
+    buffers_bytes_[index] = 0;
   }
 }
 

--- a/cider/exec/module/batch/CiderArrowBufferHolder.cpp
+++ b/cider/exec/module/batch/CiderArrowBufferHolder.cpp
@@ -24,13 +24,16 @@
 
 #include <cstdlib>
 
-CiderArrowArrayBufferHolder::CiderArrowArrayBufferHolder(size_t buffer_num,
-                                                         size_t children_num,
-                                                         bool dict)
+CiderArrowArrayBufferHolder::CiderArrowArrayBufferHolder(
+    size_t buffer_num,
+    size_t children_num,
+    std::shared_ptr<CiderAllocator> allocator,
+    bool dict)
     : buffers_(buffer_num, nullptr)
     , buffers_bytes_(buffer_num, 0)
     , children_ptr_(children_num, nullptr)
     , children_and_dict_(children_num + (dict ? 1 : 0))
+    , allocator_(allocator)
     , has_dict_(dict) {
   for (size_t i = 0; i < children_num; ++i) {
     children_and_dict_[i].release = nullptr;
@@ -47,7 +50,9 @@ CiderArrowArrayBufferHolder::~CiderArrowArrayBufferHolder() {
   }
 }
 
-// TODO: Replace with CiderAllocator
+// TODO: qiuyangshen Replace with CiderAllocator
+// Unable to determine reallocated memory size
+// refactoring code by LiJiang
 void CiderArrowArrayBufferHolder::allocBuffer(size_t index, size_t bytes) {
   if (buffers_[index]) {
     buffers_[index] = std::realloc(buffers_[index], bytes);
@@ -56,7 +61,7 @@ void CiderArrowArrayBufferHolder::allocBuffer(size_t index, size_t bytes) {
   }
 }
 
-// TODO: Replace with CiderAllocator
+// TODO: qiuyangshen Replace with CiderAllocator
 void CiderArrowArrayBufferHolder::relaseBuffer(size_t index) {
   if (buffers_[index]) {
     std::free(buffers_[index]);

--- a/cider/exec/module/batch/CiderArrowBufferHolder.h
+++ b/cider/exec/module/batch/CiderArrowBufferHolder.h
@@ -22,14 +22,19 @@
 #ifndef CIDER_ARROW_BUFFER_HOLDER_H
 #define CIDER_ARROW_BUFFER_HOLDER_H
 
+#include <memory>
 #include <vector>
+#include "cider/CiderAllocator.h"
 
 struct ArrowSchema;
 struct ArrowArray;
 
 class CiderArrowArrayBufferHolder {
  public:
-  CiderArrowArrayBufferHolder(size_t buffer_num, size_t children_num, bool dict);
+  CiderArrowArrayBufferHolder(size_t buffer_num,
+                              size_t children_num,
+                              std::shared_ptr<CiderAllocator> allocator,
+                              bool dict);
   ~CiderArrowArrayBufferHolder();
 
   const void** getBufferPtrs() { return const_cast<const void**>(buffers_.data()); }
@@ -53,6 +58,7 @@ class CiderArrowArrayBufferHolder {
   std::vector<size_t> buffers_bytes_;  // Used for allocator.
   std::vector<ArrowArray*> children_ptr_;
   std::vector<ArrowArray> children_and_dict_;
+  std::shared_ptr<CiderAllocator> allocator_;
   const bool has_dict_;
 };
 

--- a/cider/exec/module/batch/CiderArrowBufferHolder.h
+++ b/cider/exec/module/batch/CiderArrowBufferHolder.h
@@ -22,7 +22,6 @@
 #ifndef CIDER_ARROW_BUFFER_HOLDER_H
 #define CIDER_ARROW_BUFFER_HOLDER_H
 
-#include <memory>
 #include <vector>
 #include "cider/CiderAllocator.h"
 

--- a/cider/exec/module/batch/CiderBatch.cpp
+++ b/cider/exec/module/batch/CiderBatch.cpp
@@ -151,7 +151,7 @@ std::unique_ptr<CiderBatch> CiderBatch::getChildAt(size_t index) {
   }
 
   auto child_batch =
-      CiderBatchUtils::createCiderBatch(child_schema, allocator_, child_array);
+      CiderBatchUtils::createCiderBatch(allocator_, child_schema, child_array);
   child_batch->ownership_ = false;  // Only root batch has ownership.
   child_batch->reallocate_ =
       true;  // ArrowArray allocated from Cider could (re-)allocate buffer.

--- a/cider/exec/module/batch/CiderBatch.cpp
+++ b/cider/exec/module/batch/CiderBatch.cpp
@@ -19,8 +19,7 @@
  * under the License.
  */
 
-#include "include/cider/batch/CiderBatch.h"
-#include <memory>
+#include "cider/batch/CiderBatch.h"
 #include "ArrowABI.h"
 
 CiderBatch::CiderBatch(ArrowSchema* schema, std::shared_ptr<CiderAllocator> allocator)
@@ -42,12 +41,19 @@ CiderBatch::CiderBatch(ArrowSchema* schema, std::shared_ptr<CiderAllocator> allo
   arrow_array_->release = CiderBatchUtils::ciderArrowArrayReleaser;
 }
 
-CiderBatch::CiderBatch(ArrowSchema* schema, ArrowArray* array)
-    : arrow_schema_(schema), arrow_array_(array), ownership_(true), reallocate_(false) {
+CiderBatch::CiderBatch(ArrowSchema* schema,
+                       ArrowArray* array,
+                       std::shared_ptr<CiderAllocator> allocator)
+    : arrow_schema_(schema)
+    , arrow_array_(array)
+    , ownership_(true)
+    , reallocate_(false)
+    , allocator_(allocator) {
   CHECK(arrow_schema_);
   CHECK(arrow_schema_->release);
   CHECK(arrow_array_);
   CHECK(arrow_array_->release);
+  CHECK(allocator_);
 }
 
 CiderBatch::~CiderBatch() {
@@ -60,6 +66,7 @@ CiderBatch::CiderBatch(const CiderBatch& rh) {
   this->arrow_schema_ = rh.arrow_schema_;
   this->ownership_ = false;
   this->reallocate_ = rh.reallocate_;
+  this->allocator_ = rh.allocator_;
 }
 
 CiderBatch& CiderBatch::operator=(const CiderBatch& rh) {
@@ -72,6 +79,7 @@ CiderBatch& CiderBatch::operator=(const CiderBatch& rh) {
   this->arrow_schema_ = rh.arrow_schema_;
   this->ownership_ = false;
   this->reallocate_ = rh.reallocate_;
+  this->allocator_ = rh.allocator_;
 
   return *this;
 }
@@ -81,6 +89,7 @@ CiderBatch::CiderBatch(CiderBatch&& rh) noexcept {
   this->arrow_schema_ = rh.arrow_schema_;
   this->ownership_ = rh.ownership_;
   this->reallocate_ = rh.reallocate_;
+  this->allocator_ = rh.allocator_;
 
   rh.arrow_array_ = nullptr;
   rh.arrow_schema_ = nullptr;
@@ -99,6 +108,7 @@ CiderBatch& CiderBatch::operator=(CiderBatch&& rh) noexcept {
   this->arrow_schema_ = rh.arrow_schema_;
   this->ownership_ = rh.ownership_;
   this->reallocate_ = rh.reallocate_;
+  this->allocator_ = rh.allocator_;
 
   rh.arrow_array_ = nullptr;
   rh.arrow_schema_ = nullptr;

--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -19,6 +19,7 @@
  * under the License.
  */
 
+#include <memory>
 #define CIDERBATCH_WITH_ARROW
 
 #include "cider/batch/CiderBatchUtils.h"
@@ -230,7 +231,9 @@ ArrowSchema* convertCiderTypeInfoToArrowSchema(const SQLTypeInfo& sql_info) {
   return root_schema;
 }
 
-std::unique_ptr<CiderBatch> createCiderBatch(ArrowSchema* schema, ArrowArray* array) {
+std::unique_ptr<CiderBatch> createCiderBatch(ArrowSchema* schema,
+                                             std::shared_ptr<CiderAllocator> allocator,
+                                             ArrowArray* array) {
   CHECK(schema);
   CHECK(schema->release);
 
@@ -238,25 +241,25 @@ std::unique_ptr<CiderBatch> createCiderBatch(ArrowSchema* schema, ArrowArray* ar
   switch (format[0]) {
     // Scalar Types
     case 'b':
-      return ScalarBatch<bool>::Create(schema, array);
+      return ScalarBatch<bool>::Create(schema, allocator, array);
     case 'c':
-      return ScalarBatch<int8_t>::Create(schema, array);
+      return ScalarBatch<int8_t>::Create(schema, allocator, array);
     case 's':
-      return ScalarBatch<int16_t>::Create(schema, array);
+      return ScalarBatch<int16_t>::Create(schema, allocator, array);
     case 'i':
-      return ScalarBatch<int32_t>::Create(schema, array);
+      return ScalarBatch<int32_t>::Create(schema, allocator, array);
     case 'l':
-      return ScalarBatch<int64_t>::Create(schema, array);
+      return ScalarBatch<int64_t>::Create(schema, allocator, array);
     case 'f':
-      return ScalarBatch<float>::Create(schema, array);
+      return ScalarBatch<float>::Create(schema, allocator, array);
     case 'g':
-      return ScalarBatch<double>::Create(schema, array);
+      return ScalarBatch<double>::Create(schema, allocator, array);
     case '+':
       // Complex Types
       switch (format[1]) {
         // Struct Type
         case 's':
-          return StructBatch::Create(schema, array);
+          return StructBatch::Create(schema, allocator, array);
       }
     default:
       CIDER_THROW(CiderCompileException,

--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -19,7 +19,6 @@
  * under the License.
  */
 
-#include <memory>
 #define CIDERBATCH_WITH_ARROW
 
 #include "cider/batch/CiderBatchUtils.h"

--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -231,8 +231,8 @@ ArrowSchema* convertCiderTypeInfoToArrowSchema(const SQLTypeInfo& sql_info) {
   return root_schema;
 }
 
-std::unique_ptr<CiderBatch> createCiderBatch(ArrowSchema* schema,
-                                             std::shared_ptr<CiderAllocator> allocator,
+std::unique_ptr<CiderBatch> createCiderBatch(std::shared_ptr<CiderAllocator> allocator,
+                                             ArrowSchema* schema,
                                              ArrowArray* array) {
   CHECK(schema);
   CHECK(schema->release);

--- a/cider/exec/operator/aggregate/CiderAggHashTable.cpp
+++ b/cider/exec/operator/aggregate/CiderAggHashTable.cpp
@@ -259,7 +259,7 @@ CiderAggHashTable::CiderAggHashTable(
     , query_mem_desc_(query_mem_desc.get())
     , rel_alg_exec_unit_(rel_alg_exec_unit.get())
     , buffer_memory_(buffers_num, nullptr)
-    , buffer_empty_map_(buffers_num)
+    , buffer_empty_map_(buffers_num, CiderBitUtils::CiderBitVector<>(allocator, 0))
     , runtime_state_(
           buffers_num_,
           {query_mem_desc->getEntryCount()})  // TODO: Fix Runtime State initialization.
@@ -626,7 +626,8 @@ int8_t* CiderAggHashTable::allocateBufferAt(size_t buffer_id) {
   CHECK_LT(buffer_id, buffers_num_);
   if (nullptr == buffer_memory_[buffer_id]) {
     buffer_memory_[buffer_id] = allocator_->allocate(buffer_width_ * sizeof(int8_t));
-    buffer_empty_map_[buffer_id] = CiderBitUtils::CiderBitVector<>(buffer_entry_num_);
+    buffer_empty_map_[buffer_id] =
+        CiderBitUtils::CiderBitVector<>(allocator_, buffer_entry_num_);
   } else {
     LOG(ERROR) << "Existing a buffer";
   }

--- a/cider/exec/operator/aggregate/CiderAggHashTable.cpp
+++ b/cider/exec/operator/aggregate/CiderAggHashTable.cpp
@@ -681,7 +681,7 @@ void CiderAggHashTable::initCountDistinctInBuffer(size_t buffer_index) {
             CHECK_LT(col_info.count_distinct_desc.bitmap_sz_bits, MAX_BITMAP_BITS);
             const auto bitmap_byte_sz =
                 col_info.count_distinct_desc.bitmapPaddedSizeBytes();
-            int8_t* buffer = reinterpret_cast<int8_t*>(std::malloc(bitmap_byte_sz));
+            int8_t* buffer = allocator_->allocate(bitmap_byte_sz);
             int64_t address = reinterpret_cast<int64_t>(buffer);
             std::memcpy(col_ptr, &address, slot_width_);
           } else {

--- a/cider/exec/template/CountDistinct.h
+++ b/cider/exec/template/CountDistinct.h
@@ -23,8 +23,6 @@
 #define QUERYENGINE_COUNTDISTINCT_H
 // FIXME: workaround for compile issue of ConstructBatch.h
 // Will be safe to remove it after formally switch to Arrow
-#include <cstdint>
-#include <memory>
 #define CIDERBATCH_WITH_ARROW
 #include "HyperLogLog.h"
 #include "cider/CiderBatch.h"

--- a/cider/exec/template/Execute.cpp
+++ b/cider/exec/template/Execute.cpp
@@ -198,7 +198,7 @@ StringDictionaryProxy* RowSetMemoryOwner::getOrAddStringDictProxy(
   if (!lit_str_dict_proxy_) {
     const DictRef dict_ref(-1, 1);
     std::shared_ptr<StringDictionary> tsd = std::make_shared<StringDictionary>(
-        dict_ref, "", false, true, g_cache_string_hash);
+        dict_ref, "", allocator_, false, true, g_cache_string_hash);
     lit_str_dict_proxy_.reset(new StringDictionaryProxy(
         tsd, 0, 0));  // use 0 string_dict_id to denote literal proxy
   }

--- a/cider/exec/template/OutputBufferInitialization.cpp
+++ b/cider/exec/template/OutputBufferInitialization.cpp
@@ -21,7 +21,6 @@
  */
 
 #include "OutputBufferInitialization.h"
-#include <memory>
 #include "exec/template/BufferCompaction.h"
 #include "exec/template/TypePunning.h"
 #include "exec/template/common/descriptors/QueryMemoryDescriptor.h"

--- a/cider/exec/template/OutputBufferInitialization.h
+++ b/cider/exec/template/OutputBufferInitialization.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include "cider/CiderAllocator.h"
 
 namespace Analyzer {
 class Expr;
@@ -51,7 +52,8 @@ int64_t get_agg_initial_val(const SQLAgg agg,
 
 std::vector<int64_t> init_agg_val(const std::vector<Analyzer::Expr*>& targets,
                                   const std::list<std::shared_ptr<Analyzer::Expr>>& quals,
-                                  const QueryMemoryDescriptor& query_mem_desc);
+                                  const QueryMemoryDescriptor& query_mem_desc,
+                                  std::shared_ptr<CiderAllocator> allocator);
 
 std::vector<int64_t> init_agg_val_vec(
     const std::vector<Analyzer::Expr*>& targets,

--- a/cider/include/cider/CiderAllocator.h
+++ b/cider/include/cider/CiderAllocator.h
@@ -86,12 +86,14 @@ class AlignAllocator : public CiderAllocator {
   }
 
   void deallocate(int8_t* p, size_t size) final {
-    if constexpr (ALIGNMENT > kNoAlignment && ALIGNMENT <= kMaxAlignment) {
-      uint8_t offset = *(uint8_t*)(p - 1);
-      p = adjustAddress(p, offset);
+    if (p) {
+      if constexpr (ALIGNMENT > kNoAlignment && ALIGNMENT <= kMaxAlignment) {
+        uint8_t offset = *(uint8_t*)(p - 1);
+        p = adjustAddress(p, offset);
+      }
+      parent_->deallocate(p, size);
+      return;
     }
-    parent_->deallocate(p, size);
-    return;
   }
 
  private:

--- a/cider/include/cider/CiderCompileModule.h
+++ b/cider/include/cider/CiderCompileModule.h
@@ -23,6 +23,7 @@
 #define CIDER_CIDERCOMPILEMODULE_H
 
 #include <map>
+#include <memory>
 #include <string>
 
 #include "CiderInterface.h"
@@ -93,6 +94,7 @@ class CiderCompileModule {
 
   class Impl;
   std::unique_ptr<Impl> impl_;
+  std::shared_ptr<CiderAllocator> allocator_;
 };
 
 #endif  // CIDER_CIDERCOMPILEMODULE_H

--- a/cider/include/cider/CiderCompileModule.h
+++ b/cider/include/cider/CiderCompileModule.h
@@ -23,7 +23,6 @@
 #define CIDER_CIDERCOMPILEMODULE_H
 
 #include <map>
-#include <memory>
 #include <string>
 
 #include "CiderInterface.h"
@@ -51,10 +50,11 @@ class CiderCompilationResult {
 
 class CiderCompileModule {
  public:
-  CiderCompileModule();
+  CiderCompileModule(std::shared_ptr<CiderAllocator> allocator);
   ~CiderCompileModule();
 
-  static std::shared_ptr<CiderCompileModule> Make();
+  static std::shared_ptr<CiderCompileModule> Make(
+      std::shared_ptr<CiderAllocator> allocator);
 
   std::shared_ptr<CiderCompilationResult> compile(
       const substrait::Plan& plan,

--- a/cider/include/cider/batch/CiderBatch.h
+++ b/cider/include/cider/batch/CiderBatch.h
@@ -22,7 +22,6 @@
 #ifndef CIDER_CIDERBATCH_H
 #define CIDER_CIDERBATCH_H
 
-#include <memory>
 #include "../CiderAllocator.h"
 #include "../CiderTableSchema.h"
 #include "../CiderTypes.h"
@@ -42,7 +41,9 @@ class CiderBatch {
   explicit CiderBatch(ArrowSchema* schema, std::shared_ptr<CiderAllocator> allocator);
   // In this case, CiderBatch references the memory allocated by the Caller, therefore
   // resize is not allowed.
-  explicit CiderBatch(ArrowSchema* schema, ArrowArray* array);
+  explicit CiderBatch(ArrowSchema* schema,
+                      ArrowArray* array,
+                      std::shared_ptr<CiderAllocator> allocator);
 
   virtual ~CiderBatch();
 

--- a/cider/include/cider/batch/CiderBatch.h
+++ b/cider/include/cider/batch/CiderBatch.h
@@ -22,6 +22,7 @@
 #ifndef CIDER_CIDERBATCH_H
 #define CIDER_CIDERBATCH_H
 
+#include <memory>
 #include "../CiderAllocator.h"
 #include "../CiderTableSchema.h"
 #include "../CiderTypes.h"
@@ -38,7 +39,7 @@ class CiderBatch {
   // buffers they hold, so ArrowSchema and ArrowArray should allocated from
   // CiderBatchUtils. Never construct distinct CiderBatches by this method with same
   // schema and array.
-  explicit CiderBatch(ArrowSchema* schema);
+  explicit CiderBatch(ArrowSchema* schema, std::shared_ptr<CiderAllocator> allocator);
   // In this case, CiderBatch references the memory allocated by the Caller, therefore
   // resize is not allowed.
   explicit CiderBatch(ArrowSchema* schema, ArrowArray* array);
@@ -435,7 +436,7 @@ class CiderBatch {
   int64_t row_capacity_ = 0;
   std::vector<size_t> column_type_size_{};
   std::vector<const int8_t*> table_ptr_{};  // underlayer format is Modular SQL format
-  std::shared_ptr<CiderAllocator> allocator_ = nullptr;
+  std::shared_ptr<CiderAllocator> allocator_;
   std::shared_ptr<CiderTableSchema> schema_ = nullptr;
   bool is_use_self_memory_manager_ = true;
   uint32_t align_ = kDefaultAlignment;

--- a/cider/include/cider/batch/CiderBatchUtils.h
+++ b/cider/include/cider/batch/CiderBatchUtils.h
@@ -22,6 +22,7 @@
 #ifndef CIDER_CIDERBATCHUTILS_H
 #define CIDER_CIDERBATCHUTILS_H
 
+#include "cider/CiderAllocator.h"
 #include "type/data/sqltypes.h"
 
 class CiderBatch;
@@ -48,6 +49,7 @@ int64_t getBufferNum(const ArrowSchema* schema);
 SQLTypes convertArrowTypeToCiderType(const char* format);
 
 std::unique_ptr<CiderBatch> createCiderBatch(ArrowSchema* schema,
+                                             std::shared_ptr<CiderAllocator> allocator,
                                              ArrowArray* array = nullptr);
 
 const char* convertCiderTypeToArrowType(SQLTypes type);

--- a/cider/include/cider/batch/CiderBatchUtils.h
+++ b/cider/include/cider/batch/CiderBatchUtils.h
@@ -48,8 +48,8 @@ int64_t getBufferNum(const ArrowSchema* schema);
 
 SQLTypes convertArrowTypeToCiderType(const char* format);
 
-std::unique_ptr<CiderBatch> createCiderBatch(ArrowSchema* schema,
-                                             std::shared_ptr<CiderAllocator> allocator,
+std::unique_ptr<CiderBatch> createCiderBatch(std::shared_ptr<CiderAllocator> allocator,
+                                             ArrowSchema* schema,
                                              ArrowArray* array = nullptr);
 
 const char* convertCiderTypeToArrowType(SQLTypes type);

--- a/cider/include/cider/batch/ScalarBatch.h
+++ b/cider/include/cider/batch/ScalarBatch.h
@@ -33,7 +33,7 @@ class ScalarBatch final : public CiderBatch {
   static std::unique_ptr<ScalarBatch<T>> Create(ArrowSchema* schema,
                                                 std::shared_ptr<CiderAllocator> allocator,
                                                 ArrowArray* array = nullptr) {
-    return array ? std::make_unique<ScalarBatch<T>>(schema, array)
+    return array ? std::make_unique<ScalarBatch<T>>(schema, array, allocator)
                  : std::make_unique<ScalarBatch<T>>(schema, allocator);
   }
 
@@ -41,8 +41,10 @@ class ScalarBatch final : public CiderBatch {
       : CiderBatch(schema, allocator) {
     checkArrowEntries();
   }
-  explicit ScalarBatch(ArrowSchema* schema, ArrowArray* array)
-      : CiderBatch(schema, array) {
+  explicit ScalarBatch(ArrowSchema* schema,
+                       ArrowArray* array,
+                       std::shared_ptr<CiderAllocator> allocator)
+      : CiderBatch(schema, array, allocator) {
     checkArrowEntries();
   }
 

--- a/cider/include/cider/batch/ScalarBatch.h
+++ b/cider/include/cider/batch/ScalarBatch.h
@@ -31,12 +31,16 @@ template <typename T>
 class ScalarBatch final : public CiderBatch {
  public:
   static std::unique_ptr<ScalarBatch<T>> Create(ArrowSchema* schema,
+                                                std::shared_ptr<CiderAllocator> allocator,
                                                 ArrowArray* array = nullptr) {
     return array ? std::make_unique<ScalarBatch<T>>(schema, array)
-                 : std::make_unique<ScalarBatch<T>>(schema);
+                 : std::make_unique<ScalarBatch<T>>(schema, allocator);
   }
 
-  explicit ScalarBatch(ArrowSchema* schema) : CiderBatch(schema) { checkArrowEntries(); }
+  explicit ScalarBatch(ArrowSchema* schema, std::shared_ptr<CiderAllocator> allocator)
+      : CiderBatch(schema, allocator) {
+    checkArrowEntries();
+  }
   explicit ScalarBatch(ArrowSchema* schema, ArrowArray* array)
       : CiderBatch(schema, array) {
     checkArrowEntries();

--- a/cider/include/cider/batch/StructBatch.h
+++ b/cider/include/cider/batch/StructBatch.h
@@ -32,7 +32,7 @@ class StructBatch final : public CiderBatch {
   static std::unique_ptr<StructBatch> Create(ArrowSchema* schema,
                                              std::shared_ptr<CiderAllocator> allocator,
                                              ArrowArray* array = nullptr) {
-    return array ? std::make_unique<StructBatch>(schema, array)
+    return array ? std::make_unique<StructBatch>(schema, array, allocator)
                  : std::make_unique<StructBatch>(schema, allocator);
   }
 
@@ -40,8 +40,10 @@ class StructBatch final : public CiderBatch {
       : CiderBatch(schema, allocator) {
     checkArrowEntries();
   }
-  explicit StructBatch(ArrowSchema* schema, ArrowArray* array)
-      : CiderBatch(schema, array) {
+  explicit StructBatch(ArrowSchema* schema,
+                       ArrowArray* array,
+                       std::shared_ptr<CiderAllocator> allocator)
+      : CiderBatch(schema, array, allocator) {
     checkArrowEntries();
   }
 

--- a/cider/include/cider/batch/StructBatch.h
+++ b/cider/include/cider/batch/StructBatch.h
@@ -30,12 +30,16 @@
 class StructBatch final : public CiderBatch {
  public:
   static std::unique_ptr<StructBatch> Create(ArrowSchema* schema,
+                                             std::shared_ptr<CiderAllocator> allocator,
                                              ArrowArray* array = nullptr) {
     return array ? std::make_unique<StructBatch>(schema, array)
-                 : std::make_unique<StructBatch>(schema);
+                 : std::make_unique<StructBatch>(schema, allocator);
   }
 
-  explicit StructBatch(ArrowSchema* schema) : CiderBatch(schema) { checkArrowEntries(); }
+  explicit StructBatch(ArrowSchema* schema, std::shared_ptr<CiderAllocator> allocator)
+      : CiderBatch(schema, allocator) {
+    checkArrowEntries();
+  }
   explicit StructBatch(ArrowSchema* schema, ArrowArray* array)
       : CiderBatch(schema, array) {
     checkArrowEntries();

--- a/cider/tests/CiderAggHashTableTest.cpp
+++ b/cider/tests/CiderAggHashTableTest.cpp
@@ -36,6 +36,9 @@ extern size_t g_watchdog_baseline_max_groups;
 
 using namespace TestHelpers;
 
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
+
 class CiderNewDataFormatTest : public ::testing::Test {
  protected:
   static MockTable* MockTableForTest;
@@ -194,7 +197,7 @@ void testScalarTypeSingleKey(MockTable* table,
                               0});
 
   std::vector<CiderBitUtils::CiderBitVector<>> null_vectors(
-      2, CiderBitUtils::CiderBitVector<>(5, 0xFF));
+      2, CiderBitUtils::CiderBitVector<>(allocator, 5, 0xFF));
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 0);
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 1);
 
@@ -292,7 +295,7 @@ void testScalarTypeMultipleKey(MockTable* table,
                               0});
 
   std::vector<CiderBitUtils::CiderBitVector<>> null_vectors(
-      2, CiderBitUtils::CiderBitVector<>(5, 0xFF));
+      2, CiderBitUtils::CiderBitVector<>(allocator, 5, 0xFF));
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 0);
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 1);
   CiderBitUtils::clearBitAt(null_vectors[1].as<uint8_t>(), 0);
@@ -393,7 +396,7 @@ void testScalarTypeArithemicExpr(MockTable* table,
                               0});
 
   std::vector<CiderBitUtils::CiderBitVector<>> null_vectors(
-      2, CiderBitUtils::CiderBitVector<>(5, 0xFF));
+      2, CiderBitUtils::CiderBitVector<>(allocator, 5, 0xFF));
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 0);
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 1);
   CiderBitUtils::clearBitAt(null_vectors[1].as<uint8_t>(), 0);
@@ -510,7 +513,7 @@ void testScalarTypeCmpExpr(MockTable* table,
                               0});
 
   std::vector<CiderBitUtils::CiderBitVector<>> null_vectors(
-      2, CiderBitUtils::CiderBitVector<>(5, 0xFF));
+      2, CiderBitUtils::CiderBitVector<>(allocator, 5, 0xFF));
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 0);
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 1);
   CiderBitUtils::clearBitAt(null_vectors[1].as<uint8_t>(), 0);
@@ -606,7 +609,7 @@ void testScalarTypeLogicalExpr(MockTable* table,
                               0});
 
   std::vector<CiderBitUtils::CiderBitVector<>> null_vectors(
-      3, CiderBitUtils::CiderBitVector<>(5, 0xFF));
+      3, CiderBitUtils::CiderBitVector<>(allocator, 5, 0xFF));
 
   if (!col1->type.get_notnull()) {
     CiderBitUtils::clearBitAt(null_vectors[1].as<uint8_t>(), 0);
@@ -736,7 +739,7 @@ void testScalarTypeFilter(MockTable* table,
                               0});
 
   std::vector<CiderBitUtils::CiderBitVector<>> null_vectors(
-      2, CiderBitUtils::CiderBitVector<>(5, 0xFF));
+      2, CiderBitUtils::CiderBitVector<>(allocator, 5, 0xFF));
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 0);
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 1);
   CiderBitUtils::clearBitAt(null_vectors[1].as<uint8_t>(), 0);

--- a/cider/tests/CiderAggTestHelper.h
+++ b/cider/tests/CiderAggTestHelper.h
@@ -33,6 +33,8 @@
 #include "cider/batch/StructBatch.h"
 
 const int db_id = 100;
+static const std::shared_ptr<CiderAllocator> ciderAllocator =
+    std::make_shared<CiderDefaultAllocator>();
 
 class MockTable {
  public:
@@ -105,7 +107,7 @@ class MockTable {
     }
     auto type = SQLTypeInfo(kSTRUCT, false, children_types);
     auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type);
-    auto batch = StructBatch::Create(schema);
+    auto batch = StructBatch::Create(schema, ciderAllocator);
     CHECK(batch->resizeBatch(element_num_, true));
 
     for (size_t i = 0; i < col_names.size(); ++i) {

--- a/cider/tests/CiderAggTestHelper.h
+++ b/cider/tests/CiderAggTestHelper.h
@@ -33,8 +33,6 @@
 #include "cider/batch/StructBatch.h"
 
 const int db_id = 100;
-static const std::shared_ptr<CiderAllocator> ciderAllocator =
-    std::make_shared<CiderDefaultAllocator>();
 
 class MockTable {
  public:
@@ -107,7 +105,7 @@ class MockTable {
     }
     auto type = SQLTypeInfo(kSTRUCT, false, children_types);
     auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type);
-    auto batch = StructBatch::Create(schema, ciderAllocator);
+    auto batch = StructBatch::Create(schema, std::make_shared<CiderDefaultAllocator>());
     CHECK(batch->resizeBatch(element_num_, true));
 
     for (size_t i = 0; i < col_names.size(); ++i) {
@@ -234,7 +232,8 @@ void runTest(const std::string& test_name,
   LOG(DEBUG1) << "----------------------Test case: " + test_name +
                      " --------------------------------------";
 
-  auto cider_compile_module = CiderCompileModule::Make();
+  auto cider_compile_module =
+      CiderCompileModule::Make(std::make_shared<CiderDefaultAllocator>());
   auto exe_option = CiderExecutionOption::defaults();
   auto compile_option = CiderCompilationOption::defaults();
 

--- a/cider/tests/CiderArrowBatchTest.cpp
+++ b/cider/tests/CiderArrowBatchTest.cpp
@@ -29,6 +29,9 @@
 using namespace CiderBatchUtils;
 using namespace std;
 
+static const std::shared_ptr<CiderAllocator> ciderAllocator =
+    std::make_shared<CiderDefaultAllocator>();
+
 class CiderArrowBatchTest : public ::testing::Test {};
 
 template <typename T, SQLTypes SQLT>
@@ -95,7 +98,7 @@ void scalarBatchTest(const vector<T>& data, const vector<bool>& not_null = {}) {
   SQLTypeInfo type_info(SQLT, not_null.empty());
   ArrowSchema* schema = convertCiderTypeInfoToArrowSchema(type_info);
 
-  auto batch = ScalarBatch<T>::Create(schema);
+  auto batch = ScalarBatch<T>::Create(schema, ciderAllocator);
   EXPECT_TRUE(batch->isRootOwner());
 
   runScalarBatchTest<T, SQLT>(batch.get(), data, not_null);
@@ -194,7 +197,7 @@ TEST_F(CiderArrowBatchTest, StructBatchTest) {
              kSTRUCT, true, {SQLTypeInfo(kBIGINT, false), SQLTypeInfo(kFLOAT, true)})});
 
     auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type);
-    auto batch = StructBatch::Create(schema);
+    auto batch = StructBatch::Create(schema, ciderAllocator);
 
     EXPECT_TRUE(batch->isRootOwner());
     EXPECT_TRUE(batch->resizeBatch(10));
@@ -311,7 +314,7 @@ TEST_F(CiderArrowBatchTest, StructBatchTest) {
     SQLTypeInfo type(kSTRUCT, true);
 
     auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type);
-    auto batch = StructBatch::Create(schema);
+    auto batch = StructBatch::Create(schema, ciderAllocator);
 
     EXPECT_TRUE(batch->isRootOwner());
     EXPECT_TRUE(batch->resizeBatch(10));
@@ -327,7 +330,7 @@ TEST_F(CiderArrowBatchTest, CopyFuncTest) {
 
   {
     auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type);
-    auto batch = StructBatch::Create(schema);
+    auto batch = StructBatch::Create(schema, ciderAllocator);
     {
       StructBatch copy_batch(*batch);
       EXPECT_FALSE(copy_batch.isRootOwner());
@@ -379,11 +382,11 @@ TEST_F(CiderArrowBatchTest, CopyFuncTest) {
   }
   {
     auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type);
-    auto batch = StructBatch::Create(schema);
+    auto batch = StructBatch::Create(schema, ciderAllocator);
     {
       auto type1 = SQLTypeInfo(kSTRUCT, true);
       auto schema1 = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type1);
-      StructBatch copy_batch(schema1);
+      StructBatch copy_batch(schema1, ciderAllocator);
 
       copy_batch.resizeBatch(100);
       copy_batch = *batch;
@@ -443,7 +446,7 @@ TEST_F(CiderArrowBatchTest, MoveFuncTest) {
   auto type2 = SQLTypeInfo(kSTRUCT, false, {SQLTypeInfo(kINT, false)});
   {
     auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type2);
-    auto batch = StructBatch::Create(schema);
+    auto batch = StructBatch::Create(schema, ciderAllocator);
     {
       batch->resizeBatch(10);
       auto child = batch->getChildAt(0);
@@ -456,7 +459,7 @@ TEST_F(CiderArrowBatchTest, MoveFuncTest) {
     }
     {
       auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type1);
-      StructBatch move_batch(schema);
+      StructBatch move_batch(schema, ciderAllocator);
       move_batch = std::move(*batch);
       EXPECT_FALSE(batch->isRootOwner());
       EXPECT_TRUE(batch->isMoved());
@@ -474,12 +477,12 @@ TEST_F(CiderArrowBatchTest, MoveFuncTest) {
   }
   {
     auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type1);
-    auto batch = StructBatch::Create(schema);
+    auto batch = StructBatch::Create(schema, ciderAllocator);
     batch->resizeBatch(100);
     EXPECT_EQ(batch->getChildrenNum(), 2);
     {
       auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type2);
-      batch = StructBatch::Create(schema);
+      batch = StructBatch::Create(schema, ciderAllocator);
       EXPECT_TRUE(batch->isRootOwner());
       EXPECT_FALSE(batch->isMoved());
       EXPECT_EQ(batch->getChildrenNum(), 1);
@@ -490,7 +493,7 @@ TEST_F(CiderArrowBatchTest, MoveFuncTest) {
   }
   {
     auto schema1 = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type1);
-    StructBatch batch(std::move(*StructBatch::Create(schema1)));
+    StructBatch batch(std::move(*StructBatch::Create(schema1, ciderAllocator)));
     EXPECT_TRUE(batch.isRootOwner());
     EXPECT_FALSE(batch.isMoved());
     EXPECT_EQ(batch.getChildrenNum(), 2);
@@ -504,7 +507,7 @@ TEST_F(CiderArrowBatchTest, ArrowEntryMoveTest) {
       kSTRUCT, false, {SQLTypeInfo(kBIGINT, false), SQLTypeInfo(kFLOAT, false)});
   {
     auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type);
-    auto batch = StructBatch::Create(schema);
+    auto batch = StructBatch::Create(schema, ciderAllocator);
     batch->resizeBatch(100);
 
     auto child1 = batch->getChildAt(0);
@@ -528,7 +531,7 @@ TEST_F(CiderArrowBatchTest, ArrowEntryMoveTest) {
     EXPECT_TRUE(batch->isMoved());
     batch.reset();
 
-    auto new_batch = StructBatch::Create(moved_schema, moved_array);
+    auto new_batch = StructBatch::Create(moved_schema, ciderAllocator, moved_array);
     EXPECT_TRUE(new_batch->isRootOwner());
     EXPECT_FALSE(new_batch->isMoved());
 

--- a/cider/tests/CiderBitUtilsTest.cpp
+++ b/cider/tests/CiderBitUtilsTest.cpp
@@ -31,14 +31,17 @@
 
 using namespace CiderBitUtils;
 
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
+
 class CiderBitUtilsTest : public ::testing::Test {};
 
 template <size_t alignFactor>
 void testAlignment() {
   size_t bitsNum = (alignFactor << 3);
-  CiderBitVector<alignFactor> bit_vec_1(bitsNum - 1);
-  CiderBitVector<alignFactor> bit_vec_2(bitsNum);
-  CiderBitVector<alignFactor> bit_vec_3(bitsNum + 1);
+  CiderBitVector<alignFactor> bit_vec_1(allocator, bitsNum - 1);
+  CiderBitVector<alignFactor> bit_vec_2(allocator, bitsNum);
+  CiderBitVector<alignFactor> bit_vec_3(allocator, bitsNum + 1);
 
   EXPECT_EQ(bit_vec_1.getBitsNum(), bitsNum);
   EXPECT_EQ(bit_vec_2.getBitsNum(), bitsNum);
@@ -54,7 +57,7 @@ void testAlignment() {
 
 template <size_t alignFactor>
 void testBasicOp(size_t bit_num) {
-  CiderBitVector<alignFactor> bit_vec_1(bit_num);
+  CiderBitVector<alignFactor> bit_vec_1(allocator, bit_num);
   auto actual_bit_num = bit_vec_1.getBitsNum();
   auto bit_vec_uint8 = bit_vec_1.template as<uint8_t>();
   for (size_t i = 0; i < actual_bit_num; ++i) {
@@ -95,7 +98,7 @@ TEST_F(CiderBitUtilsTest, BasicOpTest) {
 }
 
 TEST_F(CiderBitUtilsTest, CountTest) {
-  CiderBitVector<16> bit_vec_1(1025);
+  CiderBitVector<16> bit_vec_1(allocator, 1025);
   auto bit_vec = bit_vec_1.as<uint8_t>();
 
   EXPECT_EQ(countSetBits(bit_vec, 1025), 0ul);

--- a/cider/tests/CiderCompileModuleTest.cpp
+++ b/cider/tests/CiderCompileModuleTest.cpp
@@ -41,7 +41,8 @@ TEST(CiderCompileModuleTest, FilterProject) {
   substrait::Plan sub_plan;
   google::protobuf::util::JsonStringToMessage(sub_data, &sub_plan);
 
-  auto ciderCompileModule = CiderCompileModule::Make();
+  auto ciderCompileModule =
+      CiderCompileModule::Make(std::make_shared<CiderDefaultAllocator>());
   auto result = ciderCompileModule->compile(sub_plan);
 }
 

--- a/cider/tests/CiderNongroupbyAggTest.cpp
+++ b/cider/tests/CiderNongroupbyAggTest.cpp
@@ -24,7 +24,8 @@
 #include "TestHelpers.h"
 
 using namespace TestHelpers;
-
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
 class CiderNongroupbyAggArrowFormatTest : public ::testing::Test {
  protected:
   static MockTable* MockTableForTest;
@@ -170,7 +171,7 @@ void testScalarTypeSingleKey(MockTable* table,
                               0});
 
   std::vector<CiderBitUtils::CiderBitVector<>> null_vectors(
-      2, CiderBitUtils::CiderBitVector<>(5, 0xFF));
+      2, CiderBitUtils::CiderBitVector<>(allocator, 5, 0xFF));
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 1);
   CiderBitUtils::clearBitAt(null_vectors[0].as<uint8_t>(), 4);
 

--- a/cider/tests/CiderNongroupbyAggTestHelper.h
+++ b/cider/tests/CiderNongroupbyAggTestHelper.h
@@ -19,6 +19,7 @@
  * under the License.
  */
 
+#include <memory>
 #define CIDERBATCH_WITH_ARROW
 #include <gtest/gtest.h>
 #include "type/schema/ColumnInfo.h"
@@ -105,7 +106,7 @@ class MockTable {
     }
     auto type = SQLTypeInfo(kSTRUCT, false, children_types);
     auto schema = CiderBatchUtils::convertCiderTypeInfoToArrowSchema(type);
-    auto batch = StructBatch::Create(schema);
+    auto batch = StructBatch::Create(schema, std::make_shared<CiderDefaultAllocator>());
     CHECK(batch->resizeBatch(element_num_, true));
 
     for (size_t i = 0; i < col_names.size(); ++i) {

--- a/cider/tests/CiderNongroupbyAggTestHelper.h
+++ b/cider/tests/CiderNongroupbyAggTestHelper.h
@@ -19,7 +19,6 @@
  * under the License.
  */
 
-#include <memory>
 #define CIDERBATCH_WITH_ARROW
 #include <gtest/gtest.h>
 #include "type/schema/ColumnInfo.h"
@@ -287,7 +286,8 @@ void runTest(const std::string& test_name,
   LOG(DEBUG1) << "----------------------Test case: " + test_name +
                      " --------------------------------------";
 
-  auto cider_compile_module = CiderCompileModule::Make();
+  auto cider_compile_module =
+      CiderCompileModule::Make(std::make_shared<CiderDefaultAllocator>());
   auto exe_option = CiderExecutionOption::defaults();
   auto compile_option = CiderCompilationOption::defaults();
 

--- a/cider/tests/CiderRuntimeModuleJoinTest.cpp
+++ b/cider/tests/CiderRuntimeModuleJoinTest.cpp
@@ -140,7 +140,8 @@ void RunOneBatchAgg(std::string file_name) {
   generator::SubstraitToRelAlgExecutionUnit eu_translator(sub_plan);
   eu_translator.createRelAlgExecutionUnit();
 
-  auto cider_compile_module = CiderCompileModule::Make();
+  auto cider_compile_module =
+      CiderCompileModule::Make(std::make_shared<CiderDefaultAllocator>());
 
   cider_compile_module->feedBuildTable(std::move(buildOrdersCiderBatch()));
 

--- a/cider/tests/CiderRuntimeModuleTest.cpp
+++ b/cider/tests/CiderRuntimeModuleTest.cpp
@@ -31,6 +31,9 @@
 #include <google/protobuf/util/json_util.h>
 #include <gtest/gtest.h>
 
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
+
 RelAlgExecutionUnit buildFakeRelAlgEU(SQLTypes coltype, Datum d) {
   int db_id = 100;
   int table_id = 100;
@@ -135,7 +138,7 @@ CiderTableSchema buildTableSchema(std::string type_json) {
 }
 
 TEST(CiderRuntimeModuleTest, processInt) {
-  auto ciderCompileModule = CiderCompileModule::Make();
+  auto ciderCompileModule = CiderCompileModule::Make(allocator);
 
   // build compile input parameters
   SQLTypes intType{SQLTypes::kINT};
@@ -204,7 +207,7 @@ TEST(CiderRuntimeModuleTest, processInt) {
 }
 
 TEST(CiderRuntimeModuleTest, processDouble) {
-  auto ciderCompileModule = CiderCompileModule::Make();
+  auto ciderCompileModule = CiderCompileModule::Make(allocator);
 
   // build compile input parameters
   SQLTypes doubleType{SQLTypes::kDOUBLE};
@@ -277,7 +280,7 @@ TEST(CiderRuntimeModuleTest, processDouble) {
 }
 
 TEST(CiderRuntimeModuleTest, processMultiple) {
-  auto ciderCompileModule = CiderCompileModule::Make();
+  auto ciderCompileModule = CiderCompileModule::Make(allocator);
 
   // build compile input parameters
   SQLTypes doubleType{SQLTypes::kDOUBLE};

--- a/cider/tests/CompileWorkUnitTest.cpp
+++ b/cider/tests/CompileWorkUnitTest.cpp
@@ -135,7 +135,8 @@ std::vector<InputTableInfo> buildQueryInfo() {
 }
 
 TEST(APITest, case1) {
-  auto cider_compile_module = CiderCompileModule::Make();
+  auto cider_compile_module =
+      CiderCompileModule::Make(std::make_shared<CiderDefaultAllocator>());
 
   // build compile input parameters
   RelAlgExecutionUnit ra_exe_unit = buildFakeAggRelAlgEU();

--- a/cider/tests/ExpressionEvalTest.cpp
+++ b/cider/tests/ExpressionEvalTest.cpp
@@ -33,6 +33,8 @@
 #include "exec/plan/parser/SubstraitToRelAlgExecutionUnit.h"
 #include "exec/plan/parser/TypeUtils.h"
 
+static const auto allocator = std::make_shared<CiderDefaultAllocator>();
+
 TEST(ExpressionEvalTest, Add_I64_I64) {
   // should be expression or Measure
   std::string expr_json = R"({
@@ -115,7 +117,8 @@ TEST(ExpressionEvalTest, Add_I64_I64) {
                           .build();
   EXPECT_EQ(2, input_batch.row_num());
 
-  CiderExprEvaluator evaluator({&sub_expr}, {&func_info}, &schema, ExprType::ProjectExpr);
+  CiderExprEvaluator evaluator(
+      {&sub_expr}, {&func_info}, &schema, allocator, ExprType::ProjectExpr);
   auto out_batch1 = evaluator.eval(input_batch);
   auto out_batch2 = evaluator.eval(input_batch);
   auto expect_batch_ptr = std::make_shared<CiderBatch>(expect_batch);
@@ -150,7 +153,7 @@ TEST(ExpressionEvalTest, Complex_I32_I32) {
                           .addColumn<int64_t>("0", CREATE_SUBSTRAIT_TYPE(I32), {8, 15})
                           .build();
   CiderExprEvaluator evaluator(
-      {add_expr}, builder->funcsInfo(), schema, ExprType::ProjectExpr);
+      {add_expr}, builder->funcsInfo(), schema, allocator, ExprType::ProjectExpr);
   auto out_batch1 = evaluator.eval(input_batch);
   auto out_batch2 = evaluator.eval(input_batch);
   auto expect_batch_ptr = std::make_shared<CiderBatch>(expect_batch);
@@ -183,7 +186,7 @@ TEST(ExpressionEvalTest, GT_I64_I64) {
                           .addColumn<int64_t>("b", CREATE_SUBSTRAIT_TYPE(I64), {3})
                           .build();
   CiderExprEvaluator evaluator(
-      {gt_expr}, builder->funcsInfo(), schema, ExprType::FilterExpr);
+      {gt_expr}, builder->funcsInfo(), schema, allocator, ExprType::FilterExpr);
   auto out_batch1 = evaluator.eval(input_batch);
   auto out_batch2 = evaluator.eval(input_batch);
   auto expect_batch_ptr = std::make_shared<CiderBatch>(expect_batch);

--- a/cider/tests/Substrait2IRTest.cpp
+++ b/cider/tests/Substrait2IRTest.cpp
@@ -106,7 +106,8 @@ void relAlgExecutionUnitCreateAndCompile(std::string file_name) {
   ::substrait::Plan sub_plan;
   google::protobuf::util::JsonStringToMessage(sub_data, &sub_plan);
   generator::SubstraitToRelAlgExecutionUnit eu_translator(sub_plan);
-  auto cider_compile_module = CiderCompileModule::Make();
+  auto cider_compile_module =
+      CiderCompileModule::Make(std::make_shared<CiderDefaultAllocator>());
   cider_compile_module->feedBuildTable(std::move(buildCiderBatch()));
   cider_compile_module->compile(sub_plan);
 }

--- a/cider/tests/utils/CiderBatchBuilder.h
+++ b/cider/tests/utils/CiderBatchBuilder.h
@@ -28,6 +28,8 @@
 #include "substrait/type.pb.h"
 #include "util/Logger.h"
 
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
 class CiderBatchBuilder {
  public:
   CiderBatchBuilder() : row_num_(0), is_row_num_set_(false) {}
@@ -72,7 +74,7 @@ class CiderBatchBuilder {
       if (!null_data.empty()) {
         CHECK_EQ(row_num_, null_data.size());
       }
-      buf = (int8_t*)std::malloc(sizeof(T) * row_num_);
+      buf = allocator->allocate(sizeof(T) * row_num_);
       std::memcpy(buf, col_data.data(), sizeof(T) * row_num_);
     }
     table_ptr_.push_back(buf);
@@ -107,7 +109,7 @@ class CiderBatchBuilder {
       if (!null_data.empty()) {
         CHECK_EQ(row_num_, null_data.size());
       }
-      buf = (int8_t*)std::malloc(sizeof(int64_t) * row_num_);
+      buf = allocator->allocate(sizeof(int64_t) * row_num_);
       int64_t* dump = reinterpret_cast<int64_t*>(buf);
       for (auto i = 0; i < row_num_; i++) {
         dump[i] = col_data[i].getInt64Val();
@@ -143,7 +145,7 @@ class CiderBatchBuilder {
         CHECK_EQ(row_num_, null_data.size());
       }
       int len = sizeof(CiderByteArray) * row_num_;
-      buf = (int8_t*)std::malloc(len);
+      buf = allocator->allocate(len);
       std::memcpy(buf, col_data.data(), len);
     }
     table_ptr_.push_back(buf);

--- a/cider/tests/utils/CiderBatchBuilder.h
+++ b/cider/tests/utils/CiderBatchBuilder.h
@@ -28,11 +28,12 @@
 #include "substrait/type.pb.h"
 #include "util/Logger.h"
 
-static const std::shared_ptr<CiderAllocator> allocator =
-    std::make_shared<CiderDefaultAllocator>();
 class CiderBatchBuilder {
  public:
-  CiderBatchBuilder() : row_num_(0), is_row_num_set_(false) {}
+  CiderBatchBuilder()
+      : row_num_(0)
+      , is_row_num_set_(false)
+      , allocator_(std::make_shared<CiderDefaultAllocator>()) {}
 
   CiderBatchBuilder& setRowNum(int row_num) {
     if (is_row_num_set_) {  // have set before, throw exception
@@ -74,7 +75,7 @@ class CiderBatchBuilder {
       if (!null_data.empty()) {
         CHECK_EQ(row_num_, null_data.size());
       }
-      buf = allocator->allocate(sizeof(T) * row_num_);
+      buf = allocator_->allocate(sizeof(T) * row_num_);
       std::memcpy(buf, col_data.data(), sizeof(T) * row_num_);
     }
     table_ptr_.push_back(buf);
@@ -109,7 +110,7 @@ class CiderBatchBuilder {
       if (!null_data.empty()) {
         CHECK_EQ(row_num_, null_data.size());
       }
-      buf = allocator->allocate(sizeof(int64_t) * row_num_);
+      buf = allocator_->allocate(sizeof(int64_t) * row_num_);
       int64_t* dump = reinterpret_cast<int64_t*>(buf);
       for (auto i = 0; i < row_num_; i++) {
         dump[i] = col_data[i].getInt64Val();
@@ -145,7 +146,7 @@ class CiderBatchBuilder {
         CHECK_EQ(row_num_, null_data.size());
       }
       int len = sizeof(CiderByteArray) * row_num_;
-      buf = allocator->allocate(len);
+      buf = allocator_->allocate(len);
       std::memcpy(buf, col_data.data(), len);
     }
     table_ptr_.push_back(buf);
@@ -179,6 +180,7 @@ class CiderBatchBuilder {
   std::vector<::substrait::Type> col_types_;
   std::string table_name_ = "";
   std::vector<std::vector<bool>> null_vecs_;  // mark null data when builder adds columns
+  std::shared_ptr<CiderAllocator> allocator_;
 };
 
 #endif  // CIDER_CIDERBATCHBUILDER_H

--- a/cider/tests/utils/CiderBenchmarkRunner.h
+++ b/cider/tests/utils/CiderBenchmarkRunner.h
@@ -34,7 +34,8 @@
 class CiderBenchmarkRunner : public CiderQueryRunner {
  public:
   CiderBenchmarkRunner() {
-    ciderCompileModule_ = CiderCompileModule::Make();
+    ciderCompileModule_ =
+        CiderCompileModule::Make(std::make_shared<CiderDefaultAllocator>());
     exe_option = CiderExecutionOption::defaults();
     compile_option = CiderCompilationOption::defaults();
     compile_option.max_groups_buffer_entry_guess = 16384;

--- a/cider/tests/utils/CiderQueryRunner.h
+++ b/cider/tests/utils/CiderQueryRunner.h
@@ -33,7 +33,8 @@
 class CiderQueryRunner {
  public:
   CiderQueryRunner() {
-    ciderCompileModule_ = CiderCompileModule::Make();
+    ciderCompileModule_ =
+        CiderCompileModule::Make(std::make_shared<CiderDefaultAllocator>());
     exe_option = CiderExecutionOption::defaults();
     compile_option = CiderCompilationOption::defaults();
     compile_option.max_groups_buffer_entry_guess = 16384;

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "DuckDbQueryRunner.h"
-#include <cstdint>
 #include "Utils.h"
 #include "cider/CiderTypes.h"
 #include "exec/plan/parser/TypeUtils.h"

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -20,10 +20,14 @@
  */
 
 #include "DuckDbQueryRunner.h"
+#include <cstdint>
 #include "Utils.h"
 #include "cider/CiderTypes.h"
 #include "exec/plan/parser/TypeUtils.h"
 #include "util/Logger.h"
+
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
 
 void DuckDbQueryRunner::createTableAndInsertData(
     const std::string& table_name,
@@ -376,7 +380,8 @@ void addColumnDataToCiderBatch<CiderByteArray>(
     } else {
       std::string value = dataChunk->GetValue(i, j).GetValue<std::string>();
       // memory leak risk. user should manually free.
-      uint8_t* value_buf = (uint8_t*)std::malloc(value.length());
+      uint8_t* value_buf =
+          reinterpret_cast<uint8_t*>(allocator->allocate(value.length()));
       std::memcpy(value_buf, value.c_str(), value.length());
       buf[j].len = value.length();
       buf[j].ptr = value_buf;

--- a/cider/tests/utils/QueryDataGenerator.h
+++ b/cider/tests/utils/QueryDataGenerator.h
@@ -210,7 +210,7 @@ class QueryDataGenerator {
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz";
     int mod = sizeof(alphanum) - 1;
-    char* buf = (char*)std::malloc(len);
+    char* buf = reinterpret_cast<char*>(allocator->allocate(len));
     for (int i = 0; i < len; i++) {
       buf[i] = alphanum[rand() % mod];
     }
@@ -223,7 +223,7 @@ class QueryDataGenerator {
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz";
     int mod = sizeof(alphanum) - 1;
-    char* buf = (char*)std::malloc(len);
+    char* buf = reinterpret_cast<char*>(allocator->allocate(len));
     for (int i = 0; i < len; i++) {
       buf[i] = alphanum[index % mod];
     }

--- a/cider/tests/utils/QueryDataGenerator.h
+++ b/cider/tests/utils/QueryDataGenerator.h
@@ -210,6 +210,7 @@ class QueryDataGenerator {
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz";
     int mod = sizeof(alphanum) - 1;
+    auto allocator = std::make_shared<CiderDefaultAllocator>();
     char* buf = reinterpret_cast<char*>(allocator->allocate(len));
     for (int i = 0; i < len; i++) {
       buf[i] = alphanum[rand() % mod];
@@ -223,6 +224,7 @@ class QueryDataGenerator {
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz";
     int mod = sizeof(alphanum) - 1;
+    auto allocator = std::make_shared<CiderDefaultAllocator>();
     char* buf = reinterpret_cast<char*>(allocator->allocate(len));
     for (int i = 0; i < len; i++) {
       buf[i] = alphanum[index % mod];

--- a/cider/type/data/string/StringDictionary.cpp
+++ b/cider/type/data/string/StringDictionary.cpp
@@ -28,6 +28,7 @@
 #include <boost/sort/spreadsort/string_sort.hpp>
 #include <future>
 #include <iostream>
+#include <memory>
 #include <string_view>
 #include <thread>
 #include "cider/CiderException.h"
@@ -90,12 +91,14 @@ constexpr size_t StringDictionary::MAX_STRCOUNT;
 
 StringDictionary::StringDictionary(const DictRef& dict_ref,
                                    const std::string& folder,
+                                   std::shared_ptr<CiderAllocator> allocator,
                                    const bool isTemp,
                                    const bool recover,
                                    const bool materializeHashes,
                                    size_t initial_capacity)
     : dict_ref_(dict_ref)
     , folder_(folder)
+    , allocator_(allocator)
     , str_count_(0)
     , string_id_string_dict_hash_table_(initial_capacity, INVALID_STR_ID)
     , hash_cache_(initial_capacity)
@@ -1307,7 +1310,10 @@ size_t StringDictionary::addStorageCapacity(
                (min_capacity_requested / SYSTEM_PAGE_SIZE + 1) * SYSTEM_PAGE_SIZE);
 
   if (canary_buffer_size < canary_buff_size_to_add) {
-    CANARY_BUFFER = static_cast<char*>(realloc(CANARY_BUFFER, canary_buff_size_to_add));
+    CANARY_BUFFER = reinterpret_cast<char*>(
+        allocator_->reallocate(reinterpret_cast<int8_t*>(CANARY_BUFFER),
+                               canary_buffer_size,
+                               canary_buff_size_to_add));
     canary_buffer_size = canary_buff_size_to_add;
     CHECK(CANARY_BUFFER);
     memset(CANARY_BUFFER, 0xff, canary_buff_size_to_add);
@@ -1327,13 +1333,16 @@ void* StringDictionary::addMemoryCapacity(void* addr,
       std::max(static_cast<size_t>(1024 * SYSTEM_PAGE_SIZE),
                (min_capacity_requested / SYSTEM_PAGE_SIZE + 1) * SYSTEM_PAGE_SIZE);
   if (canary_buffer_size < canary_buff_size_to_add) {
-    CANARY_BUFFER =
-        reinterpret_cast<char*>(realloc(CANARY_BUFFER, canary_buff_size_to_add));
+    CANARY_BUFFER = reinterpret_cast<char*>(
+        allocator_->reallocate(reinterpret_cast<int8_t*>(CANARY_BUFFER),
+                               canary_buffer_size,
+                               canary_buff_size_to_add));
     canary_buffer_size = canary_buff_size_to_add;
     CHECK(CANARY_BUFFER);
     memset(CANARY_BUFFER, 0xff, canary_buff_size_to_add);
   }
-  void* new_addr = realloc(addr, mem_size + canary_buff_size_to_add);
+  void* new_addr = allocator_->reallocate(
+      reinterpret_cast<int8_t*>(addr), mem_size, mem_size + canary_buff_size_to_add);
   CHECK(new_addr);
   void* write_addr = reinterpret_cast<void*>(static_cast<char*>(new_addr) + mem_size);
   CHECK(memcpy(write_addr, CANARY_BUFFER, canary_buff_size_to_add));

--- a/cider/type/data/string/StringDictionary.cpp
+++ b/cider/type/data/string/StringDictionary.cpp
@@ -28,7 +28,6 @@
 #include <boost/sort/spreadsort/string_sort.hpp>
 #include <future>
 #include <iostream>
-#include <memory>
 #include <string_view>
 #include <thread>
 #include "cider/CiderException.h"

--- a/cider/type/data/string/StringDictionary.h
+++ b/cider/type/data/string/StringDictionary.h
@@ -30,11 +30,13 @@
 #include <functional>
 #include <future>
 #include <map>
+#include <memory>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <tuple>
 #include <vector>
+#include "cider/CiderAllocator.h"
 
 extern bool g_enable_stringdict_parallel;
 
@@ -52,6 +54,7 @@ class StringDictionary {
  public:
   StringDictionary(const DictRef& dict_ref,
                    const std::string& folder,
+                   std::shared_ptr<CiderAllocator> allocator,
                    const bool isTemp,
                    const bool recover,
                    const bool materializeHashes = false,
@@ -243,6 +246,7 @@ class StringDictionary {
 
   const DictRef dict_ref_;
   const std::string folder_;
+  std::shared_ptr<CiderAllocator> allocator_;
   size_t str_count_;
   size_t collisions_;
   std::vector<int32_t> string_id_string_dict_hash_table_;

--- a/cider/type/data/string/StringDictionary.h
+++ b/cider/type/data/string/StringDictionary.h
@@ -30,7 +30,6 @@
 #include <functional>
 #include <future>
 #include <map>
-#include <memory>
 #include <shared_mutex>
 #include <string>
 #include <string_view>

--- a/docs/CiderAllocator-use-guide.rst
+++ b/docs/CiderAllocator-use-guide.rst
@@ -43,5 +43,5 @@ A typical usage in CiderRunTimeModule
     `allocator_->deallocate(reinterpret_cast<int8_t*>(col_buffers),sizeof(int8_t**) * (total_col_num));`
 
 2.4 Finally we can pass a custom allocator when creating CiderRunTimeModule or use the default
-    `auto customAllocator = make_shared<CustomAllocator>();
+    `auto customAllocator = std::make_shared<CustomAllocator>();
     cider_runtime_module_ = std::make_shared<CiderRuntimeModule>(compile_res_, compile_option, exe_option, customAllocator);`

--- a/docs/CiderAllocator-use-guide.rst
+++ b/docs/CiderAllocator-use-guide.rst
@@ -1,0 +1,47 @@
+CiderAllocator use guide
+==========================================================================================================
+
+1 introduction to CiderAllocator
+We provide the allocation interface in CiderAllocator.h and two default implementations
+1.1
+CiderDefaultAllocator provide the default allocate and deallocate function via system library
+1.2
+AlignAllocator provide the function to perform memory alignment
+
+=========================================================================================================
+2 how to use
+user can construct an allocator from upstream memory pool, and then memory allocated will be in the pool.
+or use the CiderDefaultAllocator, AlignAllocator if they don't want to do it, 
+but this allocator must be present and passed throughout the calling logic
+because Only in this way can you know the memory usage during the entire operation for memory managerment
+
+---------------------------------------------------------------------------------------------------------
+A typical usage in CiderRunTimeModule
+2.1  add the member variables in .h file
+    `std::shared_ptr<CiderAllocator> allocator`
+    and add it in the constructor
+    `CiderRuntimeModule(
+      std::shared_ptr<CiderCompilationResult> ciderCompilationResult,
+      CiderCompilationOption ciderCompilationOption = CiderCompilationOption::defaults(),
+      CiderExecutionOption ciderExecutionOption = CiderExecutionOption::defaults(),
+      std::shared_ptr<CiderAllocator> allocator = std::make_shared<CiderDefaultAllocator>());`
+
+2.2 in .cpp implementation class
+    `CiderRuntimeModule::CiderRuntimeModule(
+        std::shared_ptr<CiderCompilationResult> ciderCompilationResult,
+        CiderCompilationOption ciderCompilationOption,
+        CiderExecutionOption ciderExecutionOption,
+        std::shared_ptr<CiderAllocator> allocator)
+        : ciderCompilationResult_(ciderCompilationResult)
+        , ciderCompilationOption_(ciderCompilationOption)
+        , ciderExecutionOption_(ciderExecutionOption)
+        , allocator_(allocator)`
+
+2.3 Then we can use it in the implementation class for memory allocation and release
+    `const int8_t** col_buffers = reinterpret_cast<const int8_t**>(allocator_->allocate(sizeof(int8_t**) * (total_col_num)));`
+
+    `allocator_->deallocate(reinterpret_cast<int8_t*>(col_buffers),sizeof(int8_t**) * (total_col_num));`
+
+2.4 Finally we can pass a custom allocator when creating CiderRunTimeModule or use the default
+    `auto customAllocator = make_shared<CustomAllocator>();
+    cider_runtime_module_ = std::make_shared<CiderRuntimeModule>(compile_res_, compile_option, exe_option, customAllocator);`


### PR DESCRIPTION
### What changes were proposed in this pull request?
code refactor with CiderAllocator, mainly include code such as std::malloc(size), replace it by allocator->allocate(size)，and add the Instructions for CiderAllocator us. Some omissions will be added later

### Why are the changes needed?
Refactor the original method of allocating memory to CiderAllocator for unified memory management

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT

### Which label does this PR belong to?
CodeRefactor