### PR TITLE
[POAE7-2408] Replace folly::split of function look up

### DIFF
--- a/cider/function/substrait/CMakeLists.txt
+++ b/cider/function/substrait/CMakeLists.txt
@@ -22,4 +22,4 @@ set(SRCS
     SubstraitFunction.cpp SubstraitExtension.cpp SubstraitFunctionLookup.cpp)
 
 add_library(substrait_function_look_up STATIC ${SRCS})
-target_link_libraries(substrait_function_look_up substrait yaml-cpp)
+target_link_libraries(substrait_function_look_up substrait yaml-cpp cider_util)

--- a/cider/function/substrait/SubstraitFunctionLookup.cpp
+++ b/cider/function/substrait/SubstraitFunctionLookup.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "function/substrait/SubstraitFunctionLookup.h"
-#include <folly/String.h>
 #include "function/substrait/SubstraitSignature.h"
 
 namespace cider::function::substrait {

--- a/cider/function/substrait/SubstraitSignature.cpp
+++ b/cider/function/substrait/SubstraitSignature.cpp
@@ -20,10 +20,8 @@
  */
 
 #include "function/substrait/SubstraitSignature.h"
-#include <folly/String.h>
 #include <sstream>
-
-using namespace folly;
+#include "util/StringTransform.h"
 
 namespace cider::function::substrait {
 
@@ -50,8 +48,7 @@ const std::string SubstraitFunctionSignature::signature(
     const SubstraitFunctionMappingsPtr& functionMappings) {
   // try to replace function name with function mappings
   if (functionMappings) {
-    std::vector<std::string> functionAndSignatures;
-    folly::split(":", functionSignature, functionAndSignatures);
+    std::vector<std::string> functionAndSignatures = split(functionSignature, ":");
     const auto& scalarMappings = functionMappings->scalarMappings();
     const auto& aggregateMappings = functionMappings->aggregateMappings();
     if (functionAndSignatures.size() == 2) {

--- a/cider/tests/utils/CiderQueryRunner.h
+++ b/cider/tests/utils/CiderQueryRunner.h
@@ -73,10 +73,6 @@ class CiderQueryRunner {
       std::shared_ptr<CiderCompilationResult> compile_res);
 
  private:
-  // for debug
-  bool print_substrait_ = false;
-  bool print_IR_ = false;
-
   CiderBatch updateCountDistinctRes(std::unique_ptr<CiderBatch> output_batch,
                                     std::shared_ptr<CiderCompilationResult> compile_res);
 };


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://wiki.ith.intel.com/display/MOIN/How+to+contribute#Howtocontribute-CodeDevelopment&Review
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][POAE7-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation MIP, please add the link. https://wiki.ith.intel.com/display/MOIN/MIP+template
  4. If there is a discussion in the mailing list, please add the link.
-->
folly is not used by debug model in function look up, that will cause compilation failure, fix that use cider util split replace folly:split

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
folly is not used by debug model in function look up, that will cause compilation failure, fix that use cider util split replace folly:split

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Uts

### Which label does this PR belong to?
<!-- 
If the label supposed to be bug, coderefactor or infra. Please use the UPPER case of these three words. For other labels: 
veloxIntegration, cider, documentation, CICD, test, benchmark, publicApi,  they are not need to be specified here. And try to ensure that the capitalization of the above three words does not appear in the PR as much as possible.
-->
BUG