### PR TITLE
[POAE7-2432] Fix Old CiderBatch Memory Allocation for Group-By Result Fetching

### DIFF
--- a/cider/exec/module/CiderRuntimeModule.cpp
+++ b/cider/exec/module/CiderRuntimeModule.cpp
@@ -618,7 +618,7 @@ CiderRuntimeModule::fetchResults(int32_t max_row) {
   auto schema = ciderCompilationResult_->getOutputCiderTableSchema();
   std::vector<size_t> column_size;
   column_size.reserve(column_num);
-  for (int column_index = 0, type_index = 0; column_index < column_num;
+  for (size_t column_index = 0, type_index = 0; column_index < column_num;
        column_index++, type_index++) {
     ColumnHint hint = schema->getColHints()[type_index];
     // FIXME: kStruct is not supported in old CiderBatch and CiderTableSchema

--- a/cider/exec/module/CiderRuntimeModule.cpp
+++ b/cider/exec/module/CiderRuntimeModule.cpp
@@ -614,16 +614,26 @@ CiderRuntimeModule::fetchResults(int32_t max_row) {
   }
 
   // for group_by_agg
-
-  // FIXME: some testcase(CiderAggHashTableTest) does not setup output table schema
-  // correctly.
-  // int column_num =
-  // ciderCompilationResult_->getOutputCiderTableSchema().getColumnCount();
   int column_num = ciderCompilationResult_->impl_->rel_alg_exe_unit_->target_exprs.size();
+  auto schema = ciderCompilationResult_->getOutputCiderTableSchema();
   std::vector<size_t> column_size;
-  for (int i = 0; i < column_num; i++) {
-    column_size.push_back(sizeof(int64_t));
+  column_size.reserve(column_num);
+  for (int column_index = 0, type_index = 0; column_index < column_num;
+       column_index++, type_index++) {
+    ColumnHint hint = schema.getColHints()[type_index];
+    // FIXME: kStruct is not supported in old CiderBatch and CiderTableSchema
+    if (hint == ColumnHint::Normal) {
+      column_size.push_back(schema.GetColumnTypeSize(type_index));
+    } else if (hint == ColumnHint::PartialAVG) {
+      // FIXME: Workaround for Partial AVG
+      column_size.push_back(sizeof(int64_t));
+      column_size.push_back(sizeof(int64_t));
+      ++column_index;
+    } else {
+      CIDER_THROW(CiderRuntimeException, "Unknow ColumnHint of output schema.");
+    }
   }
+
   // TODO: should we read all data or just some row by once?
   int32_t row_num = max_row > 0 ? max_row : kMaxOutputRows;
   std::unique_ptr<CiderBatch> groupby_agg_result;

--- a/cider/exec/module/CiderRuntimeModule.cpp
+++ b/cider/exec/module/CiderRuntimeModule.cpp
@@ -620,10 +620,10 @@ CiderRuntimeModule::fetchResults(int32_t max_row) {
   column_size.reserve(column_num);
   for (int column_index = 0, type_index = 0; column_index < column_num;
        column_index++, type_index++) {
-    ColumnHint hint = schema.getColHints()[type_index];
+    ColumnHint hint = schema->getColHints()[type_index];
     // FIXME: kStruct is not supported in old CiderBatch and CiderTableSchema
     if (hint == ColumnHint::Normal) {
-      column_size.push_back(schema.GetColumnTypeSize(type_index));
+      column_size.push_back(schema->GetColumnTypeSize(type_index));
     } else if (hint == ColumnHint::PartialAVG) {
       // FIXME: Workaround for Partial AVG
       column_size.push_back(sizeof(int64_t));

--- a/cider/tests/CiderLogTest.cpp
+++ b/cider/tests/CiderLogTest.cpp
@@ -33,7 +33,7 @@ TEST_F(CiderLogTest, log) {
   LOG(INFO) << "INFO log";
   LOG(WARNING) << "WARNING log";
   LOG(ERROR) << "ERROR log";
-  LOG(FATAL) << "FATAL log";
+  EXPECT_THROW({ LOG(FATAL) << "FATAL log"; }, CheckFatalException);
 }
 
 /*

--- a/cider/util/Logger.cpp
+++ b/cider/util/Logger.cpp
@@ -422,7 +422,7 @@ Logger::Logger(Severity severity)
   }
 }
 
-Logger::~Logger() {
+Logger::~Logger() noexcept(false) {
   if (stream_) {
     if (is_channel_) {
       get_channel_logger(static_cast<Channel>(enum_value_))

--- a/cider/util/Logger.h
+++ b/cider/util/Logger.h
@@ -172,7 +172,7 @@ class Logger {
   explicit Logger(Channel);
   explicit Logger(Severity);
   Logger(Logger&&) = default;
-  ~Logger();
+  ~Logger() noexcept(false);
   operator bool() const;
   // Must check operator bool() first before calling stream().
   boost::log::record_ostream& stream(char const* file, int line);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://wiki.ith.intel.com/display/MOIN/How+to+contribute#Howtocontribute-CodeDevelopment&Review
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][POAE7-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation MIP, please add the link. https://wiki.ith.intel.com/display/MOIN/MIP+template
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Previous memory allocation of output old CiderBatch doesn't follow the schema in CiderOutputTableSchema or CiderAggHashTable, which works fine when the size of item less than 8 bytes. However, the size of VarChar type recently supported is 16 bytes, it leads memory problems.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UTs and e2e test.

### Which label does this PR belong to?
<!-- 
If the label supposed to be bug, coderefactor or infra. Please use the UPPER case of these three words. For other labels: 
veloxIntegration, cider, documentation, CICD, test, benchmark, publicApi,  they are not need to be specified here. And try to ensure that the capitalization of the above three words does not appear in the PR as much as possible.
-->
BugFix

Pls take a review @harborn @winningsix 
