### PR TITLE
[POAE7-2415] codegen string using Arrow format

### DIFF
--- a/cider/exec/module/batch/CiderArrowBufferHolder.cpp
+++ b/cider/exec/module/batch/CiderArrowBufferHolder.cpp
@@ -46,8 +46,12 @@ CiderArrowArrayBufferHolder::CiderArrowArrayBufferHolder(
 
 CiderArrowArrayBufferHolder::~CiderArrowArrayBufferHolder() {
   for (size_t i = 0; i < buffers_.size(); ++i) {
-    relaseBuffer(i);
+    releaseBuffer(i);
   }
+}
+
+size_t CiderArrowArrayBufferHolder::getBufferSizeAt(size_t index) {
+  return buffers_bytes_[index];
 }
 
 void CiderArrowArrayBufferHolder::allocBuffer(size_t index, size_t bytes) {
@@ -61,7 +65,7 @@ void CiderArrowArrayBufferHolder::allocBuffer(size_t index, size_t bytes) {
   }
 }
 
-void CiderArrowArrayBufferHolder::relaseBuffer(size_t index) {
+void CiderArrowArrayBufferHolder::releaseBuffer(size_t index) {
   if (buffers_[index]) {
     allocator_->deallocate(reinterpret_cast<int8_t*>(buffers_[index]),
                            buffers_bytes_[index]);

--- a/cider/exec/module/batch/CiderArrowBufferHolder.h
+++ b/cider/exec/module/batch/CiderArrowBufferHolder.h
@@ -50,8 +50,10 @@ class CiderArrowArrayBufferHolder {
 
   ArrowArray* getDictPtr();
 
+  size_t getBufferSizeAt(size_t index);
+
  private:
-  void relaseBuffer(size_t index);
+  void releaseBuffer(size_t index);
 
   std::vector<void*> buffers_;
   std::vector<size_t> buffers_bytes_;  // Used for allocator.

--- a/cider/exec/module/batch/CiderBatch.cpp
+++ b/cider/exec/module/batch/CiderBatch.cpp
@@ -58,7 +58,9 @@ CiderBatch::CiderBatch(ArrowSchema* schema,
 
 CiderBatch::~CiderBatch() {
   releaseArrowEntries();
+#ifdef CIDER_BATCH_CIDER_IMPL
   destroy();  // TODO: Remove
+#endif
 }
 
 CiderBatch::CiderBatch(const CiderBatch& rh) {
@@ -95,8 +97,9 @@ CiderBatch::CiderBatch(CiderBatch&& rh) noexcept {
   rh.arrow_schema_ = nullptr;
   rh.ownership_ = false;
   rh.reallocate_ = false;
-
+#ifdef CIDER_BATCH_CIDER_IMPL
   moveFrom(&rh);  // TODO: Remove
+#endif
 }
 
 CiderBatch& CiderBatch::operator=(CiderBatch&& rh) noexcept {
@@ -115,8 +118,9 @@ CiderBatch& CiderBatch::operator=(CiderBatch&& rh) noexcept {
   rh.ownership_ = false;
   rh.reallocate_ = false;
 
+#ifdef CIDER_BATCH_CIDER_IMPL
   moveFrom(&rh);  // TODO: Remove
-
+#endif
   return *this;
 }
 
@@ -283,13 +287,8 @@ void CiderBatch::convertToArrowRepresentation() {
     arrow_array_->children[i] = new ArrowArray();
     arrow_array_->children[i]->length = row_num();
     arrow_array_->children[i]->n_children = 0;
-    arrow_array_->children[i]->buffers = (const void**)std::malloc(sizeof(void*) * 2);
-    // FIXME: fill actual null
     void* null_buf = std::malloc(row_num() / 8 + 1);
     std::memset(null_buf, 0xFF, row_num() / 8 + 1);
-    arrow_array_->children[i]->buffers[0] = null_buf;
-    arrow_array_->children[i]->buffers[1] = table_ptr_[i];
-    arrow_array_->children[i]->n_buffers = 2;
     arrow_array_->children[i]->private_data = nullptr;
     arrow_array_->children[i]->dictionary = nullptr;
     arrow_array_->children[i]->release = CiderBatchUtils::ciderEmptyArrowArrayReleaser;
@@ -300,6 +299,28 @@ void CiderBatch::convertToArrowRepresentation() {
     arrow_schema_->children[i]->n_children = 0;
     arrow_schema_->children[i]->children = nullptr;
     arrow_schema_->children[i]->release = CiderBatchUtils::ciderEmptyArrowSchemaReleaser;
+
+    // (Kunshang)To be removed. temp code to pass ut. CiderStringTest::CiderStringTestArrow
+    if (schema_->getColumnTypeById(i).has_varchar()) {
+      arrow_array_->children[i]->n_buffers = 3;
+      arrow_array_->children[i]->buffers = (const void**)std::malloc(sizeof(void*) * 3);
+      arrow_array_->children[i]->buffers[0] = null_buf;
+
+      arrow_schema_->children[i]->format = "";
+      // 10 string row 0-9
+      int32_t* offset_buf = new int[11]{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
+      char* data_buf(
+          "000000000011111111112222222222333333333344444444445555555555666666666677777777"
+          "7788888888889999999999");
+      arrow_array_->children[i]->buffers[1] = offset_buf;
+      arrow_array_->children[i]->buffers[2] = data_buf;
+    } else {
+      arrow_array_->children[i]->buffers = (const void**)std::malloc(sizeof(void*) * 2);
+      // FIXME: fill actual null
+      arrow_array_->children[i]->buffers[0] = null_buf;
+      arrow_array_->children[i]->buffers[1] = table_ptr_[i];
+      arrow_array_->children[i]->n_buffers = 2;
+    }
   }
 }
 

--- a/cider/exec/module/batch/CiderBatch.cpp
+++ b/cider/exec/module/batch/CiderBatch.cpp
@@ -300,7 +300,8 @@ void CiderBatch::convertToArrowRepresentation() {
     arrow_schema_->children[i]->children = nullptr;
     arrow_schema_->children[i]->release = CiderBatchUtils::ciderEmptyArrowSchemaReleaser;
 
-    // (Kunshang)To be removed. temp code to pass ut. CiderStringTest::CiderStringTestArrow
+    // (Kunshang)To be removed. temp code to pass ut.
+    // CiderStringTest::CiderStringTestArrow
     if (schema_->getColumnTypeById(i).has_varchar()) {
       arrow_array_->children[i]->n_buffers = 3;
       arrow_array_->children[i]->buffers = (const void**)std::malloc(sizeof(void*) * 3);

--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -187,6 +187,8 @@ SQLTypes convertArrowTypeToCiderType(const char* format) {
         case 's':
           return kSTRUCT;
       }
+    case 'u':
+      return kVARCHAR;
     default:
       CIDER_THROW(CiderCompileException,
                   std::string("Unsupported data type to CiderBatch: ") + format);

--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -154,6 +154,8 @@ int64_t getBufferNum(const ArrowSchema* schema) {
       if (!strcmp(type, "tdm")) {
         return 2;
       }
+    case 'u':
+      return 3;
     default:
       CIDER_THROW(CiderException,
                   std::string("Unsupported data type to CiderBatch: ") + type);
@@ -209,6 +211,8 @@ const char* convertCiderTypeToArrowType(SQLTypes type) {
       return "g";
     case kSTRUCT:
       return "+s";
+    case kVARCHAR:
+      return "u";
     default:
       CIDER_THROW(CiderCompileException,
                   std::string("Unsupported to convert type ") + toString(type) +
@@ -264,6 +268,8 @@ const char* convertSubstraitTypeToArrowType(const substrait::Type& type) {
       return "+s";
     case Type::kDate:
       return "tdm";
+    case Type::kVarchar:
+      return "u";
     default:
       CIDER_THROW(CiderRuntimeException,
                   std::string("Unsupported to convert type ") + type.GetTypeName() +
@@ -334,6 +340,8 @@ std::unique_ptr<CiderBatch> createCiderBatch(std::shared_ptr<CiderAllocator> all
       if (!strcmp(format, "tdm")) {
         return ScalarBatch<int64_t>::Create(schema, allocator, array);
       }
+    case 'u':
+      return ScalarBatch<CiderVarchar>::Create(schema, allocator, array);
     default:
       CIDER_THROW(CiderCompileException,
                   std::string("Unsupported data type to create CiderBatch: ") + format);

--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -343,7 +343,7 @@ std::unique_ptr<CiderBatch> createCiderBatch(std::shared_ptr<CiderAllocator> all
         return ScalarBatch<int64_t>::Create(schema, allocator, array);
       }
     case 'u':
-      return ScalarBatch<CiderVarchar>::Create(schema, allocator, array);
+      return VarcharBatch::Create(schema, allocator, array);
     default:
       CIDER_THROW(CiderCompileException,
                   std::string("Unsupported data type to create CiderBatch: ") + format);

--- a/cider/exec/plan/parser/TypeUtils.h
+++ b/cider/exec/plan/parser/TypeUtils.h
@@ -148,6 +148,10 @@ class TypeUtils {
         return getIsNullable(type.time().nullability());
       case substrait::Type::kTimestamp:
         return getIsNullable(type.timestamp().nullability());
+      case substrait::Type::kVarchar:
+          return getIsNullable(type.varchar().nullability());
+      case substrait::Type::kFixedChar:
+          return getIsNullable(type.fixed_char().nullability());
       default:
         return true;
     }

--- a/cider/exec/plan/parser/TypeUtils.h
+++ b/cider/exec/plan/parser/TypeUtils.h
@@ -149,9 +149,9 @@ class TypeUtils {
       case substrait::Type::kTimestamp:
         return getIsNullable(type.timestamp().nullability());
       case substrait::Type::kVarchar:
-          return getIsNullable(type.varchar().nullability());
+        return getIsNullable(type.varchar().nullability());
       case substrait::Type::kFixedChar:
-          return getIsNullable(type.fixed_char().nullability());
+        return getIsNullable(type.fixed_char().nullability());
       default:
         return true;
     }

--- a/cider/exec/template/CodeGenerator.h
+++ b/cider/exec/template/CodeGenerator.h
@@ -162,6 +162,12 @@ class CodeGenerator {
       CodegenColValues* rhs,
       llvm::Value* null);
 
+  std::unique_ptr<CodegenColValues> codegenVarcharCmpFun(
+      const Analyzer::BinOper* bin_oper,
+      CodegenColValues* lhs,
+      CodegenColValues* rhs,
+      llvm::Value* null);
+
   llvm::Value* codegenCmp(const SQLOps,
                           const SQLQualifier,
                           std::vector<llvm::Value*>,
@@ -321,6 +327,12 @@ class CodeGenerator {
       llvm::Value* pos_arg,
       const CompilationOptions& co);
 
+  std::unique_ptr<CodegenColValues> codegenVarCharColVar(
+      const Analyzer::ColumnVar* col_var,
+      llvm::Value* col_byte_stream,
+      llvm::Value* pos_arg,
+      const CompilationOptions& co);
+
   llvm::Value* codegenFixedLengthColVar(const Analyzer::ColumnVar* col_var,
                                         llvm::Value* col_byte_stream,
                                         llvm::Value* pos_arg);
@@ -335,6 +347,10 @@ class CodeGenerator {
                                      llvm::Value* pos_arg);
 
   std::vector<llvm::Value*> codegenVariableLengthStringColVar(
+      llvm::Value* col_byte_stream,
+      llvm::Value* pos_arg);
+
+  std::vector<llvm::Value*> codegenVariableLengthStringColVarArrow(
       llvm::Value* col_byte_stream,
       llvm::Value* pos_arg);
 

--- a/cider/exec/template/Codec.cpp
+++ b/cider/exec/template/Codec.cpp
@@ -296,3 +296,35 @@ std::vector<llvm::Instruction*> FixedWidthSmallDate::codegenDecode(
     return {llvm::CallInst::Create(f, args), nullptr};
   }
 }
+
+VarcharDecoder::VarcharDecoder(const size_t byte_width,
+                               llvm::IRBuilder<>* ir_builder,
+                               bool nullable)
+    : Decoder(ir_builder, nullable), byte_width_{byte_width} {}
+
+llvm::Instruction* VarcharDecoder::codegenDecode(llvm::Value* byte_stream,
+                                                 llvm::Value* pos,
+                                                 llvm::Module* module) const {
+  UNREACHABLE();
+}
+
+std::vector<llvm::Instruction*> VarcharDecoder::codegenDecode(llvm::Module* module,
+                                                              llvm::Value* byte_stream,
+                                                              llvm::Value* pos) const {
+  auto nulls = extractNullVector(module, byte_stream);
+  auto offset_buffer = extractBufferAt(module, byte_stream, 1);
+  auto data_buffer = extractBufferAt(module, byte_stream, 2);
+
+  llvm::Instruction* str_ptr = llvm::CallInst::Create(
+      module->getFunction("extract_str_ptr_arrow"), {data_buffer, offset_buffer, pos});
+  llvm::Instruction* str_len = llvm::CallInst::Create(
+      module->getFunction("extract_str_len_arrow"), {offset_buffer, pos});
+
+  if (nulls) {
+    auto get_is_null = module->getFunction("check_bit_vector_clear");
+    CHECK(get_is_null);
+    return {str_ptr, str_len, llvm::CallInst::Create(get_is_null, {nulls, pos})};
+  } else {
+    return {str_ptr, str_len};
+  }
+}

--- a/cider/exec/template/Codec.h
+++ b/cider/exec/template/Codec.h
@@ -161,4 +161,22 @@ class FixedWidthSmallDate : public Decoder {
   static constexpr int64_t ret_null_val_ = NULL_BIGINT;
 };
 
+class VarcharDecoder : public Decoder {
+ public:
+  VarcharDecoder(const size_t byte_width,
+                 llvm::IRBuilder<>* ir_builder,
+                 bool nullable = false);
+
+  llvm::Instruction* codegenDecode(llvm::Value* byte_stream,
+                                   llvm::Value* pos,
+                                   llvm::Module* module) const override;
+
+  std::vector<llvm::Instruction*> codegenDecode(llvm::Module* module,
+                                                llvm::Value* byte_stream,
+                                                llvm::Value* pos) const override;
+
+ private:
+  const size_t byte_width_;
+};
+
 #endif  // QUERYENGINE_CODEC_H

--- a/cider/exec/template/CodegenColValues.h
+++ b/cider/exec/template/CodegenColValues.h
@@ -87,4 +87,13 @@ class MultipleValueColValues : public NullableColValues {
   std::vector<llvm::Value*> values_;
 };
 
+class TwoValueColValues : public MultipleValueColValues {
+ public:
+  TwoValueColValues(llvm::Value* value1, llvm::Value* value2, llvm::Value* null = nullptr):
+      MultipleValueColValues({value1, value2}, null){}
+  std::unique_ptr<CodegenColValues> copy() const override {
+    return std::make_unique<TwoValueColValues>(*this);
+  }
+};
+
 #endif

--- a/cider/exec/template/CodegenColValues.h
+++ b/cider/exec/template/CodegenColValues.h
@@ -89,8 +89,8 @@ class MultipleValueColValues : public NullableColValues {
 
 class TwoValueColValues : public MultipleValueColValues {
  public:
-  TwoValueColValues(llvm::Value* value1, llvm::Value* value2, llvm::Value* null = nullptr):
-      MultipleValueColValues({value1, value2}, null){}
+  TwoValueColValues(llvm::Value* value1, llvm::Value* value2, llvm::Value* null = nullptr)
+      : MultipleValueColValues({value1, value2}, null) {}
   std::unique_ptr<CodegenColValues> copy() const override {
     return std::make_unique<TwoValueColValues>(*this);
   }

--- a/cider/exec/template/CodegenColValues.h
+++ b/cider/exec/template/CodegenColValues.h
@@ -72,4 +72,19 @@ class FixedSizeColValues : public NullableColValues {
   DEF_CODEGEN_COL_VALUES_MEMBER(Value, value_)
 };
 
+class MultipleValueColValues : public NullableColValues {
+ public:
+  MultipleValueColValues(std::vector<llvm::Value*> values, llvm::Value* null = nullptr)
+      : NullableColValues(null), values_(values) {}
+  std::unique_ptr<CodegenColValues> copy() const override {
+    return std::make_unique<MultipleValueColValues>(*this);
+  }
+  std::vector<llvm::Value*> getValues() { return values_; }
+  const std::vector<llvm::Value*> getValues() const { return values_; }
+  llvm::Value* getValueAt(int index) { return values_[index]; }
+
+ private:
+  std::vector<llvm::Value*> values_;
+};
+
 #endif

--- a/cider/exec/template/ColumnIR.cpp
+++ b/cider/exec/template/ColumnIR.cpp
@@ -253,7 +253,6 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenVarCharColVar(
   if (values.size() == 3) {
     null = values[2];
     values.pop_back();
-    cgen_state_->ir_builder_.Insert(null);
   }
   return std::make_unique<TwoValueColValues>(values[0], values[1], null);
 }

--- a/cider/exec/template/ColumnIR.cpp
+++ b/cider/exec/template/ColumnIR.cpp
@@ -169,7 +169,8 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenColumnExpr(
         break;
       }
     case kVARCHAR:
-      CIDER_THROW(CiderCompileException, "String type ColumnVar is not supported now.");
+      col_values = codegenVarCharColVar(col_var, input_col_descriptor_ptr, pos_arg, co);
+      break;
     case kARRAY:
       CIDER_THROW(CiderCompileException, "Array type ColumnVar is not supported now.");
     default:
@@ -232,6 +233,30 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenFixedLengthColVar(
   }
 
   return std::make_unique<FixedSizeColValues>(dec_val_cast, null);
+}
+
+std::unique_ptr<CodegenColValues> CodeGenerator::codegenVarCharColVar(
+    const Analyzer::ColumnVar* col_var,
+    llvm::Value* col_byte_stream,
+    llvm::Value* pos_arg,
+    const CompilationOptions& co) {
+  AUTOMATIC_IR_METADATA(cgen_state_);
+  const size_t size =8;
+  VarcharDecoder decoder(
+      size, &cgen_state_->ir_builder_, !col_var->get_type_info().get_notnull());
+  std::vector<llvm::Instruction*> values =
+      decoder.codegenDecode(cgen_state_->module_, col_byte_stream, pos_arg);
+  for(auto v: values) {
+    cgen_state_->ir_builder_.Insert(v);
+  }
+  llvm::Instruction* null = nullptr;
+  if (values.size() == 3) {
+    null = values[2];
+    values.pop_back();
+    cgen_state_->ir_builder_.Insert(null);
+  }
+  std::vector<llvm::Value*> vec(values.begin(), values.end());
+  return std::make_unique<MultipleValueColValues>(vec, null);
 }
 
 std::vector<llvm::Value*> CodeGenerator::codegenColVar(const Analyzer::ColumnVar* col_var,

--- a/cider/exec/template/ColumnIR.cpp
+++ b/cider/exec/template/ColumnIR.cpp
@@ -255,8 +255,7 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenVarCharColVar(
     values.pop_back();
     cgen_state_->ir_builder_.Insert(null);
   }
-  std::vector<llvm::Value*> vec(values.begin(), values.end());
-  return std::make_unique<MultipleValueColValues>(vec, null);
+  return std::make_unique<TwoValueColValues>(values[0], values[1], null);
 }
 
 std::vector<llvm::Value*> CodeGenerator::codegenColVar(const Analyzer::ColumnVar* col_var,

--- a/cider/exec/template/ColumnIR.cpp
+++ b/cider/exec/template/ColumnIR.cpp
@@ -241,12 +241,12 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenVarCharColVar(
     llvm::Value* pos_arg,
     const CompilationOptions& co) {
   AUTOMATIC_IR_METADATA(cgen_state_);
-  const size_t size =8;
+  const size_t size = 8;
   VarcharDecoder decoder(
       size, &cgen_state_->ir_builder_, !col_var->get_type_info().get_notnull());
   std::vector<llvm::Instruction*> values =
       decoder.codegenDecode(cgen_state_->module_, col_byte_stream, pos_arg);
-  for(auto v: values) {
+  for (auto v : values) {
     cgen_state_->ir_builder_.Insert(v);
   }
   llvm::Instruction* null = nullptr;

--- a/cider/exec/template/CompareIR.cpp
+++ b/cider/exec/template/CompareIR.cpp
@@ -347,12 +347,15 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenCmpFun(
   } else if (lhs_nullable || rhs_nullable) {
     null = lhs_nullable ? lhs_nullable->getNull() : rhs_nullable->getNull();
   }
-  if (lhs_ti.is_string()) {
-    CHECK(rhs_ti.is_string());
-    return codegenVarcharCmpFun(bin_oper, lhs_lv.get(), rhs_lv.get(), null);
-  }
 
-  return codegenFixedSizeColCmpFun(bin_oper, lhs_lv.get(), rhs_lv.get(), null);
+  switch (lhs_ti.get_type()) {
+    case kVARCHAR:
+    case kTEXT:
+    case kCHAR:
+      return codegenVarcharCmpFun(bin_oper, lhs_lv.get(), rhs_lv.get(), null);
+    default:
+      return codegenFixedSizeColCmpFun(bin_oper, lhs_lv.get(), rhs_lv.get(), null);
+  }
 }
 
 std::unique_ptr<CodegenColValues> CodeGenerator::codegenFixedSizeColCmpFun(

--- a/cider/exec/template/CompareIR.cpp
+++ b/cider/exec/template/CompareIR.cpp
@@ -340,7 +340,7 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenCmpFun(
   if (lhs_nullable && rhs_nullable) {
     if (lhs_nullable->getNull() && rhs_nullable->getNull()) {
       null = cgen_state_->ir_builder_.CreateOr(lhs_nullable->getNull(),
-                                                rhs_nullable->getNull());
+                                               rhs_nullable->getNull());
     } else {
       null = lhs_nullable->getNull() ? lhs_nullable->getNull() : rhs_nullable->getNull();
     }

--- a/cider/exec/template/CompareIR.cpp
+++ b/cider/exec/template/CompareIR.cpp
@@ -348,6 +348,7 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenCmpFun(
     null = lhs_nullable ? lhs_nullable->getNull() : rhs_nullable->getNull();
   }
   if (lhs_ti.is_string()) {
+    CHECK(rhs_ti.is_string());
     return codegenVarcharCmpFun(bin_oper, lhs_lv.get(), rhs_lv.get(), null);
   }
 
@@ -384,8 +385,10 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenVarcharCmpFun(
     CodegenColValues* rhs,
     llvm::Value* null) {
   AUTOMATIC_IR_METADATA(cgen_state_);
-  auto lhs_fixsize = dynamic_cast<MultipleValueColValues*>(lhs);
-  auto rhs_fixsize = dynamic_cast<MultipleValueColValues*>(rhs);
+  auto lhs_fixsize = dynamic_cast<TwoValueColValues*>(lhs);
+  CHECK(lhs_fixsize);
+  auto rhs_fixsize = dynamic_cast<TwoValueColValues*>(rhs);
+  CHECK(rhs_fixsize);
 
   llvm::Value* value = cgen_state_->emitCall("string_eq",
                                              {lhs_fixsize->getValueAt(0),

--- a/cider/exec/template/IRCodegen.cpp
+++ b/cider/exec/template/IRCodegen.cpp
@@ -235,9 +235,10 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenConstantExpr(
 
   switch (ti.get_type()) {
     case kVARCHAR:
-      constant_value.erase(constant_value.begin());
-      return std::make_unique<MultipleValueColValues>(
-          constant_value,
+      CHECK(constant_value.size() == 3);
+      return std::make_unique<TwoValueColValues>(
+          constant_value[1],
+          constant_value[2],
           constant_expr->get_is_null()
               ? llvm::ConstantInt::getTrue(cgen_state_->context_)
               : llvm::ConstantInt::getFalse(cgen_state_->context_));

--- a/cider/exec/template/IRCodegen.cpp
+++ b/cider/exec/template/IRCodegen.cpp
@@ -235,6 +235,12 @@ std::unique_ptr<CodegenColValues> CodeGenerator::codegenConstantExpr(
 
   switch (ti.get_type()) {
     case kVARCHAR:
+      constant_value.erase(constant_value.begin());
+      return std::make_unique<MultipleValueColValues>(
+          constant_value,
+          constant_expr->get_is_null()
+              ? llvm::ConstantInt::getTrue(cgen_state_->context_)
+              : llvm::ConstantInt::getFalse(cgen_state_->context_));
     case kARRAY:
       UNREACHABLE();
     default:

--- a/cider/exec/template/TargetExprBuilder.cpp
+++ b/cider/exec/template/TargetExprBuilder.cpp
@@ -58,11 +58,6 @@ std::vector<std::string> agg_fn_base_names(const TargetInfo& target_info,
     return {"agg_id_varlen"};
   }
   if (!target_info.is_agg || target_info.agg_kind == kSAMPLE) {
-    if (chosen_type.is_varlen()) {
-      // not a varlen projection (not creating new varlen outputs). Just store the pointer
-      // and offset into the input buffer in the output slots.
-      return {"agg_id", "agg_id"};
-    }
     return {"agg_id"};
   }
   switch (target_info.agg_kind) {

--- a/cider/exec/template/TargetExprBuilder.cpp
+++ b/cider/exec/template/TargetExprBuilder.cpp
@@ -150,7 +150,8 @@ void TargetExprCodegen::codegen(
   const auto arg_expr = agg_arg(target_expr);
 
   const bool varlen_projection = is_varlen_projection(target_expr, target_info.sql_type);
-  const auto agg_fn_names = agg_fn_base_names(target_info, varlen_projection, co.use_cider_data_format);
+  const auto agg_fn_names =
+      agg_fn_base_names(target_info, varlen_projection, co.use_cider_data_format);
   const auto window_func = dynamic_cast<const Analyzer::WindowFunction*>(target_expr);
   WindowProjectNodeContext::resetWindowFunctionContext(executor);
   auto target_lvs =
@@ -224,8 +225,10 @@ void TargetExprCodegen::codegenAggregate(
 
   auto& context = executor->getContext();
 
-  const auto agg_fn_names = agg_fn_base_names(
-      target_info, is_varlen_projection(target_expr, target_info.sql_type), co.use_cider_data_format);
+  const auto agg_fn_names =
+      agg_fn_base_names(target_info,
+                        is_varlen_projection(target_expr, target_info.sql_type),
+                        co.use_cider_data_format);
   auto arg_expr = agg_arg(target_expr);
 
   for (const auto& agg_base_name : agg_fn_names) {
@@ -299,7 +302,7 @@ void TargetExprCodegen::codegenAggregate(
         llvm::Value* project_arraies_i8 =
             LL_BUILDER.CreateIntToPtr(LL_BUILDER.CreateLoad(project_arraies_ptr, false),
                                       llvm::Type::getInt8PtrTy(context));
-        if(target_info.sql_type.is_string()) {
+        if (target_info.sql_type.is_string()) {
           // muset be a ProjectIDStringCodeGenerator
           generator->codegen(agg_input_data, project_arraies_i8, row_num);
         } else {
@@ -619,8 +622,10 @@ void TargetExprCodegenBuilder::operator()(const Analyzer::Expr* target_expr,
   target_exprs_to_codegen.emplace_back(
       target_expr, target_info, slot_index_counter, target_index_counter++, is_group_by);
 
-  const auto agg_fn_names = agg_fn_base_names(
-      target_info, is_varlen_projection(target_expr, target_info.sql_type), co.use_cider_data_format);
+  const auto agg_fn_names =
+      agg_fn_base_names(target_info,
+                        is_varlen_projection(target_expr, target_info.sql_type),
+                        co.use_cider_data_format);
   slot_index_counter += agg_fn_names.size();
 }
 

--- a/cider/exec/template/TargetExprBuilder.cpp
+++ b/cider/exec/template/TargetExprBuilder.cpp
@@ -51,13 +51,19 @@ inline bool is_varlen_projection(const Analyzer::Expr* target_expr,
 }
 
 std::vector<std::string> agg_fn_base_names(const TargetInfo& target_info,
-                                           const bool is_varlen_projection) {
+                                           const bool is_varlen_projection,
+                                           const bool use_arrow_format = false) {
   const auto& chosen_type = get_compact_type(target_info);
   if (is_varlen_projection) {
     UNREACHABLE();
     return {"agg_id_varlen"};
   }
   if (!target_info.is_agg || target_info.agg_kind == kSAMPLE) {
+    if (chosen_type.is_varlen() && !use_arrow_format) {
+      // not a varlen projection (not creating new varlen outputs). Just store the pointer
+      // and offset into the input buffer in the output slots.
+      return {"agg_id", "agg_id"};
+    }
     return {"agg_id"};
   }
   switch (target_info.agg_kind) {
@@ -144,7 +150,7 @@ void TargetExprCodegen::codegen(
   const auto arg_expr = agg_arg(target_expr);
 
   const bool varlen_projection = is_varlen_projection(target_expr, target_info.sql_type);
-  const auto agg_fn_names = agg_fn_base_names(target_info, varlen_projection);
+  const auto agg_fn_names = agg_fn_base_names(target_info, varlen_projection, co.use_cider_data_format);
   const auto window_func = dynamic_cast<const Analyzer::WindowFunction*>(target_expr);
   WindowProjectNodeContext::resetWindowFunctionContext(executor);
   auto target_lvs =
@@ -219,7 +225,7 @@ void TargetExprCodegen::codegenAggregate(
   auto& context = executor->getContext();
 
   const auto agg_fn_names = agg_fn_base_names(
-      target_info, is_varlen_projection(target_expr, target_info.sql_type));
+      target_info, is_varlen_projection(target_expr, target_info.sql_type), co.use_cider_data_format);
   auto arg_expr = agg_arg(target_expr);
 
   for (const auto& agg_base_name : agg_fn_names) {
@@ -293,16 +299,21 @@ void TargetExprCodegen::codegenAggregate(
         llvm::Value* project_arraies_i8 =
             LL_BUILDER.CreateIntToPtr(LL_BUILDER.CreateLoad(project_arraies_ptr, false),
                                       llvm::Type::getInt8PtrTy(context));
-        llvm::Value* col_data =
-            executor->cgen_state_->emitCall("cider_ColDecoder_extractArrowBuffersAt",
-                                            {project_arraies_i8, LL_INT((uint64_t)1)});
-        if (target_info.skip_null_val) {
-          llvm::Value* col_null =
-              executor->cgen_state_->emitCall("cider_ColDecoder_extractArrowBuffersAt",
-                                              {project_arraies_i8, LL_INT((uint64_t)0)});
-          generator->codegen(agg_input_data, col_data, row_num, col_null);
+        if(target_info.sql_type.is_string()) {
+          // muset be a ProjectIDStringCodeGenerator
+          generator->codegen(agg_input_data, project_arraies_i8, row_num);
         } else {
-          generator->codegen(agg_input_data, col_data, row_num);
+          llvm::Value* col_data =
+              executor->cgen_state_->emitCall("cider_ColDecoder_extractArrowBuffersAt",
+                                              {project_arraies_i8, LL_INT((uint64_t)1)});
+          if (target_info.skip_null_val) {
+            llvm::Value* col_null = executor->cgen_state_->emitCall(
+                "cider_ColDecoder_extractArrowBuffersAt",
+                {project_arraies_i8, LL_INT((uint64_t)0)});
+            generator->codegen(agg_input_data, col_data, row_num, col_null);
+          } else {
+            generator->codegen(agg_input_data, col_data, row_num);
+          }
         }
       } else {
         // Fetch output buffers.
@@ -609,7 +620,7 @@ void TargetExprCodegenBuilder::operator()(const Analyzer::Expr* target_expr,
       target_expr, target_info, slot_index_counter, target_index_counter++, is_group_by);
 
   const auto agg_fn_names = agg_fn_base_names(
-      target_info, is_varlen_projection(target_expr, target_info.sql_type));
+      target_info, is_varlen_projection(target_expr, target_info.sql_type), co.use_cider_data_format);
   slot_index_counter += agg_fn_names.size();
 }
 

--- a/cider/exec/template/operator/aggregate/CiderAggregateCodeGenerator.cpp
+++ b/cider/exec/template/operator/aggregate/CiderAggregateCodeGenerator.cpp
@@ -221,7 +221,7 @@ void ProjectIDStringCodeGenerator::codegen(CodegenColValues* input,
   AUTOMATIC_IR_METADATA(cgen_state_);
   CHECK(project_arraies_i8);
   CHECK(index);
-  MultipleValueColValues* args = dynamic_cast<MultipleValueColValues*>(input);
+  TwoValueColValues* args = dynamic_cast<TwoValueColValues*>(input);
   if (nullptr == args) {
     CIDER_THROW(CiderCompileException,
                 "ProjectIDStringCodeGenerator only support MultipleValueCol data now.");

--- a/cider/exec/template/operator/aggregate/CiderAggregateCodeGenerator.cpp
+++ b/cider/exec/template/operator/aggregate/CiderAggregateCodeGenerator.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<AggregateCodeGenerator> SimpleAggregateCodeGenerator::Make(
     }
   } else {
     CIDER_THROW(CiderCompileException,
-                "Unsuppored data type for SimpleAggregateCodeGenerator.");
+                "Unsupported data type for SimpleAggregateCodeGenerator.");
   }
 
   if (target_info.skip_null_val) {
@@ -160,7 +160,9 @@ std::unique_ptr<AggregateCodeGenerator> ProjectIDCodeGenerator::Make(
   CHECK(cgen_state);
   CHECK(base_fname == "agg_id");
 
-  auto generator = std::make_unique<ProjectIDCodeGenerator>();
+  auto generator = target_info.sql_type.is_string()
+                       ? std::make_unique<ProjectIDStringCodeGenerator>()
+                       : std::make_unique<ProjectIDCodeGenerator>();
 
   generator->base_fname_ = "cider_" + base_fname + "_proj";
   generator->target_info_ = target_info;
@@ -199,8 +201,10 @@ std::unique_ptr<AggregateCodeGenerator> ProjectIDCodeGenerator::Make(
     generator->base_fname_ += "_int64";
   } else if (target_info.sql_type.is_boolean()) {
     generator->base_fname_ += "_bool";
+  } else if (target_info.sql_type.is_string()) {
+    generator->base_fname_ += "_string";
   } else {
-    throw std::runtime_error("Unsuppored data type for ProjectIDCodeGenerator.");
+    throw std::runtime_error("Unsupported data type for ProjectIDCodeGenerator.");
   }
 
   if (target_info.skip_null_val) {
@@ -208,6 +212,36 @@ std::unique_ptr<AggregateCodeGenerator> ProjectIDCodeGenerator::Make(
   }
 
   return generator;
+}
+
+void ProjectIDStringCodeGenerator::codegen(CodegenColValues* input,
+                                           llvm::Value* output_buffer,
+                                           llvm::Value* index,
+                                           llvm::Value* output_null_buffer) const {
+  AUTOMATIC_IR_METADATA(cgen_state_);
+  CHECK(output_buffer);
+  CHECK(index);
+  MultipleValueColValues* args = dynamic_cast<MultipleValueColValues*>(input);
+  if (nullptr == args) {
+    CIDER_THROW(CiderCompileException,
+                "ProjectIDStringCodeGenerator only support MultipleValueCol data now.");
+  }
+  auto value_str_ptr = args->getValueAt(0), value_str_len = args->getValueAt(1),
+       is_null = args->getNull();
+  output_buffer = castToIntPtrTyIn(output_buffer, 8);
+  index = cgen_state_->castToTypeIn(index, 64);
+
+  std::vector<llvm::Value*> fun_args = {
+      output_buffer, index, value_str_ptr, value_str_len};
+  if (target_info_.skip_null_val) {
+    CHECK(output_null_buffer);
+    CHECK(is_null);
+    output_null_buffer = castToIntPtrTyIn(output_null_buffer, 8);
+    fun_args.push_back(output_null_buffer);
+    fun_args.push_back(is_null);
+  }
+  cgen_state_->emitCall(base_fname_, fun_args);
+  return;
 }
 
 std::unique_ptr<AggregateCodeGenerator> CountAggregateCodeGenerator::Make(

--- a/cider/exec/template/operator/aggregate/CiderAggregateCodeGenerator.h
+++ b/cider/exec/template/operator/aggregate/CiderAggregateCodeGenerator.h
@@ -69,6 +69,14 @@ class ProjectIDCodeGenerator : public SimpleAggregateCodeGenerator {
                                                       CgenState* cgen_state);
 };
 
+class ProjectIDStringCodeGenerator : public ProjectIDCodeGenerator {
+ public:
+  void codegen(CodegenColValues* input,
+               llvm::Value* output_buffer,
+               llvm::Value* index,
+               llvm::Value* output_null_buffer = nullptr) const override;
+};
+
 // Aggregate code generator for COUNT(*), COUNT(col), DISTINCT COUNT(col).
 class CountAggregateCodeGenerator : public AggregateCodeGenerator {
  public:

--- a/cider/function/aggregate/CiderRuntimeFunctions.h
+++ b/cider/function/aggregate/CiderRuntimeFunctions.h
@@ -108,14 +108,13 @@ ALWAYS_INLINE void cider_agg_id(T& agg_val, const T& val) {
   agg_val = val;
 }
 
-extern "C" ALWAYS_INLINE void cider_agg_id_proj_string_nullable(
-    int8_t* str_data_buffer,
-    int8_t* str_offset_buffer,
-    const uint64_t index,
-    int8_t* str_ptr,
-    const int32_t str_len,
-    uint8_t* agg_null_buffer,
-    bool is_null) {
+extern "C" ALWAYS_INLINE void cider_agg_id_proj_string_nullable(int8_t* str_data_buffer,
+                                                                int8_t* str_offset_buffer,
+                                                                const uint64_t index,
+                                                                int8_t* str_ptr,
+                                                                const int32_t str_len,
+                                                                uint8_t* agg_null_buffer,
+                                                                bool is_null) {
   if (is_null) {
     CiderBitUtils::clearBitAt(agg_null_buffer, index);
   } else {

--- a/cider/function/aggregate/CiderRuntimeFunctions.h
+++ b/cider/function/aggregate/CiderRuntimeFunctions.h
@@ -106,6 +106,31 @@ template <typename T>
 ALWAYS_INLINE void cider_agg_id(T& agg_val, const T& val) {
   agg_val = val;
 }
+
+extern "C" ALWAYS_INLINE void cider_agg_id_proj_string(int8_t* agg_val_buffer,
+                                                       const uint64_t index,
+                                                       const int8_t* str_ptr,
+                                                       const uint32_t str_len) {
+  int8_t* start_addr = agg_val_buffer + index * 16;
+  *(reinterpret_cast<int64_t*>(start_addr)) = reinterpret_cast<int64_t>(str_ptr);
+  *(reinterpret_cast<int32_t*>(start_addr + 8)) = str_len;
+}
+
+extern "C" ALWAYS_INLINE void cider_agg_id_proj_string_nullable(int8_t* agg_val_buffer,
+                                                                const uint64_t index,
+                                                                const int8_t* str_ptr,
+                                                                const uint32_t str_len,
+                                                                uint8_t* agg_null_buffer,
+                                                                bool is_null) {
+  if (is_null) {
+    CiderBitUtils::clearBitAt(agg_null_buffer, index);
+  } else {
+    int8_t* start_addr = agg_val_buffer + index * 16;
+    *(reinterpret_cast<int64_t*>(start_addr)) = reinterpret_cast<int64_t>(str_ptr);
+    *(reinterpret_cast<int32_t*>(start_addr + 8)) = str_len;
+  }
+}
+
 DEF_CIDER_SIMPLE_AGG_FUNCS(id, cider_agg_id)
 /********************************************************************************/
 

--- a/cider/function/aggregate/CiderRuntimeFunctions.h
+++ b/cider/function/aggregate/CiderRuntimeFunctions.h
@@ -108,6 +108,16 @@ ALWAYS_INLINE void cider_agg_id(T& agg_val, const T& val) {
   agg_val = val;
 }
 
+extern "C" ALWAYS_INLINE void cider_agg_id_proj_string(int8_t* str_data_buffer,
+                                                       int8_t* str_offset_buffer,
+                                                       const uint64_t index,
+                                                       int8_t* str_ptr,
+                                                       const int32_t str_len) {
+  int32_t current_offset = reinterpret_cast<int32_t*>(str_offset_buffer)[index];
+  reinterpret_cast<int32_t*>(str_offset_buffer)[index + 1] = current_offset + str_len;
+  memcpy(str_data_buffer + current_offset, str_ptr, str_len);
+}
+
 extern "C" ALWAYS_INLINE void cider_agg_id_proj_string_nullable(int8_t* str_data_buffer,
                                                                 int8_t* str_offset_buffer,
                                                                 const uint64_t index,
@@ -118,9 +128,7 @@ extern "C" ALWAYS_INLINE void cider_agg_id_proj_string_nullable(int8_t* str_data
   if (is_null) {
     CiderBitUtils::clearBitAt(agg_null_buffer, index);
   } else {
-    int32_t current_offset = reinterpret_cast<int32_t*>(str_offset_buffer)[index];
-    str_offset_buffer[index + 1] = current_offset + str_len;
-    memcpy(str_data_buffer + current_offset, str_ptr, str_len);
+    cider_agg_id_proj_string(str_data_buffer, str_offset_buffer, index, str_ptr, str_len);
   }
 }
 

--- a/cider/function/scalar/DecodersImpl.h
+++ b/cider/function/scalar/DecodersImpl.h
@@ -157,8 +157,9 @@ extern "C" ALWAYS_INLINE const uint8_t* cider_ColDecoder_extractArrowBuffersAt(
   return reinterpret_cast<const uint8_t*>(ptr->buffers[index]);
 }
 
-extern "C" ALWAYS_INLINE void reallocate_string_buffer_if_need(const int8_t* input_desc_ptr,
-                                                const int64_t pos) {
+extern "C" ALWAYS_INLINE void reallocate_string_buffer_if_need(
+    const int8_t* input_desc_ptr,
+    const int64_t pos) {
   // assumption: this arrow array is already initialized outside(it has 3 buffers, length
   // is set)
   const ArrowArray* ptr = reinterpret_cast<const ArrowArray*>(input_desc_ptr);

--- a/cider/function/scalar/DecodersImpl.h
+++ b/cider/function/scalar/DecodersImpl.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include "exec/module/batch/ArrowABI.h"
+#include "exec/module/batch/CiderArrowBufferHolder.h"
 #include "type/data/funcannotations.h"
 
 extern "C" ALWAYS_INLINE int64_t SUFFIX(fixed_width_int_decode)(const int8_t* byte_stream,
@@ -156,4 +157,20 @@ extern "C" ALWAYS_INLINE const uint8_t* cider_ColDecoder_extractArrowBuffersAt(
   return reinterpret_cast<const uint8_t*>(ptr->buffers[index]);
 }
 
+extern "C" ALWAYS_INLINE void reallocate_string_buffer_if_need(const int8_t* input_desc_ptr,
+                                                const int64_t pos) {
+  // assumption: this arrow array is already initialized outside(it has 3 buffers, length
+  // is set)
+  const ArrowArray* ptr = reinterpret_cast<const ArrowArray*>(input_desc_ptr);
+  CiderArrowArrayBufferHolder* holder =
+      reinterpret_cast<CiderArrowArrayBufferHolder*>(ptr->private_data);
+  int32_t* offset_buffer = (int32_t*)ptr->buffers[1];
+  size_t capacity = holder->getBufferSizeAt(2);
+  if (capacity == 0) {
+    holder->allocBuffer(2, 4096);
+  } else if (offset_buffer[pos] >
+             capacity * 0.8) {  // do reallocate when reach 90% of capacity
+    holder->allocBuffer(2, capacity * 2);
+  }
+}
 #endif  // CIDER_FUNCTION_DECODERSIMPL_H

--- a/cider/function/scalar/DecodersImpl.h
+++ b/cider/function/scalar/DecodersImpl.h
@@ -170,7 +170,7 @@ extern "C" ALWAYS_INLINE void reallocate_string_buffer_if_need(
   if (capacity == 0) {
     holder->allocBuffer(2, 4096);
   } else if (offset_buffer[pos] >
-             capacity * 0.8) {  // do reallocate when reach 90% of capacity
+             capacity * 0.9) {  // do reallocate when reach 90% of capacity
     holder->allocBuffer(2, capacity * 2);
   }
 }

--- a/cider/function/scalar/RuntimeFunctions.cpp
+++ b/cider/function/scalar/RuntimeFunctions.cpp
@@ -1437,14 +1437,13 @@ extern "C" ALWAYS_INLINE void clear_bit_vector(uint8_t* bit_vector, uint64_t ind
 extern "C" ALWAYS_INLINE int8_t* extract_str_ptr_arrow(int8_t* data_buffer,
                                                        int8_t* offset_buffer,
                                                        uint64_t pos) {
-  return reinterpret_cast<int8_t*>(data_buffer +
-                                   reinterpret_cast<int32_t*>(offset_buffer)[pos]);
+  return (data_buffer + reinterpret_cast<int32_t*>(offset_buffer)[pos]);
 }
 
 extern "C" ALWAYS_INLINE int32_t extract_str_len_arrow(int8_t* offset_buffer,
                                                        uint64_t pos) {
-  return reinterpret_cast<int32_t*>(offset_buffer)[pos + 1] -
-         reinterpret_cast<int32_t*>(offset_buffer)[pos];
+  int32_t* offset = reinterpret_cast<int32_t*>(offset_buffer);
+  return offset[pos+1] - offset[pos];
 }
 
 #include "function/aggregate/CiderRuntimeFunctions.h"

--- a/cider/function/scalar/RuntimeFunctions.cpp
+++ b/cider/function/scalar/RuntimeFunctions.cpp
@@ -1443,7 +1443,7 @@ extern "C" ALWAYS_INLINE int8_t* extract_str_ptr_arrow(int8_t* data_buffer,
 extern "C" ALWAYS_INLINE int32_t extract_str_len_arrow(int8_t* offset_buffer,
                                                        uint64_t pos) {
   int32_t* offset = reinterpret_cast<int32_t*>(offset_buffer);
-  return offset[pos+1] - offset[pos];
+  return offset[pos + 1] - offset[pos];
 }
 
 #include "function/aggregate/CiderRuntimeFunctions.h"

--- a/cider/function/scalar/RuntimeFunctions.cpp
+++ b/cider/function/scalar/RuntimeFunctions.cpp
@@ -1434,4 +1434,17 @@ extern "C" ALWAYS_INLINE void clear_bit_vector(uint8_t* bit_vector, uint64_t ind
   CiderBitUtils::clearBitAt(bit_vector, index);
 }
 
+extern "C" ALWAYS_INLINE int8_t* extract_str_ptr_arrow(int8_t* data_buffer,
+                                                       int8_t* offset_buffer,
+                                                       uint64_t pos) {
+  return reinterpret_cast<int8_t*>(data_buffer +
+                                   reinterpret_cast<int32_t*>(offset_buffer)[pos]);
+}
+
+extern "C" ALWAYS_INLINE int32_t extract_str_len_arrow(int8_t* offset_buffer,
+                                                       uint64_t pos) {
+  return reinterpret_cast<int32_t*>(offset_buffer)[pos + 1] -
+         reinterpret_cast<int32_t*>(offset_buffer)[pos];
+}
+
 #include "function/aggregate/CiderRuntimeFunctions.h"

--- a/cider/include/cider/batch/CiderBatch.h
+++ b/cider/include/cider/batch/CiderBatch.h
@@ -30,9 +30,13 @@
 #include "exec/module/batch/CiderArrowBufferHolder.h"
 #include "util/CiderBitUtils.h"
 
+#define CIDER_BATCH_ARROW_IMPL
+#define CIDER_BATCH_CIDER_IMPL
+
 /// \class CiderBatch
 /// \brief This class will be data/table format interface/protocol
 class CiderBatch {
+#ifdef CIDER_BATCH_ARROW_IMPL
  public:
   // Both constructors will take over the ownership of ArrowSchema & ArrowArray and
   // buffers they hold, so ArrowSchema and ArrowArray should allocated from
@@ -89,7 +93,7 @@ class CiderBatch {
   }
 
   // TODO: Change to pure virtual function.
-  // CiderBatch dosen't contain null vector by default until getMutableNulls is called.
+  // CiderBatch doesn't contain null vector by default until getMutableNulls is called.
   bool resizeBatch(int64_t size, bool default_not_null = false);
 
   // This function has a side effect that the null vector will be allocated if there is no
@@ -141,7 +145,9 @@ class CiderBatch {
   bool ownership_{false};  // Whether need to release the tree of schema_ and array_.
   bool reallocate_{
       false};  // Whether permitted to (re-)allocate memory to buffers of array_.
+#endif
 
+#ifdef CIDER_BATCH_CIDER_IMPL
  public:
   /// \brief Constructs CiderBatch that will use row memory layout with self memory
   /// manager. It will allocate row_num * row_size memory internally and the allocated
@@ -483,6 +489,7 @@ class CiderBatch {
     align_ = other->align_;
     null_vecs_ = other->null_vecs_;
   }
+#endif
 };
 
 #endif  // CIDER_CIDERBATCH_H

--- a/cider/include/cider/batch/ScalarBatch.h
+++ b/cider/include/cider/batch/ScalarBatch.h
@@ -26,8 +26,6 @@
 
 #include "CiderBatch.h"
 
-struct CiderVarchar {};
-
 template <typename T>
 class ScalarBatch final : public CiderBatch {
  public:
@@ -87,24 +85,22 @@ class ScalarBatch final : public CiderBatch {
   }
 };
 
-template <>
-class ScalarBatch<CiderVarchar> final : public CiderBatch {
+class VarcharBatch final : public CiderBatch {
  public:
-  static std::unique_ptr<ScalarBatch<CiderVarchar>> Create(
-      ArrowSchema* schema,
-      std::shared_ptr<CiderAllocator> allocator,
-      ArrowArray* array = nullptr) {
-    return array ? std::make_unique<ScalarBatch<CiderVarchar>>(schema, array, allocator)
-                 : std::make_unique<ScalarBatch<CiderVarchar>>(schema, allocator);
+  static std::unique_ptr<VarcharBatch> Create(ArrowSchema* schema,
+                                              std::shared_ptr<CiderAllocator> allocator,
+                                              ArrowArray* array = nullptr) {
+    return array ? std::make_unique<VarcharBatch>(schema, array, allocator)
+                 : std::make_unique<VarcharBatch>(schema, allocator);
   }
 
-  explicit ScalarBatch(ArrowSchema* schema, std::shared_ptr<CiderAllocator> allocator)
+  explicit VarcharBatch(ArrowSchema* schema, std::shared_ptr<CiderAllocator> allocator)
       : CiderBatch(schema, allocator) {
     checkArrowEntries();
   }
-  explicit ScalarBatch(ArrowSchema* schema,
-                       ArrowArray* array,
-                       std::shared_ptr<CiderAllocator> allocator)
+  explicit VarcharBatch(ArrowSchema* schema,
+                        ArrowArray* array,
+                        std::shared_ptr<CiderAllocator> allocator)
       : CiderBatch(schema, array, allocator) {
     checkArrowEntries();
   }

--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -26,7 +26,7 @@ class CiderStringTest : public CiderTestBase {
  public:
   CiderStringTest() {
     table_name_ = "test";
-    create_ddl_ = R"(CREATE TABLE test(col_1 INTEGER, col_2 VARCHAR(10));)";
+    create_ddl_ = R"(CREATE TABLE test(col_1 INTEGER NOT NULL, col_2 VARCHAR(10) NOT NULL);)";
     input_ = {std::make_shared<CiderBatch>(QueryDataGenerator::generateBatchByTypes(
         10,
         {"col_1", "col_2"},
@@ -247,13 +247,26 @@ LIKE_STRING_TEST_UNIT(CiderNullableStringTest, likeNullableStringTest)
 ESCAPE_STRING_TEST_UNIT(CiderNullableStringTest, escapeNullableStringTest)
 IN_STRING_TEST_UNIT(CiderNullableStringTest, inNullableStringTest)
 
-TEST_F(CiderStringTest, ArrowBasicStringTest) {
-  prepareArrowBatch();
-  //  assertQueryArrow("SELECT col_1 FROM test ");
-  //  assertQueryArrow("SELECT col_2 FROM test ");
-  //  assertQueryArrow("SELECT col_1, col_2 FROM test ");
+class CiderStringTestArrow : public CiderTestBase {
+ public:
+  CiderStringTestArrow() {
+    table_name_ = "test";
+    create_ddl_ =
+        R"(CREATE TABLE test(col_1 INTEGER NOT NULL, col_2 VARCHAR(10) NOT NULL);)";
 
-  assertQueryArrow("SELECT col_1 FROM test where col_2 = 'aaaa'");
+    input_ = {std::make_shared<CiderBatch>(QueryDataGenerator::generateBatchByTypes(
+        10,
+        {"col_1", "col_2"},
+        {CREATE_SUBSTRAIT_TYPE(I32), CREATE_SUBSTRAIT_TYPE(Varchar)}))};
+  }
+};
+
+TEST_F(CiderStringTestArrow, ArrowBasicStringTest) {
+  prepareArrowBatch();
+  assertQueryArrow("SELECT col_1 FROM test ");
+  assertQueryArrow("SELECT col_2 FROM test ");
+  assertQueryArrow("SELECT col_1, col_2 FROM test ");
+  assertQueryArrow("SELECT col_2 FROM test where col_2 = '0000000000'");
 }
 
 class CiderConstantStringTest : public CiderTestBase {

--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -247,6 +247,15 @@ LIKE_STRING_TEST_UNIT(CiderNullableStringTest, likeNullableStringTest)
 ESCAPE_STRING_TEST_UNIT(CiderNullableStringTest, escapeNullableStringTest)
 IN_STRING_TEST_UNIT(CiderNullableStringTest, inNullableStringTest)
 
+TEST_F(CiderStringTest, ArrowBasicStringTest) {
+  prepareArrowBatch();
+//  assertQueryArrow("SELECT col_1 FROM test ");
+//  assertQueryArrow("SELECT col_2 FROM test ");
+//  assertQueryArrow("SELECT col_1, col_2 FROM test ");
+
+    assertQueryArrow("SELECT col_1 FROM test where col_2 = 'aaaa'");
+}
+
 class CiderConstantStringTest : public CiderTestBase {
  public:
   CiderConstantStringTest() {

--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -249,11 +249,11 @@ IN_STRING_TEST_UNIT(CiderNullableStringTest, inNullableStringTest)
 
 TEST_F(CiderStringTest, ArrowBasicStringTest) {
   prepareArrowBatch();
-//  assertQueryArrow("SELECT col_1 FROM test ");
-//  assertQueryArrow("SELECT col_2 FROM test ");
-//  assertQueryArrow("SELECT col_1, col_2 FROM test ");
+  //  assertQueryArrow("SELECT col_1 FROM test ");
+  //  assertQueryArrow("SELECT col_2 FROM test ");
+  //  assertQueryArrow("SELECT col_1, col_2 FROM test ");
 
-    assertQueryArrow("SELECT col_1 FROM test where col_2 = 'aaaa'");
+  assertQueryArrow("SELECT col_1 FROM test where col_2 = 'aaaa'");
 }
 
 class CiderConstantStringTest : public CiderTestBase {

--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -26,7 +26,8 @@ class CiderStringTest : public CiderTestBase {
  public:
   CiderStringTest() {
     table_name_ = "test";
-    create_ddl_ = R"(CREATE TABLE test(col_1 INTEGER NOT NULL, col_2 VARCHAR(10) NOT NULL);)";
+    create_ddl_ =
+        R"(CREATE TABLE test(col_1 INTEGER NOT NULL, col_2 VARCHAR(10) NOT NULL);)";
     input_ = {std::make_shared<CiderBatch>(QueryDataGenerator::generateBatchByTypes(
         10,
         {"col_1", "col_2"},

--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -264,10 +264,10 @@ class CiderStringTestArrow : public CiderTestBase {
 
 TEST_F(CiderStringTestArrow, ArrowBasicStringTest) {
   prepareArrowBatch();
-  assertQueryArrow("SELECT col_1 FROM test ");
-  assertQueryArrow("SELECT col_2 FROM test ");
-  assertQueryArrow("SELECT col_1, col_2 FROM test ");
-  assertQueryArrow("SELECT col_2 FROM test where col_2 = '0000000000'");
+  assertQueryArrowTemp("SELECT col_1 FROM test ");
+  assertQueryArrowTemp("SELECT col_2 FROM test ");
+  assertQueryArrowTemp("SELECT col_1, col_2 FROM test ");
+  assertQueryArrowTemp("SELECT col_2 FROM test where col_2 = '0000000000'");
 }
 
 class CiderConstantStringTest : public CiderTestBase {

--- a/cider/tests/utils/CiderTestBase.cpp
+++ b/cider/tests/utils/CiderTestBase.cpp
@@ -59,6 +59,17 @@ void CiderTestBase::assertQueryArrow(const std::string& sql,
   EXPECT_TRUE(CiderBatchChecker::checkArrowEq(duck_res_batch, cider_res_batch, false));
 }
 
+void CiderTestBase::assertQueryArrowTemp(const std::string& sql,
+                                         const std::string& json_file) {
+  auto duck_res = duckDbQueryRunner_.runSql(sql);
+  auto duck_res_batch = DuckDbResultConvertor::fetchDataToCiderBatch(duck_res);
+
+  auto cider_input = json_file.size() ? json_file : sql;
+  auto cider_res_batch = std::make_shared<CiderBatch>(
+      ciderQueryRunner_.runQueryOneBatch(cider_input, input_[0], true));
+  EXPECT_TRUE(CiderBatchChecker::checkArrowEqTemp(duck_res_batch, cider_res_batch));
+}
+
 void CiderTestBase::assertQueryArrowIgnoreOrder(const std::string& sql,
                                                 const std::string& json_file) {
   auto duck_res = duckDbQueryRunner_.runSql(sql);

--- a/cider/tests/utils/CiderTestBase.h
+++ b/cider/tests/utils/CiderTestBase.h
@@ -55,6 +55,9 @@ class CiderTestBase : public testing::Test {
   void assertQueryArrow(const std::string& sql, const std::string& json_file = "");
   void assertQueryArrowIgnoreOrder(const std::string& sql,
                                    const std::string& json_file = "");
+  // To be deprecated. for string and other unsupported types.
+  void assertQueryArrowTemp(const std::string& sql, const std::string& json_file = "");
+
   // a method for test count distinct with multi batch case
   void assertQueryForCountDistinct(
       const std::string& sql,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://wiki.ith.intel.com/display/MOIN/How+to+contribute#Howtocontribute-CodeDevelopment&Review
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][POAE7-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation MIP, please add the link. https://wiki.ith.intel.com/display/MOIN/MIP+template
  4. If there is a discussion in the mailing list, please add the link.
-->
1. define and impl ScalarBatch<CiderVarchar>
2. impl string project/ cmp function with arrow data format, could pass simple uts.
3. fix some typos.
todo:
1. migrate to arrow based test framework when utils ready. (string builder, duck convertor).
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  4. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT.
### Which label does this PR belong to?
<!-- 
If the label supposed to be bug, coderefactor or infra. Please use the UPPER case of these three words. For other labels: 
veloxIntegration, cider, documentation, CICD, test, benchmark, publicApi,  they are not need to be specified here. And try to ensure that the capitalization of the above three words does not appear in the PR as much as possible.
-->

generated IR (row function part)
project string column:
```
; Function Attrs: alwaysinline
define i32 @row_func(i64* %group_by_buff, i64* %varlen_output_buff, i32* %crt_matched, i32* %total_matched, i32* %old_total_matched, i32 %max_matched, i64* %agg_init_val, i64 %pos, i64* %frag_row_off, i64* %num_rows_per_scan, i8* %literals, i8* %col_buf0, i8* %col_buf1, i64* %join_hash_tables) #25 {
entry:
  br i1 true, label %filter_true, label %filter_false

filter_true:                                      ; preds = %entry
  %0 = load i32, i32* %total_matched
  %1 = sext i32 %0 to i64
  %2 = add i32 %0, 1
  store i32 %2, i32* %total_matched
  %3 = icmp ne i64* %group_by_buff, null
  br i1 %3, label %groupby_nullcheck_true, label %groupby_nullcheck_false

filter_false:                                     ; preds = %groupby_nullcheck_true, %entry
  ret i32 0

groupby_nullcheck_true:                           ; preds = %filter_true
  %4 = call i8* @cider_ColDecoder_extractArrowBuffersAt(i8* %col_buf1, i64 1)
  %5 = call i8* @cider_ColDecoder_extractArrowBuffersAt(i8* %col_buf1, i64 2)
  %6 = call i8* @extract_str_ptr_arrow(i8* %5, i8* %4, i64 %pos)
  %7 = call i32 @extract_str_len_arrow(i8* %4, i64 %pos)
  %8 = getelementptr i64, i64* %group_by_buff, i32 0
  %9 = load i64, i64* %8
  %10 = inttoptr i64 %9 to i8*
  call void @reallocate_string_buffer_if_need(i8* %10, i64 %1)
  %11 = call i8* @cider_ColDecoder_extractArrowBuffersAt(i8* %10, i64 2)
  %12 = call i8* @cider_ColDecoder_extractArrowBuffersAt(i8* %10, i64 1)
  %13 = call i8* @cider_ColDecoder_extractArrowBuffersAt(i8* %10, i64 0)
  call void @cider_agg_id_proj_string(i8* %11, i8* %12, i64 %1, i8* %6, i32 %7)
  br label %filter_false

groupby_nullcheck_false:                          ; preds = %filter_true
  ret i32 -1
}
```

string_eq:
```
; Function Attrs: alwaysinline
define i32 @row_func_hoisted_literals(i64* %group_by_buff, i64* %varlen_output_buff, i32* %crt_matched, i32* %total_matched, i32* %old_total_matched, i32 %max_matched, i64* %agg_init_val, i64 %pos, i64* %frag_row_off, i64* %num_rows_per_scan, i8* %literals, i8* %col_buf0, i8* %col_buf1, i64* %join_hash_tables, i64, i8* %arg_literal_0_start_address, i32 %arg_literal_0_length) #25 {
entry:
  %1 = call i8* @cider_ColDecoder_extractArrowBuffersAt(i8* %col_buf1, i64 1)
  %2 = call i8* @cider_ColDecoder_extractArrowBuffersAt(i8* %col_buf1, i64 2)
  %3 = call i8* @extract_str_ptr_arrow(i8* %2, i8* %1, i64 %pos)
  %4 = call i32 @extract_str_len_arrow(i8* %1, i64 %pos)
  %5 = call i1 @string_eq(i8* %3, i32 %4, i8* %arg_literal_0_start_address, i32 %arg_literal_0_length)
  %6 = and i1 true, %5
  br i1 %6, label %filter_true, label %filter_false

filter_true:                                      ; preds = %entry
  %7 = load i32, i32* %total_matched
  %8 = sext i32 %7 to i64
  %9 = add i32 %7, 1
  store i32 %9, i32* %total_matched
  %10 = icmp ne i64* %group_by_buff, null
  br i1 %10, label %groupby_nullcheck_true, label %groupby_nullcheck_false

filter_false:                                     ; preds = %groupby_nullcheck_true, %entry
  ret i32 0

groupby_nullcheck_true:                           ; preds = %filter_true
  %11 = getelementptr i64, i64* %group_by_buff, i32 0
  %12 = load i64, i64* %11
  %13 = inttoptr i64 %12 to i8*
  call void @reallocate_string_buffer_if_need(i8* %13, i64 %8)
  %14 = call i8* @cider_ColDecoder_extractArrowBuffersAt(i8* %13, i64 2)
  %15 = call i8* @cider_ColDecoder_extractArrowBuffersAt(i8* %13, i64 1)
  %16 = call i8* @cider_ColDecoder_extractArrowBuffersAt(i8* %13, i64 0)
  call void @cider_agg_id_proj_string(i8* %14, i8* %15, i64 %8, i8* %3, i32 %4)
  br label %filter_false

groupby_nullcheck_false:                          ; preds = %filter_true
  ret i32 -1
}
```
