### PR TITLE
[POAE7-2316] Convert vector<VectorPtr> to CiderBatch

### DIFF
--- a/cider-velox/src/CiderJoinBuild.cpp
+++ b/cider-velox/src/CiderJoinBuild.cpp
@@ -25,7 +25,7 @@
 
 namespace facebook::velox::plugin {
 
-void CiderJoinBridge::setData(std::vector<RowVectorPtr> data) {
+void CiderJoinBridge::setData(std::vector<VectorPtr> data) {
   std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -36,7 +36,7 @@ void CiderJoinBridge::setData(std::vector<RowVectorPtr> data) {
   notify(std::move(promises));
 }
 
-std::optional<std::vector<RowVectorPtr>> CiderJoinBridge::dataOrFuture(
+std::optional<std::vector<VectorPtr>> CiderJoinBridge::dataOrFuture(
     ContinueFuture* future) {
   std::lock_guard<std::mutex> l(mutex_);
   VELOX_CHECK(!cancelled_, "Getting data after the build side is aborted");

--- a/cider-velox/src/CiderJoinBuild.h
+++ b/cider-velox/src/CiderJoinBuild.h
@@ -31,12 +31,12 @@ namespace facebook::velox::plugin {
 // multi-threaded probe pipeline.
 class CiderJoinBridge : public exec::JoinBridge {
  public:
-  void setData(std::vector<RowVectorPtr> data);
+  void setData(std::vector<VectorPtr> data);
 
-  std::optional<std::vector<RowVectorPtr>> dataOrFuture(ContinueFuture* future);
+  std::optional<std::vector<VectorPtr>> dataOrFuture(ContinueFuture* future);
 
  private:
-  std::optional<std::vector<RowVectorPtr>> data_;
+  std::optional<std::vector<VectorPtr>> data_;
 };
 
 class CiderJoinBuild : public exec::Operator {
@@ -67,7 +67,7 @@ class CiderJoinBuild : public exec::Operator {
   // Drivers must be completed before making the hash table.
   ContinueFuture future_{ContinueFuture::makeEmpty()};
 
-  std::vector<RowVectorPtr> data_;
+  std::vector<VectorPtr> data_;
 };
 
 }  // namespace facebook::velox::plugin

--- a/cider-velox/src/CiderOperator.h
+++ b/cider-velox/src/CiderOperator.h
@@ -62,7 +62,7 @@ class CiderOperator : public exec::Operator {
   std::chrono::microseconds convertorInternalCounter;
 
   // these properties are used for join with w/o agg case
-  std::optional<std::vector<RowVectorPtr>> buildData_;
+  std::optional<std::vector<VectorPtr>> buildData_;
   bool buildSideEmpty_{false};
   bool buildTableFed_{false};
   bool finished_{false};

--- a/cider-velox/test/CiderOperatorJoinTest.cpp
+++ b/cider-velox/test/CiderOperatorJoinTest.cpp
@@ -65,12 +65,9 @@ class CiderOperatorJoinTest : public HiveConnectorTestBase {
   }
 
   void testJoin(int32_t numThreads,
-                int32_t leftSize,
-                int32_t rightSize,
+                const std::vector<RowVectorPtr>& leftBatch,
+                const std::vector<RowVectorPtr>& rightBatch,
                 const std::string& referenceQuery) {
-    auto leftBatch = {makeSimpleRowVector(leftSize)};
-    auto rightBatch = {makeSimpleRowVector(rightSize)};
-
     CursorParameters params;
     auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
 
@@ -100,7 +97,15 @@ class CiderOperatorJoinTest : public HiveConnectorTestBase {
 };
 
 TEST_F(CiderOperatorJoinTest, basic) {
-  testJoin(1, 10, 10, "SELECT t.c0, u.c0 FROM t JOIN u ON t.c0 = u.c0");
+  auto leftBatch = {makeSimpleRowVector(10)};
+  auto rightBatch = {makeSimpleRowVector(10)};
+  testJoin(1, leftBatch, rightBatch, "SELECT t.c0, u.c0 FROM t JOIN u ON t.c0 = u.c0");
+}
+
+TEST_F(CiderOperatorJoinTest, multiBuild) {
+  auto leftBatch = {makeSimpleRowVector(10)};
+  auto rightBatch = {makeSimpleRowVector(20), makeSimpleRowVector(30)};
+  testJoin(1, leftBatch, rightBatch, "SELECT t.c0, u.c0 FROM t JOIN u ON t.c0 = u.c0");
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
convert multi batches to a single RowVector then convert to CiderBatch for hash join build

### Why are the changes needed?
Remove previous hard code


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT

### Which label does this PR belong to?
veloxIntegration
