### PR TITLE
[POAE7-2384] change CiderTableSchema to shared_ptr in CiderCompilationResults

### DIFF
--- a/cider-velox/src/CiderOperator.cpp
+++ b/cider-velox/src/CiderOperator.cpp
@@ -60,8 +60,7 @@ CiderOperator::CiderOperator(int32_t operatorId,
         ciderCompileModule_->compile(plan, compile_option, exec_option);
     ciderRuntimeModule_ = std::make_shared<CiderRuntimeModule>(
         ciderCompileResult, compile_option, exec_option, allocator);
-    outputSchema_ = std::make_shared<CiderTableSchema>(
-        ciderCompileResult->getOutputCiderTableSchema());
+    outputSchema_ = ciderCompileResult->getOutputCiderTableSchema();
 
     is_using_arrow_format_ = compile_option.use_cider_data_format;
   }
@@ -155,8 +154,7 @@ exec::BlockingReason CiderOperator::isBlocked(ContinueFuture* future) {
     ciderRuntimeModule_ = std::make_shared<CiderRuntimeModule>(
         compileResult, compile_option, exec_option, allocator);
 
-    outputSchema_ =
-        std::make_shared<CiderTableSchema>(compileResult->getOutputCiderTableSchema());
+    outputSchema_ = compileResult->getOutputCiderTableSchema();
     buildTableFed_ = true;
   }
   return exec::BlockingReason::kNotBlocked;

