### PR TITLE
[POAE7-2308] Transformer support multi-source Cider plan

### DIFF
--- a/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
+++ b/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
@@ -58,16 +58,16 @@ std::shared_ptr<CiderPlanNode> CiderPlanUtil::toCiderPlanNode(
   auto newLeftSrc = PlanUtil::findInNodeAddrMap(newSrcMap, leftSrcBranchId, 0);
   auto newRightSrc = PlanUtil::findInNodeAddrMap(newSrcMap, rightSrcBranchId, 0);
   if (newLeftSrc.first && newRightSrc.first) {
-    auto ciderPlanNode = std::make_shared<CiderPlanNode>(
-        planSection.target.nodePtr->id(),
-        newLeftSrc.second,
-        newRightSrc.second,
-        planSection.target.nodePtr->outputType(),
-        *sPlan);
+    auto ciderPlanNode =
+        std::make_shared<CiderPlanNode>(planSection.target.nodePtr->id(),
+                                        newLeftSrc.second,
+                                        newRightSrc.second,
+                                        planSection.target.nodePtr->outputType(),
+                                        *sPlan);
     return ciderPlanNode;
   } else {
     VELOX_FAIL(
-          "Can't find source nodes in the src node list of multi source planSection.");
+        "Can't find source nodes in the source node list of multi source planSection.");
   }
 }
 

