### PR TITLE
[POAE7-2385]incorrect filter result because of null varchar and len 0 varchar

### DIFF
--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -50,7 +50,7 @@ class CiderRandomStringTest : public CiderTestBase {
         {CREATE_SUBSTRAIT_TYPE(I32), CREATE_SUBSTRAIT_TYPE(Varchar)},
         {},
         GeneratePattern::Random,
-        2,
+        0,
         20))};
   }
 };
@@ -66,7 +66,7 @@ class CiderNullableStringTest : public CiderTestBase {
         {CREATE_SUBSTRAIT_TYPE(I32), CREATE_SUBSTRAIT_TYPE(Varchar)},
         {0, 2},
         GeneratePattern::Random,
-        2,
+        0,
         20))};
   }
 };

--- a/cider/tests/utils/QueryDataGenerator.h
+++ b/cider/tests/utils/QueryDataGenerator.h
@@ -309,7 +309,7 @@ class QueryDataGenerator {
       case GeneratePattern::Random:
         for (auto i = 0; i < row_num; ++i) {
           int len = rand() % (default_char_len - min_len + 1) + min_len;  // NOLINT
-          null_data[i] = Random::oneIn(null_chance, rng)
+          null_data[i] = Random::oneIn(null_chance, rng) || len == 0
                              ? (col_data[i] = CiderByteArray(), true)
                              : (col_data[i] = genRandomCiderByteArray(len), false);
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Incorrect filter result because of null varchar and len 0 varchar.
The duckdb will regard len 0 varchar as null but query data generator will not, so the UT will fail if random generated varchar's length is 0 


### Why are the changes needed?
Fix bug


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
Change the min length of random varchar to 0 in CiderStringTest.cpp, so the bug can happen again. After the fix the UT can all pass.


### Which label does this PR belong to?
bug
