### PR TITLE
[POAE7-2455] Add a tool to dump substrait plan, llvm ir and llvm cfg

### DIFF
--- a/cider/exec/module/CiderOptions.cpp
+++ b/cider/exec/module/CiderOptions.cpp
@@ -37,7 +37,7 @@ DEFINE_bool(needs_error_check, false, "needs error check");
 // Execution Options
 DEFINE_bool(output_columnar_hint, false, "output columnar hint");
 DEFINE_bool(allow_multifrag, true, "allow multifrag");
-DEFINE_bool(just_explain, true, "just explain");
+DEFINE_uint32(just_explain, 0, "just explain. 1: func, 2: module");
 DEFINE_bool(allow_loop_joins, false, "allow loop joins");
 DEFINE_bool(jit_debug, true, "jit debug");
 DEFINE_bool(with_watchdog, false, "with watchdog");

--- a/cider/exec/template/CompilationOptions.h
+++ b/cider/exec/template/CompilationOptions.h
@@ -62,7 +62,7 @@ enum class ExecutorType { Native, Extern, TableFunctions };
 struct ExecutionOptions {
   bool output_columnar_hint;
   bool allow_multifrag;
-  bool just_explain;  // return the generated IR for the first step
+  uint32_t just_explain;  // return the generated IR for the first step
   bool allow_loop_joins;
   bool with_watchdog;  // Per work unit, not global.
   bool jit_debug;
@@ -82,7 +82,7 @@ struct ExecutionOptions {
   static ExecutionOptions defaults() {
     return ExecutionOptions{false,
                             true,
-                            false,
+                            0,
                             false,
                             true,
                             false,

--- a/cider/exec/template/NativeCodegen.cpp
+++ b/cider/exec/template/NativeCodegen.cpp
@@ -1723,8 +1723,10 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
           (cgen_state_->filter_func_ ? serialize_llvm_object(cgen_state_->filter_func_)
                                      : "");
 
+#ifndef NDEBUG
       llvm_ir += serialize_llvm_metadata_footnotes(query_func, cgen_state_.get());
-    } else if (eo.just_plain == EXPLAIN_MODULE) {
+#endif
+    } else if (eo.just_explain == EXPLAIN_MODULE) {
       llvm_ir = serialize_llvm_object(cgen_state_->module_);
     }
   }

--- a/cider/exec/template/NativeCodegen.cpp
+++ b/cider/exec/template/NativeCodegen.cpp
@@ -83,8 +83,10 @@ float g_fraction_code_cache_to_evict = 0.2;
 std::unique_ptr<llvm::Module> udf_cpu_module;
 std::unique_ptr<llvm::Module> rt_udf_cpu_module;
 
-namespace {
+constexpr uint32_t EXPLAIN_FUNC = 1;
+constexpr uint32_t EXPLAIN_MODULE = 2;
 
+namespace {
 void throw_parseIR_error(const llvm::SMDiagnostic& parse_error, std::string src = "") {
   std::string excname = "LLVM IR ParseError: ";
   llvm::raw_string_ostream ss(excname);
@@ -249,7 +251,8 @@ void optimize_ir(llvm::Function* query_func,
   pass_manager.add(llvm::createJumpThreadingPass());  // Thread jumps.
   pass_manager.add(llvm::createCFGSimplificationPass());
 
-  // remove load/stores in PHIs if instructions can be accessed directly post thread jumps
+  // remove load/stores in PHIs if instructions can be accessed directly post thread
+  // jumps
   pass_manager.add(llvm::createNewGVNPass());
 
   pass_manager.add(llvm::createDeadStoreEliminationPass());
@@ -1524,15 +1527,6 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
                                                        eo.output_columnar_hint,
                                                        co);
 
-  if (query_mem_desc->getQueryDescriptionType() ==
-          QueryDescriptionType::GroupByBaselineHash &&
-      !has_cardinality_estimation && !eo.just_explain) {
-    const auto col_range_info = group_by_and_aggregate.getColRangeInfo();
-    CIDER_THROW(CiderCompileException,
-                fmt::format("Cardinality Estimation Required : {}",
-                            col_range_info.max - col_range_info.min));
-  }
-
   const bool output_columnar = query_mem_desc->didOutputColumnar();
 
   // Read the module template and target either CPU
@@ -1708,8 +1702,7 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
 
   // Serialize the important LLVM IR functions to text for SQL EXPLAIN.
   std::string llvm_ir;
-  //  if (eo.just_explain) {
-  if (true) {  // we always want IR
+  if (eo.just_explain) {
     if (co.explain_type == ExecutorExplainType::Optimized) {
 #ifdef WITH_JIT_DEBUG
       CIDER_THROW(
@@ -1722,20 +1715,23 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
       optimize_ir(query_func, cgen_state_->module_, pass_manager, live_funcs, co);
 #endif  // WITH_JIT_DEBUG
     }
-    llvm_ir =
-        serialize_llvm_object(multifrag_query_func) + serialize_llvm_object(query_func) +
-        serialize_llvm_object(cgen_state_->row_func_) +
-        (cgen_state_->filter_func_ ? serialize_llvm_object(cgen_state_->filter_func_)
-                                   : "");
+    if (eo.just_explain == EXPLAIN_FUNC) {
+      llvm_ir =
+          serialize_llvm_object(multifrag_query_func) +
+          serialize_llvm_object(query_func) +
+          serialize_llvm_object(cgen_state_->row_func_) +
+          (cgen_state_->filter_func_ ? serialize_llvm_object(cgen_state_->filter_func_)
+                                     : "");
 
-#ifndef NDEBUG
-    llvm_ir += serialize_llvm_metadata_footnotes(query_func, cgen_state_.get());
-#endif
+      llvm_ir += serialize_llvm_metadata_footnotes(query_func, cgen_state_.get());
+    } else if (eo.just_plain == EXPLAIN_MODULE) {
+      llvm_ir = serialize_llvm_object(cgen_state_->module_);
+    }
   }
 
   LOG(IR) << "\n\n" << query_mem_desc->toString() << "\n";
-  LOG(DEBUG1) << "IR for the CPU: \n";
 #ifndef NDEBUG
+  LOG(DEBUG1) << "IR for the CPU: \n";
   LOG(DEBUG1) << serialize_llvm_object(query_func)
               << serialize_llvm_object(cgen_state_->row_func_)
               << (cgen_state_->filter_func_
@@ -1743,6 +1739,7 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
                       : "")
               << "\nEnd of IR";
 #else
+  LOG(IR) << "IR for the CPU: \n";
   LOG(IR) << serialize_llvm_object(cgen_state_->module_) << "\nEnd of IR";
 #endif
 

--- a/cider/include/cider/CiderOptions.h
+++ b/cider/include/cider/CiderOptions.h
@@ -40,7 +40,7 @@ DECLARE_bool(needs_error_check);
 
 DECLARE_bool(output_columnar_hint);
 DECLARE_bool(allow_multifrag);
-DECLARE_bool(just_explain);
+DECLARE_uint32(just_explain);
 DECLARE_bool(allow_loop_joins);
 DECLARE_bool(jit_debug);
 DECLARE_bool(with_watchdog);
@@ -88,7 +88,7 @@ struct CiderCompilationOption {
 struct CiderExecutionOption {
   bool output_columnar_hint;
   bool allow_multifrag;
-  bool just_explain;  // return the generated IR for the first step
+  uint32_t just_explain;  // return the generated IR for the first step
   bool allow_loop_joins;
   bool with_watchdog;  // Per work unit, not global.
   bool jit_debug;

--- a/cider/tests/CMakeLists.txt
+++ b/cider/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(CiderArrowBatchTest CiderArrowBatchTest.cpp)
 add_executable(CiderExceptionTest CiderExceptionTest.cpp)
 add_executable(CiderLogTest CiderLogTest.cpp)
 add_executable(CiderDateFunctionTest CiderDateFunctionTest.cpp)
+add_executable(Sql2IR Sql2IR.cpp)
 
 set(EXECUTE_TEST_LIBS
     cider
@@ -68,6 +69,7 @@ target_link_libraries(CiderArrowBatchTest ${EXECUTE_TEST_LIBS})
 target_link_libraries(CiderExceptionTest ${EXECUTE_TEST_LIBS})
 target_link_libraries(CiderDateFunctionTest ${EXECUTE_TEST_LIBS})
 target_link_libraries(CiderLogTest ${EXECUTE_TEST_LIBS})
+target_link_libraries(Sql2IR ${EXECUTE_TEST_LIBS})
 
 set(TEST_ARGS "--gtest_output=xml:../")
 add_test(CodeGeneratorTest CodeGeneratorTest ${TEST_ARGS})

--- a/cider/tests/Sql2IR.cpp
+++ b/cider/tests/Sql2IR.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <cstddef>
+#include <iostream>
+
+#include <google/protobuf/util/json_util.h>
+#include <boost/program_options.hpp>
+
+#include "cider/CiderAllocator.h"
+#include "cider/CiderCompileModule.h"
+#include "cider/CiderTableSchema.h"
+#include "cider/batch/CiderBatch.h"
+#include "substrait/plan.pb.h"
+#include "substrait/type.pb.h"
+#include "util/Logger.h"
+#include "utils/Utils.h"
+
+const substrait::Rel* findJoinRightNode(const substrait::Rel& rel_node) {
+  const substrait::Rel::RelTypeCase& rel_type = rel_node.rel_type_case();
+  switch (rel_type) {
+    case substrait::Rel::RelTypeCase::kJoin:
+      return &rel_node.join().right();
+    case substrait::Rel::RelTypeCase::kFilter:
+      return findJoinRightNode(rel_node.filter().input());
+    case substrait::Rel::RelTypeCase::kProject:
+      return findJoinRightNode(rel_node.project().input());
+    case substrait::Rel::RelTypeCase::kAggregate:
+      return findJoinRightNode(rel_node.aggregate().input());
+    default:
+      return nullptr;
+  }
+}
+
+const substrait::ReadRel* findReadNode(const substrait::Rel& rel_node) {
+  const substrait::Rel::RelTypeCase& rel_type = rel_node.rel_type_case();
+  switch (rel_type) {
+    case substrait::Rel::RelTypeCase::kRead:
+      return &rel_node.read();
+    case substrait::Rel::RelTypeCase::kFilter:
+      return findReadNode(rel_node.filter().input());
+    case substrait::Rel::RelTypeCase::kProject:
+      return findReadNode(rel_node.project().input());
+    case substrait::Rel::RelTypeCase::kAggregate:
+      return findReadNode(rel_node.aggregate().input());
+    default:
+      return nullptr;
+  }
+}
+
+void feedBuildTable(substrait::Plan& plan,
+                    std::shared_ptr<CiderCompileModule> cider_compile_module) {
+  substrait::Rel root = plan.relations(0).root().input();
+  const substrait::Rel* right_node = findJoinRightNode(root);
+  if (right_node == nullptr) {
+    return;
+  }
+  const substrait::ReadRel* read_node = findReadNode(*right_node);
+  auto& schema = read_node->base_schema();
+  size_t count = schema.names_size();
+
+  std::vector<std::string> col_names;
+  std::vector<::substrait::Type> col_types;
+  for (int i = 0; i < count; ++i) {
+    col_names.emplace_back(schema.names(i));
+    col_types.emplace_back(schema.struct_().types(i));
+  }
+
+  auto table_schema = std::make_shared<CiderTableSchema>(col_names, col_types);
+
+  cider_compile_module->feedBuildTable(CiderBatch(1, table_schema));
+}
+
+int main(int argc, char** argv) {
+  namespace po = boost::program_options;
+
+  // set option
+  std::string sql, create_ddl;
+  bool dump_plan = false;
+  po::options_description options("Logging");
+  options.add_options()("sql", po::value<std::string>(&sql)->default_value(sql), "sql");
+  options.add_options()("create-ddl",
+                        po::value<std::string>(&create_ddl)->default_value(create_ddl),
+                        "table create ddl");
+  options.add_options()("dump-plan",
+                        po::value<bool>(&dump_plan)->default_value(dump_plan),
+                        "dump substait plan");
+
+  // parse option
+  po::variables_map vm;
+  po::store(
+      po::command_line_parser(argc, argv).options(options).allow_unregistered().run(),
+      vm);
+  po::notify(vm);
+
+  // output substrait plan
+  std::string json = RunIsthmus::processSql(sql, create_ddl);
+  if (dump_plan) {
+    std::cout << "substrait plan:" << std::endl << json << std::endl;
+  }
+
+  ::substrait::Plan plan;
+  google::protobuf::util::JsonStringToMessage(json, &plan);
+
+  auto cider_compile_module =
+      CiderCompileModule::Make(std::make_shared<CiderDefaultAllocator>());
+
+  // build table
+  feedBuildTable(plan, cider_compile_module);
+
+  // compile
+  auto res = cider_compile_module->compile(plan);
+
+  // output IR
+  std::cout << res->getIR() << std::endl;
+  return 0;
+}

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -10,3 +10,4 @@ Developer Guide
     develop/CiderAllocator-use-guide
     develop/contributing
     develop/logger
+    develop/utils

--- a/docs/develop/utils.rst
+++ b/docs/develop/utils.rst
@@ -1,0 +1,25 @@
+======
+Utils
+======
+
+Sql2IR
+-----------------------------------
+
+This tool can dump substrait plan json, llvm ir and cfg from a SQL.
+
+How to use
+```````````
+Sql2IR is under cider/tests/ directory. follow the debugging guide, build all the test binary, and the Sql2IR tool is built.
+
+you can find the usage by::
+    
+    Sql2IR --help
+
+dump substrait plan from sql::
+    
+    Sql2IR --sql "select sum(a*b)  as res from A where a>10 and b<5" --create-ddl "create table A(a int, b int);"
+
+If you want dump the IR cfg, dump-ir-level should be set to 2::
+
+    Sql2IR --sql "select sum(a*b)  as res from A where a>10 and b<5" --create-ddl "create table A(a int, b int);" --dump-ir-level=2 --gen-cfg=true
+


### PR DESCRIPTION
### What changes were proposed in this pull request?
add a tool to dump substrait plan, llvm ir and llvm cfg

### Why are the changes needed?
the tool can help to understand code

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UTs

### Which label does this PR belong to?
INFRA