--- a/cider-velox/test/AggWithRandomDataTest.cpp
+++ b/cider-velox/test/AggWithRandomDataTest.cpp
@@ -182,11 +182,11 @@ TEST_F(AggWithRandomDataTest, AVG_Partial_Test) {
   auto result = ciderCompileModule->compile(substraitPlan);
 
   auto outputSchema = result->getOutputCiderTableSchema();
-  auto numCols = outputSchema.getColumnCount();
+  auto numCols = outputSchema->getColumnCount();
   CHECK_EQ(numCols, 1);
-  auto outputHints = outputSchema.getColHints();
+  auto outputHints = outputSchema->getColHints();
   CHECK_EQ(outputHints[0], ColumnHint::PartialAVG);
-  auto outputType = outputSchema.getColumnTypeById(0);
+  auto outputType = outputSchema->getColumnTypeById(0);
   CHECK_EQ(outputType.has_struct_(), true);
 
   auto ciderRuntimeModule = std::make_shared<CiderRuntimeModule>(result);

--- a/cider/exec/module/CiderCompilationResultImpl.h
+++ b/cider/exec/module/CiderCompilationResultImpl.h
@@ -40,7 +40,9 @@ class CiderCompilationResult::Impl {
     return cpu_generated_code->func();
   }
 
-  CiderTableSchema getOutputCiderTableSchema() const { return outputSchema_; }
+  std::shared_ptr<CiderTableSchema> getOutputCiderTableSchema() const {
+    return outputSchema_;
+  }
 
   QueryType getQueryType() const {
     switch (query_mem_desc_->getQueryDescriptionType()) {
@@ -61,7 +63,7 @@ class CiderCompilationResult::Impl {
   std::shared_ptr<RelAlgExecutionUnit> rel_alg_exe_unit_;
   bool hoist_literals_;
   std::vector<int8_t> hoist_buf;
-  CiderTableSchema outputSchema_;
+  std::shared_ptr<CiderTableSchema> outputSchema_;
   CiderBatch build_table_;
   std::shared_ptr<StringDictionaryProxy> ciderStringDictionaryProxy_;
 };

--- a/cider/exec/module/CiderCompileModule.cpp
+++ b/cider/exec/module/CiderCompileModule.cpp
@@ -151,7 +151,7 @@ class CiderCompileModule::Impl {
     ciderCompilationResult->impl_->hoist_buf =
         executor_->serializeLiterals(compilation_result.literal_values, 0);
     ciderCompilationResult->impl_->outputSchema_ =
-        std::make_shared<CiderTableSchema>(translator_->getOutputCiderTableSchema());
+        translator_->getOutputCiderTableSchema();
     ciderCompilationResult->impl_->rel_alg_exe_unit_ = ra_exe_unit_;
     ciderCompilationResult->impl_->build_table_ = std::move(build_table_);
     ciderCompilationResult->impl_->ciderStringDictionaryProxy_ =
@@ -213,7 +213,7 @@ class CiderCompileModule::Impl {
     ciderCompilationResult->impl_->hoist_buf =
         executor_->serializeLiterals(compilation_result.literal_values, 0);
     ciderCompilationResult->impl_->outputSchema_ =
-        std::make_shared<CiderTableSchema>(translator_->getOutputCiderTableSchema());
+        translator_->getOutputCiderTableSchema();
     ciderCompilationResult->impl_->rel_alg_exe_unit_ = ra_exe_unit_;
     return ciderCompilationResult;
   }
@@ -264,7 +264,7 @@ class CiderCompileModule::Impl {
   std::shared_ptr<CiderCompilationResult> compile(
       const RelAlgExecutionUnit& ra_exe_unit,
       const std::vector<InputTableInfo>& table_infos,
-      CiderTableSchema schema,
+      std::shared_ptr<CiderTableSchema> schema,
       CiderCompilationOption cco,
       CiderExecutionOption ceo) {
     auto co = CiderCompilationOptionToCo(cco);
@@ -301,8 +301,7 @@ class CiderCompileModule::Impl {
     ciderCompilationResult->impl_->hoist_literals_ = co.hoist_literals;
     ciderCompilationResult->impl_->hoist_buf =
         executor_->serializeLiterals(compilation_result.literal_values, 0);
-    ciderCompilationResult->impl_->outputSchema_ =
-        std::make_shared<CiderTableSchema>(schema);
+    ciderCompilationResult->impl_->outputSchema_ = schema;
     ciderCompilationResult->impl_->rel_alg_exe_unit_ = ra_exe_unit_;
     return ciderCompilationResult;
   }
@@ -534,7 +533,7 @@ std::shared_ptr<CiderCompilationResult> CiderCompileModule::compile(
 std::shared_ptr<CiderCompilationResult> CiderCompileModule::compile(
     void* ra_exe_unit_,
     void* table_infos_,
-    CiderTableSchema schema,
+    std::shared_ptr<CiderTableSchema> schema,
     CiderCompilationOption cco,
     CiderExecutionOption ceo) {
   RelAlgExecutionUnit ra_exe_unit = *(RelAlgExecutionUnit*)ra_exe_unit_;

--- a/cider/exec/module/CiderCompileModule.cpp
+++ b/cider/exec/module/CiderCompileModule.cpp
@@ -82,7 +82,8 @@ void* CiderCompilationResult::func() const {
   return impl_->func();
 }
 
-CiderTableSchema CiderCompilationResult::getOutputCiderTableSchema() const {
+std::shared_ptr<CiderTableSchema> CiderCompilationResult::getOutputCiderTableSchema()
+    const {
   return impl_->getOutputCiderTableSchema();
 }
 
@@ -150,7 +151,7 @@ class CiderCompileModule::Impl {
     ciderCompilationResult->impl_->hoist_buf =
         executor_->serializeLiterals(compilation_result.literal_values, 0);
     ciderCompilationResult->impl_->outputSchema_ =
-        translator_->getOutputCiderTableSchema();
+        std::make_shared<CiderTableSchema>(translator_->getOutputCiderTableSchema());
     ciderCompilationResult->impl_->rel_alg_exe_unit_ = ra_exe_unit_;
     ciderCompilationResult->impl_->build_table_ = std::move(build_table_);
     ciderCompilationResult->impl_->ciderStringDictionaryProxy_ =
@@ -212,7 +213,7 @@ class CiderCompileModule::Impl {
     ciderCompilationResult->impl_->hoist_buf =
         executor_->serializeLiterals(compilation_result.literal_values, 0);
     ciderCompilationResult->impl_->outputSchema_ =
-        translator_->getOutputCiderTableSchema();
+        std::make_shared<CiderTableSchema>(translator_->getOutputCiderTableSchema());
     ciderCompilationResult->impl_->rel_alg_exe_unit_ = ra_exe_unit_;
     return ciderCompilationResult;
   }
@@ -300,7 +301,8 @@ class CiderCompileModule::Impl {
     ciderCompilationResult->impl_->hoist_literals_ = co.hoist_literals;
     ciderCompilationResult->impl_->hoist_buf =
         executor_->serializeLiterals(compilation_result.literal_values, 0);
-    ciderCompilationResult->impl_->outputSchema_ = schema;
+    ciderCompilationResult->impl_->outputSchema_ =
+        std::make_shared<CiderTableSchema>(schema);
     ciderCompilationResult->impl_->rel_alg_exe_unit_ = ra_exe_unit_;
     return ciderCompilationResult;
   }

--- a/cider/exec/plan/parser/SubstraitToRelAlgExecutionUnit.cpp
+++ b/cider/exec/plan/parser/SubstraitToRelAlgExecutionUnit.cpp
@@ -137,7 +137,7 @@ SubstraitToRelAlgExecutionUnit::createRelAlgExecutionUnit(
       quals = quals_filter.quals;
       simple_quals = quals_filter.simple_quals;
       // Create output table schema
-      output_cider_table_schema_ = table_schema;
+      output_cider_table_schema_ = std::make_shared<CiderTableSchema>(table_schema);
       break;
     }
     case ExprType::ProjectExpr: {
@@ -156,8 +156,8 @@ SubstraitToRelAlgExecutionUnit::createRelAlgExecutionUnit(
         o_col_hints.push_back(ColumnHint::Normal);
         target_exprs.emplace_back(p_evaluated_expr);
       }
-      CiderTableSchema output_schema(o_names, o_column_types, "", o_col_hints);
-      output_cider_table_schema_ = output_schema;
+      output_cider_table_schema_ =
+          std::make_shared<CiderTableSchema>(o_names, o_column_types, "", o_col_hints);
       break;
     }
     default:
@@ -203,8 +203,9 @@ substrait::Type SubstraitToRelAlgExecutionUnit::reconstructStructType(size_t ind
   return s_type;
 }
 
-CiderTableSchema SubstraitToRelAlgExecutionUnit::getOutputCiderTableSchema() {
-  if (!output_cider_table_schema_.getColumnCount()) {
+std::shared_ptr<CiderTableSchema>
+SubstraitToRelAlgExecutionUnit::getOutputCiderTableSchema() {
+  if (output_cider_table_schema_ == nullptr) {
     if (plan_.relations_size() == 0) {
       CIDER_THROW(CiderCompileException, "invalid plan with no root node.");
     }
@@ -234,8 +235,8 @@ CiderTableSchema SubstraitToRelAlgExecutionUnit::getOutputCiderTableSchema() {
       }
       i_target += length;
     }
-    CiderTableSchema schema(names, column_types, "", col_hints);
-    output_cider_table_schema_ = schema;
+    output_cider_table_schema_ =
+        std::make_shared<CiderTableSchema>(names, column_types, "", col_hints);
   }
   return output_cider_table_schema_;
 }

--- a/cider/exec/plan/parser/SubstraitToRelAlgExecutionUnit.h
+++ b/cider/exec/plan/parser/SubstraitToRelAlgExecutionUnit.h
@@ -45,13 +45,18 @@ static const std::string enum_str[] = {"FilterExpr", "ProjectExpr", "Aggregation
 class SubstraitToRelAlgExecutionUnit {
  public:
   explicit SubstraitToRelAlgExecutionUnit(const substrait::Plan& plan)
-      : toAnalyzerExprConverter_(), ctx_{nullptr}, input_table_schemas_{}, plan_(plan) {}
+      : toAnalyzerExprConverter_()
+      , ctx_{nullptr}
+      , input_table_schemas_{}
+      , plan_(plan)
+      , output_cider_table_schema_(nullptr) {}
 
   explicit SubstraitToRelAlgExecutionUnit()
       : toAnalyzerExprConverter_()
       , ctx_{nullptr}
       , input_table_schemas_{}
-      , plan_(substrait::Plan()) {}
+      , plan_(substrait::Plan())
+      , output_cider_table_schema_(nullptr) {}
 
   std::shared_ptr<RelAlgExecutionUnit> createRelAlgExecutionUnit(
       const std::vector<substrait::Expression*> exprs,
@@ -79,7 +84,7 @@ class SubstraitToRelAlgExecutionUnit {
    * return the output table schema info
    * @param plan: substrait plan
    */
-  CiderTableSchema getOutputCiderTableSchema();
+  std::shared_ptr<CiderTableSchema> getOutputCiderTableSchema();
 
   const std::vector<CiderTableSchema> getInputCiderTableSchema() const {
     return input_table_schemas_;
@@ -118,6 +123,6 @@ class SubstraitToRelAlgExecutionUnit {
   std::shared_ptr<GeneratorContext> ctx_;
   std::vector<CiderTableSchema> input_table_schemas_;
   const substrait::Plan& plan_;
-  CiderTableSchema output_cider_table_schema_;
+  std::shared_ptr<CiderTableSchema> output_cider_table_schema_;
 };
 }  // namespace generator

--- a/cider/include/cider/CiderCompileModule.h
+++ b/cider/include/cider/CiderCompileModule.h
@@ -49,7 +49,7 @@ class CiderCompilationResult {
 
   void* func() const;
 
-  CiderTableSchema getOutputCiderTableSchema() const;
+  std::shared_ptr<CiderTableSchema> getOutputCiderTableSchema() const;
 
   QueryType getQueryType() const;
 

--- a/cider/include/cider/CiderCompileModule.h
+++ b/cider/include/cider/CiderCompileModule.h
@@ -92,7 +92,7 @@ class CiderCompileModule {
   std::shared_ptr<CiderCompilationResult> compile(
       void* ra_exe_unit,
       void* query_infos,
-      CiderTableSchema schema,
+      std::shared_ptr<CiderTableSchema> schema,
       CiderCompilationOption cco = CiderCompilationOption::defaults(),
       CiderExecutionOption ceo = CiderExecutionOption::defaults());
 

--- a/cider/tests/CiderAggTestHelper.h
+++ b/cider/tests/CiderAggTestHelper.h
@@ -255,8 +255,8 @@ void runTest(const std::string& test_name,
     column_types.push_back(generator::getSubstraitType(
         ra_exe_unit_ptr->target_exprs[i_target]->get_type_info()));
   }
-  CiderTableSchema schema(col_names, column_types, "", col_hints);
-
+  auto schema =
+      std::make_shared<CiderTableSchema>(col_names, column_types, "", col_hints);
   auto compile_result = cider_compile_module->compile(
       ra_exe_unit_ptr.get(), &table_infos, schema, compile_option, exe_option);
 

--- a/cider/tests/CiderNongroupbyAggTestHelper.h
+++ b/cider/tests/CiderNongroupbyAggTestHelper.h
@@ -300,8 +300,11 @@ void runTest(const std::string& test_name,
   std::vector<InputTableInfo> table_infos = {table_ptr->getInputTableInfo()};
 
   // FIXME: output table schema not set
-  auto compile_result = cider_compile_module->compile(
-      ra_exe_unit_ptr.get(), &table_infos, compile_option, exe_option);
+  auto compile_result = cider_compile_module->compile(ra_exe_unit_ptr.get(),
+                                                      &table_infos,
+                                                      *(new CiderTableSchema()),
+                                                      compile_option,
+                                                      exe_option);
 
   CiderRuntimeModule cider_runtime_module(compile_result, compile_option, exe_option);
 

--- a/cider/tests/CiderNongroupbyAggTestHelper.h
+++ b/cider/tests/CiderNongroupbyAggTestHelper.h
@@ -299,12 +299,12 @@ void runTest(const std::string& test_name,
 
   std::vector<InputTableInfo> table_infos = {table_ptr->getInputTableInfo()};
 
-  // FIXME: output table schema not set
-  auto compile_result = cider_compile_module->compile(ra_exe_unit_ptr.get(),
-                                                      &table_infos,
-                                                      *(new CiderTableSchema()),
-                                                      compile_option,
-                                                      exe_option);
+  auto compile_result =
+      cider_compile_module->compile(ra_exe_unit_ptr.get(),
+                                    &table_infos,
+                                    std::make_shared<CiderTableSchema>(),
+                                    compile_option,
+                                    exe_option);
 
   CiderRuntimeModule cider_runtime_module(compile_result, compile_option, exe_option);
 

--- a/cider/tests/CiderRuntimeModuleTest.cpp
+++ b/cider/tests/CiderRuntimeModuleTest.cpp
@@ -128,13 +128,12 @@ std::vector<InputTableInfo> buildQueryInfo() {
   return query_infos;
 }
 
-CiderTableSchema buildTableSchema(std::string type_json) {
+std::shared_ptr<CiderTableSchema> buildTableSchema(std::string type_json) {
   std::vector<std::string> col_names = {"col_0", "col_1", "col_2", "col_3"};
   ::substrait::Type col_type;
   google::protobuf::util::JsonStringToMessage(type_json, &col_type);
   std::vector<::substrait::Type> col_types = {col_type, col_type, col_type, col_type};
-  CiderTableSchema schema(col_names, col_types);
-  return schema;
+  return std::make_shared<CiderTableSchema>(col_names, col_types);
 }
 
 TEST(CiderRuntimeModuleTest, processInt) {
@@ -155,7 +154,7 @@ TEST(CiderRuntimeModuleTest, processInt) {
       }
     }
     )";
-  CiderTableSchema schema = buildTableSchema(type_json);
+  auto schema = buildTableSchema(type_json);
 
   auto cco = CiderCompilationOption::defaults();
   cco.use_default_col_range = false;
@@ -224,7 +223,7 @@ TEST(CiderRuntimeModuleTest, processDouble) {
       }
     }
     )";
-  CiderTableSchema schema = buildTableSchema(type_json);
+  auto schema = buildTableSchema(type_json);
   auto cco = CiderCompilationOption::defaults();
   cco.use_default_col_range = false;
   auto result =
@@ -297,7 +296,7 @@ TEST(CiderRuntimeModuleTest, processMultiple) {
       }
     }
     )";
-  CiderTableSchema schema = buildTableSchema(type_json);
+  auto schema = buildTableSchema(type_json);
   auto cco = CiderCompilationOption::defaults();
   cco.use_default_col_range = false;
   auto result =

--- a/cider/tests/CompileWorkUnitTest.cpp
+++ b/cider/tests/CompileWorkUnitTest.cpp
@@ -145,7 +145,7 @@ TEST(APITest, case1) {
   auto ceo = CiderExecutionOption::defaults();
   auto cco = CiderCompilationOption::defaults();
   auto compile_result = cider_compile_module->compile(
-      &ra_exe_unit, &query_infos, *(new CiderTableSchema()), cco, ceo);
+      &ra_exe_unit, &query_infos, std::make_shared<CiderTableSchema>(), cco, ceo);
 
   // build data input parameters
   std::vector<const int8_t*> input_buf;

--- a/cider/tests/CompileWorkUnitTest.cpp
+++ b/cider/tests/CompileWorkUnitTest.cpp
@@ -144,8 +144,8 @@ TEST(APITest, case1) {
 
   auto ceo = CiderExecutionOption::defaults();
   auto cco = CiderCompilationOption::defaults();
-  auto compile_result =
-      cider_compile_module->compile(&ra_exe_unit, &query_infos, cco, ceo);
+  auto compile_result = cider_compile_module->compile(
+      &ra_exe_unit, &query_infos, *(new CiderTableSchema()), cco, ceo);
 
   // build data input parameters
   std::vector<const int8_t*> input_buf;

--- a/cider/tests/Substrait2IRTest.cpp
+++ b/cider/tests/Substrait2IRTest.cpp
@@ -122,41 +122,41 @@ TEST(Substrait2IR, OutputTableSchema) {
   generator::SubstraitToRelAlgExecutionUnit eu_translator(sub_plan);
   eu_translator.createRelAlgExecutionUnit();
   auto table_schema = eu_translator.getOutputCiderTableSchema();
-  CHECK(table_schema.getColumnTypeById(0).has_bool_() &&
-        table_schema.getColumnTypeById(0).bool_().nullability() ==
+  CHECK(table_schema->getColumnTypeById(0).has_bool_() &&
+        table_schema->getColumnTypeById(0).bool_().nullability() ==
             substrait::Type::NULLABILITY_NULLABLE);
-  CHECK(table_schema.getColumnTypeById(1).has_bool_() &&
-        table_schema.getColumnTypeById(1).bool_().nullability() ==
+  CHECK(table_schema->getColumnTypeById(1).has_bool_() &&
+        table_schema->getColumnTypeById(1).bool_().nullability() ==
             substrait::Type::NULLABILITY_REQUIRED);
-  CHECK(table_schema.getColumnTypeById(2).has_i32() &&
-        table_schema.getColumnTypeById(2).i32().nullability() ==
+  CHECK(table_schema->getColumnTypeById(2).has_i32() &&
+        table_schema->getColumnTypeById(2).i32().nullability() ==
             substrait::Type::NULLABILITY_NULLABLE);
-  CHECK(table_schema.getColumnTypeById(3).has_i32() &&
-        table_schema.getColumnTypeById(3).i32().nullability() ==
+  CHECK(table_schema->getColumnTypeById(3).has_i32() &&
+        table_schema->getColumnTypeById(3).i32().nullability() ==
             substrait::Type::NULLABILITY_REQUIRED);
-  CHECK(table_schema.getColumnTypeById(4).has_i64() &&
-        table_schema.getColumnTypeById(4).i64().nullability() ==
+  CHECK(table_schema->getColumnTypeById(4).has_i64() &&
+        table_schema->getColumnTypeById(4).i64().nullability() ==
             substrait::Type::NULLABILITY_NULLABLE);
-  CHECK(table_schema.getColumnTypeById(5).has_i64() &&
-        table_schema.getColumnTypeById(5).i64().nullability() ==
+  CHECK(table_schema->getColumnTypeById(5).has_i64() &&
+        table_schema->getColumnTypeById(5).i64().nullability() ==
             substrait::Type::NULLABILITY_REQUIRED);
-  CHECK(table_schema.getColumnTypeById(6).has_decimal() &&
-        table_schema.getColumnTypeById(6).decimal().nullability() ==
+  CHECK(table_schema->getColumnTypeById(6).has_decimal() &&
+        table_schema->getColumnTypeById(6).decimal().nullability() ==
             substrait::Type::NULLABILITY_NULLABLE);
-  CHECK(table_schema.getColumnTypeById(7).has_decimal() &&
-        table_schema.getColumnTypeById(7).decimal().nullability() ==
+  CHECK(table_schema->getColumnTypeById(7).has_decimal() &&
+        table_schema->getColumnTypeById(7).decimal().nullability() ==
             substrait::Type::NULLABILITY_REQUIRED);
-  CHECK(table_schema.getColumnTypeById(8).has_fp32() &&
-        table_schema.getColumnTypeById(8).fp32().nullability() ==
+  CHECK(table_schema->getColumnTypeById(8).has_fp32() &&
+        table_schema->getColumnTypeById(8).fp32().nullability() ==
             substrait::Type::NULLABILITY_NULLABLE);
-  CHECK(table_schema.getColumnTypeById(9).has_fp32() &&
-        table_schema.getColumnTypeById(9).fp32().nullability() ==
+  CHECK(table_schema->getColumnTypeById(9).has_fp32() &&
+        table_schema->getColumnTypeById(9).fp32().nullability() ==
             substrait::Type::NULLABILITY_REQUIRED);
-  CHECK(table_schema.getColumnTypeById(10).has_fp64() &&
-        table_schema.getColumnTypeById(10).fp64().nullability() ==
+  CHECK(table_schema->getColumnTypeById(10).has_fp64() &&
+        table_schema->getColumnTypeById(10).fp64().nullability() ==
             substrait::Type::NULLABILITY_NULLABLE);
-  CHECK(table_schema.getColumnTypeById(11).has_fp64() &&
-        table_schema.getColumnTypeById(11).fp64().nullability() ==
+  CHECK(table_schema->getColumnTypeById(11).has_fp64() &&
+        table_schema->getColumnTypeById(11).fp64().nullability() ==
             substrait::Type::NULLABILITY_REQUIRED);
 }
 

--- a/cider/tests/utils/CiderBenchmarkRunner.cpp
+++ b/cider/tests/utils/CiderBenchmarkRunner.cpp
@@ -25,8 +25,7 @@ void CiderBenchmarkRunner::compile(const std::string& sql) {
   compile_res_ = ciderCompileModule_->compile(plan, compile_option, exe_option);
   cider_runtime_module_ =
       std::make_shared<CiderRuntimeModule>(compile_res_, compile_option, exe_option);
-  output_schema_ =
-      std::make_shared<CiderTableSchema>(compile_res_->getOutputCiderTableSchema());
+  output_schema_ = compile_res_->getOutputCiderTableSchema();
 }
 
 CiderBatch CiderBenchmarkRunner::runNextBatch(

--- a/cider/tests/utils/QueryDataGenerator.h
+++ b/cider/tests/utils/QueryDataGenerator.h
@@ -266,7 +266,8 @@ class QueryDataGenerator {
   }
 
   static CiderByteArray genDateFormatCiderByteArray(int len) {
-    char* buf = (char*)std::malloc(len);
+    auto allocator = std::make_shared<CiderDefaultAllocator>();
+    char* buf = reinterpret_cast<char*>(allocator->allocate(len));
     char base = '0';
     std::mt19937 rng(std::random_device{}());  // NOLINT
     buf[0] = base + Random::randInt32(1, 2, rng);

--- a/docs/CiderAllocator-use-guide.rst
+++ b/docs/CiderAllocator-use-guide.rst
@@ -1,23 +1,28 @@
+========================
 CiderAllocator use guide
-==========================================================================================================
+========================
 
 1 introduction to CiderAllocator
+---------------------------------
 We provide the allocation interface in CiderAllocator.h and two default implementations
-1.1
-CiderDefaultAllocator provide the default allocate and deallocate function via system library
-1.2
-AlignAllocator provide the function to perform memory alignment
 
-=========================================================================================================
+1.1 CiderDefaultAllocator provide the default allocate and deallocate function via system library
+1.2 AlignAllocator provide the function to perform memory alignment
+
 2 how to use
+---------------------------------
+
 user can construct an allocator from upstream memory pool, and then memory allocated will be in the pool.
 or use the CiderDefaultAllocator, AlignAllocator if they don't want to do it, 
 but this allocator must be present and passed throughout the calling logic
 because Only in this way can you know the memory usage during the entire operation for memory managerment
 
----------------------------------------------------------------------------------------------------------
 A typical usage in CiderRunTimeModule
-2.1  add the member variables in .h file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. add the member variables in .h file
+
+::
+
     `std::shared_ptr<CiderAllocator> allocator`
     and add it in the constructor
     `CiderRuntimeModule(
@@ -26,7 +31,10 @@ A typical usage in CiderRunTimeModule
       CiderExecutionOption ciderExecutionOption = CiderExecutionOption::defaults(),
       std::shared_ptr<CiderAllocator> allocator = std::make_shared<CiderDefaultAllocator>());`
 
-2.2 in .cpp implementation class
+2. in .cpp implementation class
+
+::
+
     `CiderRuntimeModule::CiderRuntimeModule(
         std::shared_ptr<CiderCompilationResult> ciderCompilationResult,
         CiderCompilationOption ciderCompilationOption,
@@ -37,11 +45,14 @@ A typical usage in CiderRunTimeModule
         , ciderExecutionOption_(ciderExecutionOption)
         , allocator_(allocator)`
 
-2.3 Then we can use it in the implementation class for memory allocation and release
-    `const int8_t** col_buffers = reinterpret_cast<const int8_t**>(allocator_->allocate(sizeof(int8_t**) * (total_col_num)));`
+3. Then we can use it in the implementation class for memory allocation and release
 
+::
+    `const int8_t** col_buffers = reinterpret_cast<const int8_t**>(allocator_->allocate(sizeof(int8_t**) * (total_col_num)));`
     `allocator_->deallocate(reinterpret_cast<int8_t*>(col_buffers),sizeof(int8_t**) * (total_col_num));`
 
-2.4 Finally we can pass a custom allocator when creating CiderRunTimeModule or use the default
+4. Finally we can pass a custom allocator when creating CiderRunTimeModule or use the default
+
+::
     `auto customAllocator = std::make_shared<CustomAllocator>();
     cider_runtime_module_ = std::make_shared<CiderRuntimeModule>(compile_res_, compile_option, exe_option, customAllocator);`


### PR DESCRIPTION
### What changes were proposed in this pull request?
changed the CiderTableSchema varable from class  to shared_ptr in CiderCompilationResults and the rst file format adjustment


### Why are the changes needed?
we found that create CiderTableSchema object multiple times in CiderRuntimeModule code , will cause many memory allocations，so we changed it to shared_ptr

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UTs

### Which label does this PR belong to?
codeRefactor
