### PR TITLE
[POAE7-2400] DuckDB output to Arrow-format CiderBatch

### DIFF
--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -520,6 +520,8 @@ CiderBatch DuckDbResultConvertor::fetchOneArrowFormattedBatch(
         addColumnDataToScalarBatch<int16_t>(chunk, i, row_num, child.get());
         break;
       case ::duckdb::LogicalTypeId::BOOLEAN:
+        addColumnDataToScalarBatch<bool>(chunk, i, row_num, child.get());
+        break;
       case ::duckdb::LogicalTypeId::TINYINT:
         addColumnDataToScalarBatch<int8_t>(chunk, i, row_num, child.get());
         break;

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -401,7 +401,7 @@ void addColumnDataToScalarBatch(std::unique_ptr<duckdb::DataChunk>& dataChunk,
   int64_t null_count = 0;
 
   for (int j = 0; j < row_num; j++) {
-    T value = std::numeric_limits<T>::min();  // init with Cider null value
+    T value = 0;  // No need to set to Cider null value (min) now. 0 would be fine.
     if (dataChunk->GetValue(i, j).IsNull()) {
       CiderBitUtils::clearBitAt(null_buffer, j);
       ++null_count;

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -470,7 +470,7 @@ void addColumnDataToScalarBatch<CiderByteArray>(
   child->setNullCount(null_count);
 }
 
-std::unique_ptr<CiderBatch> DuckDbResultConvertor::fetchOneArrowFormattedBatch(
+CiderBatch DuckDbResultConvertor::fetchOneArrowFormattedBatch(
     std::unique_ptr<duckdb::DataChunk>& chunk) {
   // Construct ArrowSchema
   // First build a CiderTableSchema and then convert it
@@ -540,7 +540,7 @@ std::unique_ptr<CiderBatch> DuckDbResultConvertor::fetchOneArrowFormattedBatch(
     }
   }
   chunk->Destroy();
-  return batch;
+  return std::move(*batch);
 }
 
 CiderBatch DuckDbResultConvertor::fetchOneBatch(
@@ -643,8 +643,7 @@ DuckDbResultConvertor::fetchDataToArrowFormattedCiderBatch(
       }
       return batch_res;
     }
-    auto ret_temp = fetchOneArrowFormattedBatch(chunk);
-    batch_res.push_back(std::make_shared<CiderBatch>(std::move(*ret_temp)));
+    batch_res.push_back(std::make_shared<CiderBatch>(fetchOneArrowFormattedBatch(chunk)));
   }
   return batch_res;
 }

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -400,8 +400,8 @@ void addColumnDataToScalarBatch(std::unique_ptr<duckdb::DataChunk>& dataChunk,
   auto null_buffer = child->getMutableNulls();
   int64_t null_count = 0;
 
-  T value = std::numeric_limits<T>::min();  // init with Cider null value
   for (int j = 0; j < row_num; j++) {
+    T value = std::numeric_limits<T>::min();  // init with Cider null value
     if (dataChunk->GetValue(i, j).IsNull()) {
       CiderBitUtils::clearBitAt(null_buffer, j);
       ++null_count;

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -540,7 +540,7 @@ std::unique_ptr<CiderBatch> DuckDbResultConvertor::fetchOneArrowFormattedBatch(
     }
   }
   chunk->Destroy();
-  return std::move(batch);
+  return batch;
 }
 
 CiderBatch DuckDbResultConvertor::fetchOneBatch(
@@ -644,7 +644,7 @@ DuckDbResultConvertor::fetchDataToArrowFormattedCiderBatch(
       return batch_res;
     }
     auto ret_temp = fetchOneArrowFormattedBatch(chunk);
-    batch_res.push_back(std::make_shared<CiderBatch>(std::move(*std::move(ret_temp))));
+    batch_res.push_back(std::make_shared<CiderBatch>(std::move(*ret_temp)));
   }
   return batch_res;
 }

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -491,6 +491,9 @@ CiderBatch DuckDbResultConvertor::fetchOneArrowFormattedBatch(
   }
 
   auto cider_schema = std::make_shared<CiderTableSchema>(batch_names, batch_types, "");
+
+  /// NOTE: (YBRua) This function currently only support primitive scalar types
+  /// It cannot convert Date/Time/Varchar to ArrowSchema
   auto arrow_schema =
       CiderBatchUtils::convertCiderTableSchemaToArrowSchema(*cider_schema);
 

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -395,30 +395,6 @@ void addColumnDataToCiderBatch<CiderByteArray>(
   }
 }
 
-template <typename T>
-void addColumnDataToScalarBatch(std::unique_ptr<duckdb::DataChunk>& dataChunk,
-                                int i,
-                                int row_num,
-                                CiderBatch* child) {
-  CHECK(child->resizeBatch(row_num, true));
-  auto data_buffer = child->asMutable<ScalarBatch<T>>()->getMutableRawData();
-  auto null_buffer = child->getMutableNulls();
-  int64_t null_count = 0;
-
-  for (int j = 0; j < row_num; j++) {
-    T value = 0;  // No need to set to Cider null value (min) now. 0 would be fine.
-    if (dataChunk->GetValue(i, j).IsNull()) {
-      CiderBitUtils::clearBitAt(null_buffer, j);
-      ++null_count;
-    } else {
-      value = dataChunk->GetValue(i, j).GetValue<T>();
-      CiderBitUtils::setBitAt(null_buffer, j);
-    }
-    std::memcpy(data_buffer + j, &value, sizeof(T));
-  }
-  child->setNullCount(null_count);
-}
-
 CiderBatch DuckDbResultConvertor::fetchOneArrowFormattedBatch(
     std::unique_ptr<duckdb::DataChunk>& chunk,
     std::vector<std::string>& names,

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -440,51 +440,53 @@ CiderBatch DuckDbResultConvertor::fetchOneArrowFormattedBatch(
   /// It cannot convert Date/Time/Varchar to ArrowSchema
   auto arrow_schema =
       CiderBatchUtils::convertCiderTableSchemaToArrowSchema(*cider_schema);
+  auto arrow_array = CiderBatchUtils::allocateArrowArray();
+  chunk->ToArrowArray(arrow_array);
 
   // Construct ArrowArray
   /// NOTE: (YBRua) DuckDb provides an API ToArrowArray(), but we are NOT using it
   /// since the structs for DATE and VARCHAR in Cider differ from those used in DuckDB
   auto batch =
-      StructBatch::Create(arrow_schema, std::make_shared<CiderDefaultAllocator>());
+      StructBatch::Create(arrow_schema, std::make_shared<CiderDefaultAllocator>(), arrow_array);
   CHECK(batch->resizeBatch(row_num, true));
-  for (int i = 0; i < col_num; ++i) {
-    auto child = batch->getChildAt(i);
-    auto type = types[i];
-    switch (type.id()) {
-      case ::duckdb::LogicalTypeId::HUGEINT:
-      case ::duckdb::LogicalTypeId::BIGINT:
-      case ::duckdb::LogicalTypeId::TIMESTAMP:
-      case ::duckdb::LogicalTypeId::TIME:
-        addColumnDataToScalarBatch<int64_t>(chunk, i, row_num, child.get());
-        break;
-      case ::duckdb::LogicalTypeId::INTEGER:
-        addColumnDataToScalarBatch<int32_t>(chunk, i, row_num, child.get());
-        break;
-      case ::duckdb::LogicalTypeId::SMALLINT:
-        addColumnDataToScalarBatch<int16_t>(chunk, i, row_num, child.get());
-        break;
-      case ::duckdb::LogicalTypeId::BOOLEAN:
-        addColumnDataToScalarBatch<bool>(chunk, i, row_num, child.get());
-        break;
-      case ::duckdb::LogicalTypeId::TINYINT:
-        addColumnDataToScalarBatch<int8_t>(chunk, i, row_num, child.get());
-        break;
-      case ::duckdb::LogicalTypeId::FLOAT:
-        addColumnDataToScalarBatch<float>(chunk, i, row_num, child.get());
-        break;
-      case ::duckdb::LogicalTypeId::DOUBLE:
-      case ::duckdb::LogicalTypeId::DECIMAL:
-        addColumnDataToScalarBatch<double>(chunk, i, row_num, child.get());
-        break;
-      case ::duckdb::LogicalTypeId::DATE:
-      case ::duckdb::LogicalTypeId::CHAR:
-      case ::duckdb::LogicalTypeId::VARCHAR:
-        CIDER_THROW(CiderUnsupportedException, "Date and Varchar are not supported yet");
-      default:
-        CIDER_THROW(CiderCompileException,
-                    "Unsupported type convertor: " + type.ToString());
-    }
-  }
+  // for (int i = 0; i < col_num; ++i) {
+  //   auto child = batch->getChildAt(i);
+  //   auto type = types[i];
+  //   switch (type.id()) {
+  //     case ::duckdb::LogicalTypeId::HUGEINT:
+  //     case ::duckdb::LogicalTypeId::BIGINT:
+  //     case ::duckdb::LogicalTypeId::TIMESTAMP:
+  //     case ::duckdb::LogicalTypeId::TIME:
+  //       addColumnDataToScalarBatch<int64_t>(chunk, i, row_num, child.get());
+  //       break;
+  //     case ::duckdb::LogicalTypeId::INTEGER:
+  //       addColumnDataToScalarBatch<int32_t>(chunk, i, row_num, child.get());
+  //       break;
+  //     case ::duckdb::LogicalTypeId::SMALLINT:
+  //       addColumnDataToScalarBatch<int16_t>(chunk, i, row_num, child.get());
+  //       break;
+  //     case ::duckdb::LogicalTypeId::BOOLEAN:
+  //       addColumnDataToScalarBatch<bool>(chunk, i, row_num, child.get());
+  //       break;
+  //     case ::duckdb::LogicalTypeId::TINYINT:
+  //       addColumnDataToScalarBatch<int8_t>(chunk, i, row_num, child.get());
+  //       break;
+  //     case ::duckdb::LogicalTypeId::FLOAT:
+  //       addColumnDataToScalarBatch<float>(chunk, i, row_num, child.get());
+  //       break;
+  //     case ::duckdb::LogicalTypeId::DOUBLE:
+  //     case ::duckdb::LogicalTypeId::DECIMAL:
+  //       addColumnDataToScalarBatch<double>(chunk, i, row_num, child.get());
+  //       break;
+  //     case ::duckdb::LogicalTypeId::DATE:
+  //     case ::duckdb::LogicalTypeId::CHAR:
+  //     case ::duckdb::LogicalTypeId::VARCHAR:
+  //       CIDER_THROW(CiderUnsupportedException, "Date and Varchar are not supported yet");
+  //     default:
+  //       CIDER_THROW(CiderCompileException,
+  //                   "Unsupported type convertor: " + type.ToString());
+  //   }
+  // }
   chunk->Destroy();
   return std::move(*batch);
 }

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -428,7 +428,7 @@ CiderBatch DuckDbResultConvertor::fetchOneArrowFormattedBatch(
         }
       }
     } else {
-      CHECK(child->getNullCount() == 0);
+      CHECK_EQ(child->getNullCount(), 0);
     }
     child->setNullCount(null_count);
   }

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -495,9 +495,8 @@ CiderBatch DuckDbResultConvertor::fetchOneArrowFormattedBatch(
       CiderBatchUtils::convertCiderTableSchemaToArrowSchema(*cider_schema);
 
   // Construct ArrowArray
-  /// NOTE: DuckDb provides an API DataChunk::ToArrowArray()
-  /// for exporting data to ArrowArray, but we are NOT using it
-  /// since the structs for DATE and VARCHAR differ from those used in DuckDB
+  /// NOTE: (YBRua) DuckDb provides an API ToArrowArray(), but we are NOT using it
+  /// since the structs for DATE and VARCHAR in Cider differ from those used in DuckDB
   auto batch =
       StructBatch::Create(arrow_schema, std::make_shared<CiderDefaultAllocator>());
   for (int i = 0; i < col_num; ++i) {

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -417,7 +417,7 @@ void DuckDbResultConvertor::updateChildrenNullCounts(CiderBatch& batch) {
 CiderBatch DuckDbResultConvertor::fetchOneArrowFormattedBatch(
     std::unique_ptr<duckdb::DataChunk>& chunk,
     std::vector<std::string>& names,
-    std::string& config_timezone) {
+    std::string config_timezone) {
   int col_num = chunk->ColumnCount();
   int row_num = chunk->size();
 

--- a/cider/tests/utils/DuckDbQueryRunner.h
+++ b/cider/tests/utils/DuckDbQueryRunner.h
@@ -83,7 +83,7 @@ class DuckDbResultConvertor {
   static CiderBatch fetchOneBatch(std::unique_ptr<duckdb::DataChunk>& chunk);
   static CiderBatch fetchOneArrowFormattedBatch(std::unique_ptr<duckdb::DataChunk>& chunk,
                                                 std::vector<std::string>& names,
-                                                std::string& config_timezone);
+                                                std::string config_timezone = "");
   static void updateChildrenNullCounts(CiderBatch& batch);
 };
 

--- a/cider/tests/utils/DuckDbQueryRunner.h
+++ b/cider/tests/utils/DuckDbQueryRunner.h
@@ -71,7 +71,7 @@ class DuckDbResultConvertor {
 
  private:
   static CiderBatch fetchOneBatch(std::unique_ptr<duckdb::DataChunk>& chunk);
-  static CiderBatch fetchOneArrowFormattedBatch(
+  static std::unique_ptr<CiderBatch> fetchOneArrowFormattedBatch(
       std::unique_ptr<duckdb::DataChunk>& chunk);
 };
 

--- a/cider/tests/utils/DuckDbQueryRunner.h
+++ b/cider/tests/utils/DuckDbQueryRunner.h
@@ -84,6 +84,7 @@ class DuckDbResultConvertor {
   static CiderBatch fetchOneArrowFormattedBatch(std::unique_ptr<duckdb::DataChunk>& chunk,
                                                 std::vector<std::string>& names,
                                                 std::string& config_timezone);
+  static void updateChildrenNullCounts(CiderBatch& batch);
 };
 
 #endif  // CIDER_DUCKDBQUERYRUNNER_H

--- a/cider/tests/utils/DuckDbQueryRunner.h
+++ b/cider/tests/utils/DuckDbQueryRunner.h
@@ -32,6 +32,7 @@ class DuckDbQueryRunner {
     duckdb::DBConfig config;
     config.maximum_threads = 1;
     db_ = std::move(duckdb::DuckDB("", &config));
+    config_timezone_ = "";
   }
 
   // create a basic table and insert data for test, only int32 type support.
@@ -50,6 +51,7 @@ class DuckDbQueryRunner {
                                 const std::shared_ptr<CiderBatch>& data);
 
   std::unique_ptr<::duckdb::MaterializedQueryResult> runSql(const std::string& sql);
+  std::string getConfigTimeZone();
 
  private:
   ::duckdb::DuckDB db_;
@@ -60,19 +62,28 @@ class DuckDbQueryRunner {
   void appendTableData(::duckdb::Connection& con,
                        const std::string& table_name,
                        const std::vector<std::vector<int32_t>>& table_data);
+  std::string config_timezone_;
 };
 
 class DuckDbResultConvertor {
  public:
   static std::vector<std::shared_ptr<CiderBatch>> fetchDataToCiderBatch(
       std::unique_ptr<::duckdb::MaterializedQueryResult>& result);
+  /// \brief Fetches data from duckdb query results, and returns a vector of
+  /// CiderBatch instances with Arrow format as underlying memory layout
+  /// @param result duckdb query result
+  /// @param config_timezone required by duckdb convertion method, but ONLY when data
+  /// include microsecond-timestamps w/ timezone (format `tsu:...` in ArrowSchema).
+  /// Will be appended as-is after the colon character.
   static std::vector<std::shared_ptr<CiderBatch>> fetchDataToArrowFormattedCiderBatch(
-      std::unique_ptr<::duckdb::MaterializedQueryResult>& result);
+      std::unique_ptr<::duckdb::MaterializedQueryResult>& result,
+      std::string config_timezone = "");
 
  private:
   static CiderBatch fetchOneBatch(std::unique_ptr<duckdb::DataChunk>& chunk);
-  static CiderBatch fetchOneArrowFormattedBatch(
-      std::unique_ptr<duckdb::DataChunk>& chunk);
+  static CiderBatch fetchOneArrowFormattedBatch(std::unique_ptr<duckdb::DataChunk>& chunk,
+                                                std::vector<std::string>& names,
+                                                std::string& config_timezone);
 };
 
 #endif  // CIDER_DUCKDBQUERYRUNNER_H

--- a/cider/tests/utils/DuckDbQueryRunner.h
+++ b/cider/tests/utils/DuckDbQueryRunner.h
@@ -66,9 +66,13 @@ class DuckDbResultConvertor {
  public:
   static std::vector<std::shared_ptr<CiderBatch>> fetchDataToCiderBatch(
       std::unique_ptr<::duckdb::MaterializedQueryResult>& result);
+  static std::vector<std::shared_ptr<CiderBatch>> fetchDataToArrowFormattedCiderBatch(
+      std::unique_ptr<::duckdb::MaterializedQueryResult>& result);
 
  private:
   static CiderBatch fetchOneBatch(std::unique_ptr<duckdb::DataChunk>& chunk);
+  static CiderBatch fetchOneArrowFormattedBatch(
+      std::unique_ptr<duckdb::DataChunk>& chunk);
 };
 
 #endif  // CIDER_DUCKDBQUERYRUNNER_H

--- a/cider/tests/utils/DuckDbQueryRunner.h
+++ b/cider/tests/utils/DuckDbQueryRunner.h
@@ -71,7 +71,7 @@ class DuckDbResultConvertor {
 
  private:
   static CiderBatch fetchOneBatch(std::unique_ptr<duckdb::DataChunk>& chunk);
-  static std::unique_ptr<CiderBatch> fetchOneArrowFormattedBatch(
+  static CiderBatch fetchOneArrowFormattedBatch(
       std::unique_ptr<duckdb::DataChunk>& chunk);
 };
 

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -118,7 +118,7 @@ void checkDuckDbScalarOutput(
     // check child row nums
     EXPECT_EQ(child->getLength(), expected_data[i].size());
 
-    auto data_buffer = child->as<ScalarBatch<int32_t>>()->getRawData();
+    auto data_buffer = child->as<ScalarBatch<T>>()->getRawData();
     auto null_buffer = child->getNulls();
     auto null_count = int{0};
     for (auto j = 0; j < child->getLength(); ++j) {

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -211,8 +211,6 @@ void checkDuckDbBooleanOutput(
     checkDuckDbScalarOutput<C_TYPE>(actual_batches, expected_data, expected_nulls);     \
   }
 
-#define ARROW_SIMPLE_TEST_PROCEDURE(C_TYPE, SQL_TYPE)
-
 TEST(DuckDBResultConvertorTest, simpleIntegerArrowTest) {
   ARROW_SIMPLE_TEST_SUITE(int32_t, I32, INTEGER);
 }

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -34,7 +34,7 @@
 
 template <typename T>
 std::tuple<std::vector<std::vector<T>>, std::vector<std::vector<bool>>>
-generateSequenceData(int n_rows = 10, int n_nulls = 5) {
+generateSequenceData(int n_rows = 10, int n_nulls = 3) {
   CHECK(n_nulls <= n_rows);
   int n_not_nulls = n_rows - n_nulls;
 

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -412,7 +412,6 @@ TEST(DuckDBQueryRunnerTest, insertCiderBatchTest) {
   auto res = runner.runSql("select * from table_test;");
   CHECK(!res->HasError());
   CHECK_EQ(res->ColumnCount(), 2);
-  std::cout << "error: " << res->error << std::endl;  // YBRua: wrap this into an if?
 
   auto actual_batch = DuckDbResultConvertor::fetchDataToCiderBatch(res);
 

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -96,7 +96,7 @@ void checkDuckDbScalarOutput(
   /// Change this to CiderBatchChecker after Checker is implemented
 
   // expected data should at least contain something
-  EXPECT_TRUE(expected_data.size() > 0);
+  EXPECT_GT(expected_data.size(), 0);
   // currently only supports one CiderBatch
   EXPECT_EQ(actual_batches.size(), 1);
   auto actual_batch = actual_batches[0];
@@ -153,7 +153,7 @@ void checkDuckDbBooleanOutput(
     const std::vector<std::vector<bool>>& expected_valids = {}) {
   /// TODO: (YBRua) To be deprecated.
 
-  EXPECT_TRUE(expected_data.size() > 0);
+  EXPECT_GT(expected_data.size(), 0);
   EXPECT_EQ(actual_batches.size(), 1);
   auto actual_batch = actual_batches[0];
 
@@ -209,15 +209,15 @@ void checkDuckDbBooleanOutput(
     DuckDbQueryRunner runner;                                                           \
     auto [expected_data, expected_valids] = generateSequenceData<C_TYPE>();             \
                                                                                         \
-    /* CiderBatchBuilder expects a NULL vector                                          \
-     * but expected_valids is actually a VALID vector so we flip it here*/              \
+    /* CiderBatchBuilder expects a NULL vector */                                       \
+    /* but expected_valids is actually a VALID vector so we flip it here*/              \
     auto null_vecs = expected_valids;                                                   \
     std::for_each(null_vecs.begin(), null_vecs.end(), [](std::vector<bool>& null_vec) { \
       null_vec.flip();                                                                  \
     });                                                                                 \
                                                                                         \
-    /* TODO: (YBRua) The CiderBatch generated here is not in Arrow format               \
-     * Change it to an Arrow-formatted batch after CiderBatchBuilder is updated */      \
+    /* TODO: (YBRua) The CiderBatch generated here is not in Arrow format */            \
+    /* Change it to an Arrow-formatted batch after CiderBatchBuilder is updated */      \
     auto batch = std::make_shared<CiderBatch>(                                          \
         CiderBatchBuilder()                                                             \
             .setRowNum(10)                                                              \

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -37,6 +37,9 @@ void checkDuckDbScalarOutput(
     const std::vector<std::shared_ptr<CiderBatch>>& actual_batches,
     const std::vector<std::vector<T>>& expected_data,
     const std::vector<std::vector<bool>>& expected_nulls = {}) {
+  /// NOTE: (YBRua) To be deprecated.
+  /// Change this to CiderBatchChecker after Checker is implemented
+
   // expected data should at least contain something
   EXPECT_TRUE(expected_data.size() > 0);
   // currently only supports one CiderBatch
@@ -58,7 +61,7 @@ void checkDuckDbScalarOutput(
     // scalar (primitive type) result should contain 2 buffers
     EXPECT_EQ(child->getBufferNum(), 2);
     // check child row nums
-    EXPECT_EQ(child->getLength(), col.size());
+    EXPECT_EQ(child->getLength(), expected_data[i].size());
 
     auto data_buffer = child->as<ScalarBatch<int32_t>>()->getRawData();
     auto null_buffer = child->getNulls();
@@ -71,10 +74,6 @@ void checkDuckDbScalarOutput(
 }
 
 TEST(DuckDBResultConvertorTest, simpleArrowTest) {
-  // create table, insert data, run a simple query and manually check the result
-  /// TODO: (YBRua) Add more comprehensive and elegant tests
-  /// after CiderBatchBuilder and CiderBatchChecker are updated
-
   DuckDbQueryRunner runner;
 
   std::vector<int> col{0, 1, 2, 3, 4};

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -142,6 +142,30 @@ TEST(DuckDBResultConvertorTest, simpleI32ArrowTest) {
   ARROW_SIMPLE_TEST_SUITE(int32_t, I32, INTEGER);
 }
 
+TEST(DuckDBResultConvertorTest, simpleI8ArrowTest) {
+  ARROW_SIMPLE_TEST_SUITE(int8_t, I8, TINYINT);
+}
+
+TEST(DuckDBResultConvertorTest, simpleI16ArrowTest) {
+  ARROW_SIMPLE_TEST_SUITE(int16_t, I16, SMALLINT);
+}
+
+TEST(DuckDBResultConvertorTest, simpleI64ArrowTest) {
+  ARROW_SIMPLE_TEST_SUITE(int64_t, I64, BIGINT);
+}
+
+TEST(DuckDBResultConvertorTest, simpleFp32ArrowTest) {
+  ARROW_SIMPLE_TEST_SUITE(float, Fp32, FLOAT);
+}
+
+TEST(DuckDBResultConvertorTest, simpleI64ArrowTest) {
+  ARROW_SIMPLE_TEST_SUITE(double, Fp64, DOUBLE);
+}
+
+TEST(DuckDBResultConvertorTest, simpleBoolArrowTest) {
+  ARROW_SIMPLE_TEST_SUITE(bool, Bool, BOOLEAN);
+}
+
 TEST(DuckDBQueryRunnerTest, basicTest) {
   DuckDbQueryRunner runner;
 

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -85,7 +85,8 @@ TEST(DuckDBResultConvertorTest, simpleArrowTest) {
   std::string table_name = "table_test";
   std::string create_ddl = "CREATE TABLE table_test(col_a INTEGER, col_b INTEGER)";
 
-  runner.createTableAndInsertData(table_name, create_ddl, expected_data);
+  runner.createTableAndInsertData(
+      table_name, create_ddl, expected_data, false, expected_nulls);
 
   auto res = runner.runSql("select * from table_test;");
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updated `DuckDbResultConvertor` to support `ArrowArray` and `ArrowSchema`. Currently supports *primitive scalar types*.

1. In `DuckDbResultConvertor`: Added `fetchDataToArrowFormattedCiderBatch` method. The API use case is the same as the existing `fetchDataToCiderBatch`, but it returns `CiderBatch` instances that uses Arrow format as underlying memory layout.
2. In `DuckDbQueryRunnerTest.cpp`: Added simple handcrafted tests on new convertor API for primitive types (`int` / `float` / `double` / `bool`), along with util functions to run these tests. Newly added tests are put under `DuckDBResultConvertorTest`.
   - Unit tests here are subject to change. They will be updated when `CiderBatchChecker` are updated to support Arrow format.

### Why are the changes needed?

These changes are part of the changes needed to migrate unit test framework to Arrow Format.

Example use case of the API:

```cpp
/* check cider/tests/utils/DuckDbQueryRunnerTest.cpp for details */

/* create table and insert data into runner */
DuckDbQueryRunner runner;
// ...

auto res = runner.runSql("select * from table_test;");
// actual_batches will contain `CiderBatch`es with Arrow format support.
auto actual_batches =
        DuckDbResultConvertor::fetchDataToArrowFormattedCiderBatch(res);

```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Which label does this PR belong to?
<!-- 
If the label supposed to be bug, coderefactor or infra. Please use the UPPER case of these three words. For other labels: 
veloxIntegration, cider, documentation, CICD, test, benchmark, publicApi,  they are not need to be specified here. And try to ensure that the capitalization of the above three words does not appear in the PR as much as possible.
-->