--- a/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
+++ b/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
@@ -54,11 +54,11 @@ std::shared_ptr<CiderPlanNode> CiderPlanUtil::toCiderPlanNode(
   int32_t srcBranchId = planSection.source.branchId;
   int32_t leftSrcBranchId = PlanBranches::getLeftSrcBranchId(srcBranchId);
   int32_t rightSrcBranchId = PlanBranches::getRightSrcBranchId(srcBranchId);
-  auto newSrcMap = PlanUtil::toNodeAddrMap(srcList);
-  auto newLeftSrc = PlanUtil::findInNodeAddrMap(newSrcMap, leftSrcBranchId, 0);
-  auto newRightSrc = PlanUtil::findInNodeAddrMap(newSrcMap, rightSrcBranchId, 0);
+  NodeAddrMapPtr newSrcMap = PlanUtil::toNodeAddrMap(srcList);
+  std::pair<bool, VeloxPlanNodePtr> newLeftSrc = PlanUtil::findInNodeAddrMap(newSrcMap, leftSrcBranchId, 0);
+  std::pair<bool, VeloxPlanNodePtr> newRightSrc = PlanUtil::findInNodeAddrMap(newSrcMap, rightSrcBranchId, 0);
   if (newLeftSrc.first && newRightSrc.first) {
-    auto ciderPlanNode =
+    std::shared_ptr<CiderPlanNode> ciderPlanNode =
         std::make_shared<CiderPlanNode>(planSection.target.nodePtr->id(),
                                         newLeftSrc.second,
                                         newRightSrc.second,

--- a/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
+++ b/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
@@ -55,8 +55,10 @@ std::shared_ptr<CiderPlanNode> CiderPlanUtil::toCiderPlanNode(
   int32_t leftSrcBranchId = PlanBranches::getLeftSrcBranchId(srcBranchId);
   int32_t rightSrcBranchId = PlanBranches::getRightSrcBranchId(srcBranchId);
   NodeAddrMapPtr newSrcMap = PlanUtil::toNodeAddrMap(srcList);
-  std::pair<bool, VeloxPlanNodePtr> newLeftSrc = PlanUtil::findInNodeAddrMap(newSrcMap, leftSrcBranchId, 0);
-  std::pair<bool, VeloxPlanNodePtr> newRightSrc = PlanUtil::findInNodeAddrMap(newSrcMap, rightSrcBranchId, 0);
+  std::pair<bool, VeloxPlanNodePtr> newLeftSrc =
+      PlanUtil::findInNodeAddrMap(newSrcMap, leftSrcBranchId, 0);
+  std::pair<bool, VeloxPlanNodePtr> newRightSrc =
+      PlanUtil::findInNodeAddrMap(newSrcMap, rightSrcBranchId, 0);
   if (newLeftSrc.first && newRightSrc.first) {
     std::shared_ptr<CiderPlanNode> ciderPlanNode =
         std::make_shared<CiderPlanNode>(planSection.target.nodePtr->id(),

--- a/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
+++ b/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
@@ -58,14 +58,16 @@ std::shared_ptr<CiderPlanNode> CiderPlanUtil::toCiderPlanNode(
   auto newLeftSrc = PlanUtil::findInNodeAddrMap(newSrcMap, leftSrcBranchId, 0);
   auto newRightSrc = PlanUtil::findInNodeAddrMap(newSrcMap, rightSrcBranchId, 0);
   if (newLeftSrc.first && newRightSrc.first) {
-    auto ciderPlanNode = std::make_shared<CiderPlanNode>(planSection.target.nodePtr->id(),
-                                                         newLeftSrc.second,
-                                                         newRightSrc.second
-                                                         planSection.target.nodePtr->outputType(),
-                                                         *sPlan);
+    auto ciderPlanNode = std::make_shared<CiderPlanNode>(
+        planSection.target.nodePtr->id(),
+        newLeftSrc.second,
+        newRightSrc.second,
+        planSection.target.nodePtr->outputType(),
+        *sPlan);
     return ciderPlanNode;
   } else {
-    return nullptr;
+    VELOX_FAIL(
+          "Can't find source nodes in the src node list of multi source planSection.");
   }
 }
 

--- a/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
+++ b/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
@@ -21,6 +21,8 @@
 
 #include "CiderPlanUtil.h"
 #include <memory>
+#include "planTransformer/PlanBranches.h"
+#include "planTransformer/PlanUtil.h"
 #include "substrait/plan.pb.h"
 
 namespace facebook::velox::plugin::plantransformer {
@@ -42,7 +44,29 @@ std::shared_ptr<CiderPlanNode> CiderPlanUtil::toCiderPlanNode(
 std::shared_ptr<CiderPlanNode> CiderPlanUtil::toCiderPlanNode(
     VeloxNodeAddrPlanSection& planSection,
     VeloxPlanNodeAddrList& srcList) {
-  VELOX_UNSUPPORTED("multi-source PlanSection rewrite is not supported for now.");
+  std::shared_ptr<VeloxPlanFragmentToSubstraitPlan> v2SPlanFragmentConvertor_ =
+      std::make_shared<VeloxPlanFragmentToSubstraitPlan>();
+
+  std::shared_ptr<::substrait::Plan> sPlan =
+      std::make_shared<::substrait::Plan>(v2SPlanFragmentConvertor_->toSubstraitPlan(
+          planSection.target.nodePtr, planSection.source.nodePtr));
+
+  int32_t srcBranchId = planSection.source.branchId;
+  int32_t leftSrcBranchId = PlanBranches::getLeftSrcBranchId(srcBranchId);
+  int32_t rightSrcBranchId = PlanBranches::getRightSrcBranchId(srcBranchId);
+  auto newSrcMap = PlanUtil::toNodeAddrMap(srcList);
+  auto newLeftSrc = PlanUtil::findInNodeAddrMap(newSrcMap, leftSrcBranchId, 0);
+  auto newRightSrc = PlanUtil::findInNodeAddrMap(newSrcMap, rightSrcBranchId, 0);
+  if (newLeftSrc.first && newRightSrc.first) {
+    auto ciderPlanNode = std::make_shared<CiderPlanNode>(planSection.target.nodePtr->id(),
+                                                         newLeftSrc.second,
+                                                         newRightSrc.second
+                                                         planSection.target.nodePtr->outputType(),
+                                                         *sPlan);
+    return ciderPlanNode;
+  } else {
+    return nullptr;
+  }
 }
 
 }  // namespace facebook::velox::plugin::plantransformer

--- a/cider-velox/src/planTransformer/PlanBranches.h
+++ b/cider-velox/src/planTransformer/PlanBranches.h
@@ -40,9 +40,9 @@ class PlanBranches {
   std::vector<int32_t> getSrcToRootBranchIds() { return srcToRootBranchIds_; }
   // branch Id start from 1.
   VeloxPlanBranch getBranch(int32_t branchId);
-  int32_t getParentBranchId(int32_t branchId);
-  int32_t getLeftSrcBranchId(int32_t branchId);
-  int32_t getRightSrcBranchId(int32_t branchId);
+  static int32_t getParentBranchId(int32_t branchId);
+  static int32_t getLeftSrcBranchId(int32_t branchId);
+  static int32_t getRightSrcBranchId(int32_t branchId);
   VeloxPlanNodeAddr getPlanNodeAddr(int32_t branchId, int32_t nodeId);
   VeloxPlanNodeAddr getBranchSrcNodeAddr(int32_t branchId);
   VeloxPlanNodeAddr moveToTarget(VeloxPlanNodeAddr& curNodeAddr);

--- a/cider-velox/src/planTransformer/PlanUtil.h
+++ b/cider-velox/src/planTransformer/PlanUtil.h
@@ -41,8 +41,6 @@ class PlanUtil {
                                                   VeloxPlanNodeAddrList& source);
   static VeloxPlanNodeAddrList getPlanNodeListForPlanSection(
       VeloxNodeAddrPlanSection& planSection);
-
- private:
   static NodeAddrMapPtr toNodeAddrMap(VeloxPlanNodeAddrList& nodeAddrList);
   static std::pair<bool, VeloxPlanNodePtr> findInNodeAddrMap(NodeAddrMapPtr map,
                                                              int32_t branchId,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change CiderPlanRewriter to support multi-source node rewriting.

### Why are the changes needed?
As V2S convertor Join support is done, change the CiderPlanRewriter to use the convertor and rewrite join pattern into  CiderPlanNode.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Will be tested as a part of Join-related tests.

### Which label does this PR belong to?
velox-plugin
