### PR TITLE
[POAE7-2404] Modify the Substrait::Type pass by reference

### DIFF
--- a/cider-velox/src/ArrowDataConvertor.cpp
+++ b/cider-velox/src/ArrowDataConvertor.cpp
@@ -77,7 +77,7 @@ CiderBatch ArrowDataConvertor::convertToCider(RowVectorPtr input,
 VectorPtr toVeloxVectorWithArrow(ArrowArray& arrowArray,
                                  ArrowSchema& arrowSchema,
                                  const int8_t* data_buffer,
-                                 ::substrait::Type col_type,
+                                 const ::substrait::Type& col_type,
                                  int num_rows,
                                  memory::MemoryPool* pool,
                                  int32_t dimen = 0) {

--- a/cider-velox/src/RawDataConvertor.cpp
+++ b/cider-velox/src/RawDataConvertor.cpp
@@ -552,7 +552,7 @@ VectorPtr toVeloxDecimalImpl(const TypePtr& vType,
 }
 
 VectorPtr toVeloxVector(const TypePtr& vType,
-                        const ::substrait::Type sType,
+                        const ::substrait::Type& sType,
                         const int8_t* data_buffer,
                         int num_rows,
                         memory::MemoryPool* pool,
@@ -582,7 +582,7 @@ RowVectorPtr RawDataConvertor::convertToRowVector(const CiderBatch& input,
   int inputColIndex = 0;
 
   for (int i = 0; i < num_cols; i++) {
-    ::substrait::Type sType = schema.getColumnTypeById(i);
+    auto& sType = schema.getColumnTypeById(i);
     types.push_back(getVeloxType(sType));
     auto currentData = input.column(i);
     auto columNum = input.column_num();

--- a/cider-velox/src/TypeConversions.h
+++ b/cider-velox/src/TypeConversions.h
@@ -62,7 +62,7 @@ inline const char* getArrowFormat(::substrait::Type& typeName) {
   }
 }
 
-inline TypePtr getVeloxType(::substrait::Type& typeName) {
+inline TypePtr getVeloxType(const ::substrait::Type& typeName) {
   switch (typeName.kind_case()) {
     case ::substrait::Type::KindCase::kBool:
       return BOOLEAN();

--- a/cider-velox/test/AggWithRandomDataTest.cpp
+++ b/cider-velox/test/AggWithRandomDataTest.cpp
@@ -186,7 +186,7 @@ TEST_F(AggWithRandomDataTest, AVG_Partial_Test) {
   CHECK_EQ(numCols, 1);
   auto outputHints = outputSchema->getColHints();
   CHECK_EQ(outputHints[0], ColumnHint::PartialAVG);
-  auto outputType = outputSchema->getColumnTypeById(0);
+  auto& outputType = outputSchema->getColumnTypeById(0);
   CHECK_EQ(outputType.has_struct_(), true);
 
   auto ciderRuntimeModule = std::make_shared<CiderRuntimeModule>(result);

--- a/cider/exec/module/CiderRuntimeModule.cpp
+++ b/cider/exec/module/CiderRuntimeModule.cpp
@@ -446,7 +446,7 @@ void CiderRuntimeModule::fetchNonBlockingResults(int32_t start_row,
   }
 
   const auto& query_mem_desc = ciderCompilationResult_->impl_->query_mem_desc_;
-  const auto col_slot_context = query_mem_desc->getColSlotContext();
+  const auto& col_slot_context = query_mem_desc->getColSlotContext();
   // offset start from 1 to skip the 64 bits rowid
   size_t offset = 1;
   // step is row size in 8 bytes, equal to query_mem_desc->getRowSize() / 8
@@ -454,7 +454,7 @@ void CiderRuntimeModule::fetchNonBlockingResults(int32_t start_row,
   for (size_t i = 0; i < col_num; i++) {
     const auto col_slots = col_slot_context.getSlotsForCol(i);
     int8_t* col = const_cast<int8_t*>(outBatch.column(i));
-    substrait::Type type = schema->getColumnTypeById(i);
+    auto& type = schema->getColumnTypeById(i);
     // need to convert flattened row to columns as outbatch
     switch (type.kind_case()) {
       case substrait::Type::kBool:

--- a/cider/include/cider/CiderTableSchema.h
+++ b/cider/include/cider/CiderTableSchema.h
@@ -62,7 +62,7 @@ class CiderTableSchema {
 
   std::vector<substrait::Type> getColumnTypes() const { return columnTypes_; }
 
-  substrait::Type getColumnTypeById(const int column) const {
+  const substrait::Type& getColumnTypeById(const int column) const {
     CHECK(columnTypes_.size() > 0 && column < columnTypes_.size());
     return columnTypes_[column];
   }

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -195,7 +195,7 @@ void DuckDbQueryRunner::createTableAndInsertData(
       for (int k = 0; k < col_num; ++k) {
         if (null_data.empty() || null_data[k].empty() ||  // this column is not nullable
             !null_data[k][j]) {  // ture is null, false is non-null
-          auto s_type = current_batch->schema()->getColumnTypeById(k);
+          auto& s_type = current_batch->schema()->getColumnTypeById(k);
           auto value = GEN_DUCK_VALUE_FUNC();
           appender.Append(value);
         } else {
@@ -229,7 +229,7 @@ void DuckDbQueryRunner::createTableAndInsertData(
     for (int k = 0; k < col_num; ++k) {
       if (null_data[k].empty() ||  // this column is not nullable
           !null_data[k][j]) {
-        auto s_type = current_batch->schema()->getColumnTypeById(k);
+        auto& s_type = current_batch->schema()->getColumnTypeById(k);
         auto value = GEN_DUCK_VALUE_FUNC();
         appender.Append(value);
       } else {

--- a/cider/util/measure.h
+++ b/cider/util/measure.h
@@ -73,7 +73,7 @@ std::string timer_lap(Type clock_begin, Type& clock_last) {
 }
 
 struct InjectTimer {
-  InjectTimer(std::string const& description, int const& lineNum, std::string const& func)
+  InjectTimer(const char* description, int const& lineNum, const char* func)
       : description_(description), lineNum_(lineNum), func_(func) {
     if (g_enable_debug_timer) {
       start_ = timer_start();
@@ -90,9 +90,9 @@ struct InjectTimer {
     }
   }
 
-  std::string description_;
+  const char* description_;
   int lineNum_;
-  std::string func_;
+  const char* func_;
 
   std::chrono::steady_clock::time_point start_;
 };


### PR DESCRIPTION
### What changes were proposed in this pull request?
Modify the Substrait::Type pass by reference instead of pass by object, and change the string to char* in measure.h 


### Why are the changes needed?
During code refactor with CiderAllocator and memory analysis，we found that in function CiderRuntimeModule::fetchResults, the CiderTableSchema->Substrait::Type occupies too much memory, so we try to optimize the memory usage of Substrait::Type
also in measure.h->InjectTime to save memory usage.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UTs

### Which label does this PR belong to?
codeRefactor
