### PR TITLE
[POAE7-2350]:fix bug 'Clone velox plannode:Not supported velox planno…

### DIFF
--- a/cider-velox/src/planTransformer/PlanUtil.cpp
+++ b/cider-velox/src/planTransformer/PlanUtil.cpp
@@ -144,6 +144,10 @@ VeloxPlanNodePtr PlanUtil::cloneNodeWithNewSource(VeloxPlanNodePtr node,
                                                 std::string{assignUniqueIdNode->name()},
                                                 assignUniqueIdNode->taskUniqueId(),
                                                 source);
+  } else if (auto enforceSingleRowNode =
+                 std::dynamic_pointer_cast<const EnforceSingleRowNode>(node)) {
+    return std::make_shared<EnforceSingleRowNode>(enforceSingleRowNode->id(),
+                                                  source);
   } else {
     throw std::runtime_error("Clone velox plannode: Not supported velox plannode type[" +
                              std::string(typeid(node).name()) + "]");

--- a/cider-velox/src/planTransformer/PlanUtil.cpp
+++ b/cider-velox/src/planTransformer/PlanUtil.cpp
@@ -146,8 +146,7 @@ VeloxPlanNodePtr PlanUtil::cloneNodeWithNewSource(VeloxPlanNodePtr node,
                                                 source);
   } else if (auto enforceSingleRowNode =
                  std::dynamic_pointer_cast<const EnforceSingleRowNode>(node)) {
-    return std::make_shared<EnforceSingleRowNode>(enforceSingleRowNode->id(),
-                                                  source);
+    return std::make_shared<EnforceSingleRowNode>(enforceSingleRowNode->id(), source);
   } else {
     throw std::runtime_error("Clone velox plannode: Not supported velox plannode type[" +
                              std::string(typeid(node).name()) + "]");


### PR DESCRIPTION
…de type.' in tpch q11

### What changes were proposed in this pull request?
Clone Velox Plan Node with Type EnforceSingleRowNode for PlanTransformer


### Why are the changes needed?
Since in tpch-q11, there is a plan fragment which including a EnforceSingleRow plannode. Since the EnforceSingleRow is not cloned when transform the plan, exception is thrown out.
-- PartitionedOutput[BROADCAST] -> expr_41:DOUBLE
  -- EnforceSingleRow[] -> expr_41:DOUBLE
    -- LocalPartition[GATHER] -> expr_41:DOUBLE
      -- Project[expressions: (expr_41:DOUBLE, multiply("sum_40",0.0001))] -> expr_41:DOUBLE
        -- LocalPartition[REPARTITION] -> sum_40:DOUBLE
          -- Aggregation[FINAL sum_40 := sum("sum_53")] -> sum_40:DOUBLE
            -- LocalPartition[GATHER] -> sum_53:DOUBLE
              -- Exchange[] -> sum_53:DOUBLE


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested by End-2-End tpch q11 run

### Which label does this PR belong to?
Velox-plugin
