### PR TITLE
[POAE7-2509] UT framework support for 128-bit DECIMALs

### DIFF
--- a/cider/exec/module/batch/CiderBatch.cpp
+++ b/cider/exec/module/batch/CiderBatch.cpp
@@ -139,6 +139,10 @@ SQLTypes CiderBatch::getCiderType() const {
   return CiderBatchUtils::convertArrowTypeToCiderType(arrow_schema_->format);
 }
 
+const char* CiderBatch::getArrowFormatString() const {
+  return getArrowSchema()->format;
+}
+
 // TODO: Dictionary support is TBD.
 std::unique_ptr<CiderBatch> CiderBatch::getChildAt(size_t index) {
   CHECK(!isMoved());

--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -22,6 +22,8 @@
 #include "cider/batch/CiderBatchUtils.h"
 #include "ArrowABI.h"
 #include "CiderArrowBufferHolder.h"
+#include "tests/utils/CiderInt128.h"
+
 #include "include/cider/CiderException.h"
 #include "include/cider/batch/CiderBatch.h"
 #include "include/cider/batch/CiderBatchUtils.h"
@@ -220,6 +222,8 @@ SQLTypes convertArrowTypeToCiderType(const char* format) {
       return kFLOAT;
     case 'g':
       return kDOUBLE;
+    case 'd':
+      return kDECIMAL;
     case '+':
       // Complex Types
       switch (format[1]) {
@@ -371,6 +375,8 @@ std::unique_ptr<CiderBatch> createCiderBatch(std::shared_ptr<CiderAllocator> all
       return ScalarBatch<float>::Create(schema, allocator, array);
     case 'g':
       return ScalarBatch<double>::Create(schema, allocator, array);
+    case 'd':
+      return ScalarBatch<CiderInt128>::Create(schema, allocator, array);
     case '+':
       // Complex Types
       switch (format[1]) {

--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -216,7 +216,6 @@ SQLTypes convertArrowTypeToCiderType(const char* format) {
     case 'i':
       return kINT;
     case 'l':
-    case 'd':
       return kBIGINT;
     case 'f':
       return kFLOAT;
@@ -369,7 +368,6 @@ std::unique_ptr<CiderBatch> createCiderBatch(std::shared_ptr<CiderAllocator> all
     case 'i':
       return ScalarBatch<int32_t>::Create(schema, allocator, array);
     case 'l':
-    case 'd':
       return ScalarBatch<int64_t>::Create(schema, allocator, array);
     case 'f':
       return ScalarBatch<float>::Create(schema, allocator, array);

--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -376,7 +376,7 @@ std::unique_ptr<CiderBatch> createCiderBatch(std::shared_ptr<CiderAllocator> all
     case 'g':
       return ScalarBatch<double>::Create(schema, allocator, array);
     case 'd':
-      return ScalarBatch<CiderInt128>::Create(schema, allocator, array);
+      return ScalarBatch<__int128_t>::Create(schema, allocator, array);
     case '+':
       // Complex Types
       switch (format[1]) {

--- a/cider/include/cider/batch/CiderBatch.h
+++ b/cider/include/cider/batch/CiderBatch.h
@@ -61,9 +61,7 @@ class CiderBatch {
   SQLTypes getCiderType() const;
   const char* getArrowFormatString() const;
 
-  bool isRootOwner() const {
-    return ownership_;
-  }
+  bool isRootOwner() const { return ownership_; }
 
   bool isMoved() const;
 
@@ -126,21 +124,13 @@ class CiderBatch {
   }
   bool resizeNulls(int64_t size, bool default_not_null);
 
-  virtual size_t getNullVectorIndex() const {
-    return 0;
-  }
+  virtual size_t getNullVectorIndex() const { return 0; }
 
-  bool permitBufferAllocate() const {
-    return reallocate_;
-  }
+  bool permitBufferAllocate() const { return reallocate_; }
 
-  ArrowSchema* getArrowSchema() const {
-    return arrow_schema_;
-  }
+  ArrowSchema* getArrowSchema() const { return arrow_schema_; }
 
-  ArrowArray* getArrowArray() const {
-    return arrow_array_;
-  }
+  ArrowArray* getArrowArray() const { return arrow_array_; }
 
   SchemaReleaser getSchemaReleaser() const;
   ArrayReleaser getArrayReleaser() const;
@@ -329,41 +319,27 @@ class CiderBatch {
     }
   }
 
-  const int8_t* column(int32_t col_id) const {
-    return table_ptr_[col_id];
-  }
+  const int8_t* column(int32_t col_id) const { return table_ptr_[col_id]; }
 
   const int8_t** table() const {
     return table_ptr_.empty() ? nullptr : const_cast<const int8_t**>(table_ptr_.data());
   }
 
-  int64_t row_num() const {
-    return row_num_;
-  }
+  int64_t row_num() const { return row_num_; }
 
-  size_t column_type_size(int32_t col_id) const {
-    return column_type_size_[col_id];
-  }
+  size_t column_type_size(int32_t col_id) const { return column_type_size_[col_id]; }
 
-  void set_row_num(int64_t row_num) {
-    row_num_ = row_num;
-  }
+  void set_row_num(int64_t row_num) { row_num_ = row_num; }
 
-  int64_t row_capacity() const {
-    return row_capacity_;
-  }
+  int64_t row_capacity() const { return row_capacity_; }
 
-  int64_t column_num() const {
-    return table_ptr_.size();
-  }
+  int64_t column_num() const { return table_ptr_.size(); }
 
   void set_null_vecs(std::vector<std::vector<bool>>& null_vecs) {
     null_vecs_ = null_vecs;
   }
 
-  std::vector<std::vector<bool>> get_null_vecs() const {
-    return null_vecs_;
-  }
+  std::vector<std::vector<bool>> get_null_vecs() const { return null_vecs_; }
 
   std::string toString() const {
     std::stringstream ss;
@@ -466,13 +442,9 @@ class CiderBatch {
     }
   }
 
-  const std::shared_ptr<CiderTableSchema> schema() const {
-    return schema_;
-  }
+  const std::shared_ptr<CiderTableSchema> schema() const { return schema_; }
 
-  void set_schema(const std::shared_ptr<CiderTableSchema> schema) {
-    schema_ = schema;
-  }
+  void set_schema(const std::shared_ptr<CiderTableSchema> schema) { schema_ = schema; }
 
  private:
   int64_t row_num_ = 0;

--- a/cider/include/cider/batch/CiderBatch.h
+++ b/cider/include/cider/batch/CiderBatch.h
@@ -59,8 +59,11 @@ class CiderBatch {
   size_t getBufferNum() const;
   size_t getChildrenNum() const;
   SQLTypes getCiderType() const;
+  const char* getArrowFormatString() const;
 
-  bool isRootOwner() const { return ownership_; }
+  bool isRootOwner() const {
+    return ownership_;
+  }
 
   bool isMoved() const;
 
@@ -123,13 +126,21 @@ class CiderBatch {
   }
   bool resizeNulls(int64_t size, bool default_not_null);
 
-  virtual size_t getNullVectorIndex() const { return 0; }
+  virtual size_t getNullVectorIndex() const {
+    return 0;
+  }
 
-  bool permitBufferAllocate() const { return reallocate_; }
+  bool permitBufferAllocate() const {
+    return reallocate_;
+  }
 
-  ArrowSchema* getArrowSchema() const { return arrow_schema_; }
+  ArrowSchema* getArrowSchema() const {
+    return arrow_schema_;
+  }
 
-  ArrowArray* getArrowArray() const { return arrow_array_; }
+  ArrowArray* getArrowArray() const {
+    return arrow_array_;
+  }
 
   SchemaReleaser getSchemaReleaser() const;
   ArrayReleaser getArrayReleaser() const;
@@ -318,27 +329,41 @@ class CiderBatch {
     }
   }
 
-  const int8_t* column(int32_t col_id) const { return table_ptr_[col_id]; }
+  const int8_t* column(int32_t col_id) const {
+    return table_ptr_[col_id];
+  }
 
   const int8_t** table() const {
     return table_ptr_.empty() ? nullptr : const_cast<const int8_t**>(table_ptr_.data());
   }
 
-  int64_t row_num() const { return row_num_; }
+  int64_t row_num() const {
+    return row_num_;
+  }
 
-  size_t column_type_size(int32_t col_id) const { return column_type_size_[col_id]; }
+  size_t column_type_size(int32_t col_id) const {
+    return column_type_size_[col_id];
+  }
 
-  void set_row_num(int64_t row_num) { row_num_ = row_num; }
+  void set_row_num(int64_t row_num) {
+    row_num_ = row_num;
+  }
 
-  int64_t row_capacity() const { return row_capacity_; }
+  int64_t row_capacity() const {
+    return row_capacity_;
+  }
 
-  int64_t column_num() const { return table_ptr_.size(); }
+  int64_t column_num() const {
+    return table_ptr_.size();
+  }
 
   void set_null_vecs(std::vector<std::vector<bool>>& null_vecs) {
     null_vecs_ = null_vecs;
   }
 
-  std::vector<std::vector<bool>> get_null_vecs() const { return null_vecs_; }
+  std::vector<std::vector<bool>> get_null_vecs() const {
+    return null_vecs_;
+  }
 
   std::string toString() const {
     std::stringstream ss;
@@ -441,9 +466,13 @@ class CiderBatch {
     }
   }
 
-  const std::shared_ptr<CiderTableSchema> schema() const { return schema_; }
+  const std::shared_ptr<CiderTableSchema> schema() const {
+    return schema_;
+  }
 
-  void set_schema(const std::shared_ptr<CiderTableSchema> schema) { schema_ = schema; }
+  void set_schema(const std::shared_ptr<CiderTableSchema> schema) {
+    schema_ = schema;
+  }
 
  private:
   int64_t row_num_ = 0;

--- a/cider/tests/utils/CMakeLists.txt
+++ b/cider/tests/utils/CMakeLists.txt
@@ -26,7 +26,8 @@ set(CIDER_TESTS_UTILS_SOURCE
     CiderTestBase.cpp
     CiderBatchChecker.cpp
     CiderBenchmarkRunner.cpp
-    CiderRunner.cpp)
+    CiderRunner.cpp
+    CiderInt128.cpp)
 
 add_library(test_utils ${CIDER_TESTS_UTILS_SOURCE})
 target_link_libraries(test_utils cider_plan_parser)

--- a/cider/tests/utils/CMakeLists.txt
+++ b/cider/tests/utils/CMakeLists.txt
@@ -55,8 +55,7 @@ add_test(ArrowArrayBuilderTest ${EXECUTABLE_OUTPUT_PATH}/ArrowArrayBuilderTest
 
 add_executable(CiderInt128Test CiderInt128Test.cpp)
 target_link_libraries(CiderInt128Test ${EXECUTE_TEST_UTILS_LIBS})
-add_test(CiderInt128Test ${EXECUTABLE_OUTPUT_PATH}/CiderInt128Test
-         ${TEST_ARGS})
+add_test(CiderInt128Test ${EXECUTABLE_OUTPUT_PATH}/CiderInt128Test ${TEST_ARGS})
 
 add_executable(CiderBatchBuilderTest CiderBatchBuilderTest.cpp)
 target_link_libraries(CiderBatchBuilderTest ${EXECUTE_TEST_UTILS_LIBS})

--- a/cider/tests/utils/CMakeLists.txt
+++ b/cider/tests/utils/CMakeLists.txt
@@ -53,6 +53,11 @@ target_link_libraries(ArrowArrayBuilderTest ${EXECUTE_TEST_UTILS_LIBS})
 add_test(ArrowArrayBuilderTest ${EXECUTABLE_OUTPUT_PATH}/ArrowArrayBuilderTest
          ${TEST_ARGS})
 
+add_executable(CiderInt128Test CiderInt128Test.cpp)
+target_link_libraries(CiderInt128Test ${EXECUTE_TEST_UTILS_LIBS})
+add_test(CiderInt128Test ${EXECUTABLE_OUTPUT_PATH}/CiderInt128Test
+         ${TEST_ARGS})
+
 add_executable(CiderBatchBuilderTest CiderBatchBuilderTest.cpp)
 target_link_libraries(CiderBatchBuilderTest ${EXECUTE_TEST_UTILS_LIBS})
 add_test(CiderBatchBuilderTest ${EXECUTABLE_OUTPUT_PATH}/CiderBatchBuilderTest

--- a/cider/tests/utils/CiderBatchChecker.cpp
+++ b/cider/tests/utils/CiderBatchChecker.cpp
@@ -251,6 +251,10 @@ bool CiderBatchChecker::checkOneStructBatchEqual(CiderBatch* expected_batch,
             checkOneScalarBatchEqual<double>(expected_child->as<ScalarBatch<double>>(),
                                              actual_child->as<ScalarBatch<double>>());
         break;
+      case SQLTypes::kDECIMAL:
+        // duckdb decimals use 16 bytes, but cider decimals use 8 bytes
+        // therefore buffer compare will never pass, no need to check it
+        return false;
       case SQLTypes::kSTRUCT:
         is_equal = checkOneStructBatchEqual(expected_child.get(), actual_child.get());
         break;

--- a/cider/tests/utils/CiderBatchStringifier.cpp
+++ b/cider/tests/utils/CiderBatchStringifier.cpp
@@ -95,13 +95,13 @@ std::string StructBatchStringifier::stringifyValueAt(CiderBatch* batch, int row_
   return row.getString();
 }
 
-uint8_t DecimalBatchStringifier::getScale(const ScalarBatch<CiderInt128>* batch) {
+uint8_t DecimalBatchStringifier::getScale(const ScalarBatch<__int128_t>* batch) {
   auto type_str = std::string(batch->getArrowFormatString());
   uint8_t scale = std::stoi(type_str.substr(type_str.find(',') + 1));
   return scale;
 }
 
-uint8_t DecimalBatchStringifier::getWidth(const ScalarBatch<CiderInt128>* batch) {
+uint8_t DecimalBatchStringifier::getWidth(const ScalarBatch<__int128_t>* batch) {
   auto type_str = std::string(batch->getArrowFormatString());
   auto start = type_str.find(':') + 1;
   auto end = type_str.find(',');
@@ -110,7 +110,7 @@ uint8_t DecimalBatchStringifier::getWidth(const ScalarBatch<CiderInt128>* batch)
 }
 
 std::string DecimalBatchStringifier::stringifyValueAt(CiderBatch* batch, int row_index) {
-  auto scalar_batch = batch->as<ScalarBatch<CiderInt128>>();
+  auto scalar_batch = batch->as<ScalarBatch<__int128_t>>();
   if (!scalar_batch) {
     CIDER_THROW(CiderRuntimeException,
                 "ScalarBatch is nullptr, maybe check your casting?");
@@ -124,7 +124,7 @@ std::string DecimalBatchStringifier::stringifyValueAt(CiderBatch* batch, int row
   if (valid_bitmap && !CiderBitUtils::isBitSetAt(valid_bitmap, row_index)) {
     return NULL_VALUE;
   } else {
-    CiderInt128 value = data_buffer[row_index];
+    __int128_t value = data_buffer[row_index];
 
     if (!scale) {
       // integral type

--- a/cider/tests/utils/CiderBatchStringifier.h
+++ b/cider/tests/utils/CiderBatchStringifier.h
@@ -48,6 +48,9 @@ class ScalarBatchStringifier : public CiderBatchStringifier {
   std::string stringifyValueAt(CiderBatch* batch, int row_index) override;
 };
 
+// DuckDb uses little-endian int128 to store HUGEINT and DECIMAL types
+// exported arrow array also contains int128 values
+// so we use gcc's __int128_t to directly decode the values in arrow array
 class DecimalBatchStringifier : public CiderBatchStringifier {
  private:
   uint8_t getScale(const ScalarBatch<__int128_t>* batch);

--- a/cider/tests/utils/CiderBatchStringifier.h
+++ b/cider/tests/utils/CiderBatchStringifier.h
@@ -54,7 +54,7 @@ class ScalarBatchStringifier : public CiderBatchStringifier {
 class DecimalBatchStringifier : public CiderBatchStringifier {
  private:
   uint8_t getScale(const ScalarBatch<__int128_t>* batch);
-  uint8_t getWidth(const ScalarBatch<__int128_t>* batch);
+  uint8_t getPrecision(const ScalarBatch<__int128_t>* batch);
 
  public:
   std::string stringifyValueAt(CiderBatch* batch, int row_index) override;

--- a/cider/tests/utils/CiderBatchStringifier.h
+++ b/cider/tests/utils/CiderBatchStringifier.h
@@ -23,6 +23,9 @@
 #define CIDER_CIDERBATCHSTRINGIFIER_H
 
 #include "cider/CiderBatch.h"
+#include "cider/batch/ScalarBatch.h"
+#include "cider/batch/StructBatch.h"
+#include "tests/utils/CiderInt128.h"
 
 class CiderBatchStringifier {
  public:
@@ -41,6 +44,15 @@ class StructBatchStringifier : public CiderBatchStringifier {
 
 template <typename T>
 class ScalarBatchStringifier : public CiderBatchStringifier {
+ public:
+  std::string stringifyValueAt(CiderBatch* batch, int row_index) override;
+};
+
+class DecimalBatchStringifier : public CiderBatchStringifier {
+ private:
+  uint8_t getScale(const ScalarBatch<CiderInt128>* batch);
+  uint8_t getWidth(const ScalarBatch<CiderInt128>* batch);
+
  public:
   std::string stringifyValueAt(CiderBatch* batch, int row_index) override;
 };

--- a/cider/tests/utils/CiderBatchStringifier.h
+++ b/cider/tests/utils/CiderBatchStringifier.h
@@ -50,8 +50,8 @@ class ScalarBatchStringifier : public CiderBatchStringifier {
 
 class DecimalBatchStringifier : public CiderBatchStringifier {
  private:
-  uint8_t getScale(const ScalarBatch<CiderInt128>* batch);
-  uint8_t getWidth(const ScalarBatch<CiderInt128>* batch);
+  uint8_t getScale(const ScalarBatch<__int128_t>* batch);
+  uint8_t getWidth(const ScalarBatch<__int128_t>* batch);
 
  public:
   std::string stringifyValueAt(CiderBatch* batch, int row_index) override;

--- a/cider/tests/utils/CiderInt128.cpp
+++ b/cider/tests/utils/CiderInt128.cpp
@@ -192,5 +192,15 @@ std::string CiderInt128Utils::Decimal128ToString(CiderInt128 input,
     }
   }
 
+  while (scale_counter < scale) {
+    // pad zeros
+    result = "0" + result;
+    scale_counter++;
+  }
+  // in cases where scale > length, append 0. to beginning
+  if (scale_counter == scale) {
+    result = "0." + result;
+  }
+
   return is_negative ? "-" + result : result;
 }

--- a/cider/tests/utils/CiderInt128.cpp
+++ b/cider/tests/utils/CiderInt128.cpp
@@ -35,6 +35,10 @@ CiderInt128::CiderInt128(int64_t value) {
   this->low = temp.low;
 }
 
+bool CiderInt128::operator==(const CiderInt128& rhs) const {
+  return CiderInt128Utils::Equal(*this, rhs);
+}
+
 uint8_t CiderInt128Utils::HighestSetBitPositive(const CiderInt128& value) {
   uint8_t result = 0;
 
@@ -80,7 +84,7 @@ CiderInt128 CiderInt128Utils::LeftShift(const CiderInt128& input, uint8_t n) {
 
   auto result = CiderInt128(0, 0);
   result.low = input.low << n;
-  result.high = input.high << n + input.low >> (64 - n);
+  result.high = (input.high << n) + (input.low >> (64 - n));
 
   return result;
 }
@@ -89,14 +93,14 @@ CiderInt128 CiderInt128Utils::DivModPositive(const CiderInt128& numerator,
                                              uint64_t denominator,
                                              uint64_t& remainder) {
   CHECK_GE(numerator.high, 0);
-  auto result = CiderInt128(0, 0);
+  auto result = CiderInt128(0);
   remainder = 0;
 
   auto highest_set_bit = HighestSetBitPositive(numerator);
   for (auto x = highest_set_bit; x > 0; --x) {
     // left-shift result and remainder
     result = LeftShift(result);
-    remainder << 1;
+    remainder = remainder << 1;
 
     if (IsBitSetAt(numerator, x - 1)) {
       // if current bit is set, add current bit to remainder
@@ -112,6 +116,8 @@ CiderInt128 CiderInt128Utils::DivModPositive(const CiderInt128& numerator,
       }
     }
   }
+
+  return result;
 }
 
 CiderInt128 CiderInt128Utils::Negate(const CiderInt128& input) {
@@ -124,6 +130,13 @@ CiderInt128 CiderInt128Utils::Negate(const CiderInt128& input) {
   result.high = -1 - input.high + (input.low == 0);
 
   return result;
+}
+
+bool CiderInt128Utils::Equal(const CiderInt128& lhs, const CiderInt128& rhs) {
+  bool high_eq = lhs.high == rhs.high;
+  bool low_eq = lhs.low == rhs.low;
+
+  return high_eq && low_eq;
 }
 
 std::string CiderInt128Utils::Int128ToString(CiderInt128 input) {

--- a/cider/tests/utils/CiderInt128.cpp
+++ b/cider/tests/utils/CiderInt128.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// code adapted from DuckDb Hugeint types
+// https://github.com/duckdb/duckdb/blob/master/src/common/types/hugeint.cpp
+
+#include "CiderInt128.h"
+
+CiderInt128::CiderInt128(int64_t hi, uint64_t lo) {
+  this->high = hi;
+  this->low = lo;
+}
+
+CiderInt128::CiderInt128(int64_t value) {
+  auto temp = CiderInt128Utils::Int64ToCiderInt128(value);
+  this->high = temp.high;
+  this->low = temp.low;
+}
+
+uint8_t CiderInt128Utils::HighestSetBitPositive(const CiderInt128& value) {
+  uint8_t result = 0;
+
+  if (value.high) {
+    result = 64;
+    uint64_t hi = (uint64_t)value.high;
+    while (hi) {
+      hi = hi >> 1;
+      result++;
+    }
+  } else if (value.low) {
+    result = 0;
+    uint64_t lo = value.low;
+    while (lo) {
+      lo = lo >> 1;
+      result++;
+    }
+  }
+
+  return result;
+}
+
+bool CiderInt128Utils::IsBitSetAt(const CiderInt128& value, uint8_t pos) {
+  if (pos < 64) {
+    return value.low & (uint64_t(1) << pos);
+  } else {
+    return value.high & (uint64_t(1) << (uint64_t(pos - 64)));
+  }
+}
+
+CiderInt128 CiderInt128Utils::Int64ToCiderInt128(int64_t value) {
+  auto result = CiderInt128(0, 0);
+  result.low = (uint64_t)value;
+  result.high = value < 0 ? -1 : 0;
+
+  return result;
+}
+
+CiderInt128 CiderInt128Utils::LeftShift(const CiderInt128& input, uint8_t n) {
+  // only supports shifting (0, 64) bits
+  CHECK_GT(n, 0);
+  CHECK_LT(n, 64);
+
+  auto result = CiderInt128(0, 0);
+  result.low = input.low << n;
+  result.high = input.high << n + input.low >> (64 - n);
+
+  return result;
+}
+
+CiderInt128 CiderInt128Utils::DivModPositive(const CiderInt128& numerator,
+                                             uint64_t denominator,
+                                             uint64_t& remainder) {
+  CHECK_GE(numerator.high, 0);
+  auto result = CiderInt128(0, 0);
+  remainder = 0;
+
+  auto highest_set_bit = HighestSetBitPositive(numerator);
+  for (auto x = highest_set_bit; x > 0; --x) {
+    // left-shift result and remainder
+    result = LeftShift(result);
+    remainder << 1;
+
+    if (IsBitSetAt(numerator, x - 1)) {
+      // if current bit is set, add current bit to remainder
+      remainder += 1;
+    }
+
+    if (remainder >= denominator) {
+      remainder -= denominator;
+      result.low++;
+      if (result.low == 0) {
+        // low overflowed, add carriage to high
+        result.high++;
+      }
+    }
+  }
+}
+
+CiderInt128 CiderInt128Utils::Negate(const CiderInt128& input) {
+  auto result = CiderInt128(0, 0);
+  if (input.high == std::numeric_limits<int64_t>::min() && input.low == 0) {
+    CIDER_THROW(CiderRuntimeException, "Int128 overflowed!");
+  }
+
+  result.low = std::numeric_limits<uint64_t>::max() - input.low + 1;
+  result.high = -1 - input.high + (input.low == 0);
+
+  return result;
+}
+
+std::string CiderInt128Utils::Int128ToString(CiderInt128 input) {
+  uint64_t remainder = 0;
+  std::string result;
+  bool is_negative = input.high < 0;
+
+  if (is_negative) {
+    input = Negate(input);
+  }
+
+  // build string with % 10 remainder
+  while (true) {
+    if (!input.low && !input.high) {
+      break;
+    }
+    input = DivModPositive(input, 10, remainder);
+    result = std::string(1, '0' + remainder) + result;
+  }
+
+  if (!result.size()) {
+    return std::string("0");
+  }
+
+  return is_negative ? "-" + result : result;
+}
+
+std::string CiderInt128Utils::Decimal128ToString(CiderInt128 input,
+                                                 uint8_t width,
+                                                 uint8_t scale) {
+  if (!scale) {
+    // treat as an integer
+    return Int128ToString(input);
+  }
+
+  uint8_t scale_counter = 0;
+  uint64_t remainder = 0;
+  std::string result;
+  bool is_negative = input.high < 0;
+  if (is_negative) {
+    input = Negate(input);
+  }
+
+  while (true) {
+    if (!input.low && !input.high) {
+      break;
+    }
+    scale_counter++;
+    input = DivModPositive(input, 10, remainder);
+    result = std::string(1, '0' + remainder) + result;
+    if (scale_counter == scale) {
+      result = "." + result;
+    }
+  }
+
+  return is_negative ? "-" + result : result;
+}

--- a/cider/tests/utils/CiderInt128.cpp
+++ b/cider/tests/utils/CiderInt128.cpp
@@ -19,141 +19,21 @@
  * under the License.
  */
 
-// code adapted from DuckDb Hugeint types
-// https://github.com/duckdb/duckdb/blob/master/src/common/types/hugeint.cpp
-
 #include "CiderInt128.h"
 
-CiderInt128::CiderInt128(int64_t hi, uint64_t lo) {
-  this->high = hi;
-  this->low = lo;
-}
-
-CiderInt128::CiderInt128(int64_t value) {
-  auto temp = CiderInt128Utils::Int64ToCiderInt128(value);
-  this->high = temp.high;
-  this->low = temp.low;
-}
-
-bool CiderInt128::operator==(const CiderInt128& rhs) const {
-  return CiderInt128Utils::Equal(*this, rhs);
-}
-
-uint8_t CiderInt128Utils::HighestSetBitPositive(const CiderInt128& value) {
-  uint8_t result = 0;
-
-  if (value.high) {
-    result = 64;
-    uint64_t hi = (uint64_t)value.high;
-    while (hi) {
-      hi = hi >> 1;
-      result++;
-    }
-  } else if (value.low) {
-    result = 0;
-    uint64_t lo = value.low;
-    while (lo) {
-      lo = lo >> 1;
-      result++;
-    }
-  }
-
-  return result;
-}
-
-bool CiderInt128Utils::IsBitSetAt(const CiderInt128& value, uint8_t pos) {
-  if (pos < 64) {
-    return value.low & (uint64_t(1) << pos);
-  } else {
-    return value.high & (uint64_t(1) << (uint64_t(pos - 64)));
-  }
-}
-
-CiderInt128 CiderInt128Utils::Int64ToCiderInt128(int64_t value) {
-  auto result = CiderInt128(0, 0);
-  result.low = (uint64_t)value;
-  result.high = value < 0 ? -1 : 0;
-
-  return result;
-}
-
-CiderInt128 CiderInt128Utils::LeftShift(const CiderInt128& input, uint8_t n) {
-  // only supports shifting (0, 64) bits
-  CHECK_GT(n, 0);
-  CHECK_LT(n, 64);
-
-  auto result = CiderInt128(0, 0);
-  result.low = input.low << n;
-  result.high = (input.high << n) + (input.low >> (64 - n));
-
-  return result;
-}
-
-CiderInt128 CiderInt128Utils::DivModPositive(const CiderInt128& numerator,
-                                             uint64_t denominator,
-                                             uint64_t& remainder) {
-  CHECK_GE(numerator.high, 0);
-  auto result = CiderInt128(0);
-  remainder = 0;
-
-  auto highest_set_bit = HighestSetBitPositive(numerator);
-  for (auto x = highest_set_bit; x > 0; --x) {
-    // left-shift result and remainder
-    result = LeftShift(result);
-    remainder = remainder << 1;
-
-    if (IsBitSetAt(numerator, x - 1)) {
-      // if current bit is set, add current bit to remainder
-      remainder += 1;
-    }
-
-    if (remainder >= denominator) {
-      remainder -= denominator;
-      result.low++;
-      if (result.low == 0) {
-        // low overflowed, add carriage to high
-        result.high++;
-      }
-    }
-  }
-
-  return result;
-}
-
-CiderInt128 CiderInt128Utils::Negate(const CiderInt128& input) {
-  auto result = CiderInt128(0, 0);
-  if (input.high == std::numeric_limits<int64_t>::min() && input.low == 0) {
-    CIDER_THROW(CiderRuntimeException, "Int128 overflowed!");
-  }
-
-  result.low = std::numeric_limits<uint64_t>::max() - input.low + 1;
-  result.high = -1 - input.high + (input.low == 0);
-
-  return result;
-}
-
-bool CiderInt128Utils::Equal(const CiderInt128& lhs, const CiderInt128& rhs) {
-  bool high_eq = lhs.high == rhs.high;
-  bool low_eq = lhs.low == rhs.low;
-
-  return high_eq && low_eq;
-}
-
-std::string CiderInt128Utils::Int128ToString(CiderInt128 input) {
+std::string CiderInt128Utils::Int128ToString(__int128_t input) {
   uint64_t remainder = 0;
   std::string result;
-  bool is_negative = input.high < 0;
+  bool is_negative = input < 0;
 
   if (is_negative) {
-    input = Negate(input);
+    input = -input;
   }
 
   // build string with % 10 remainder
-  while (true) {
-    if (!input.low && !input.high) {
-      break;
-    }
-    input = DivModPositive(input, 10, remainder);
+  while (input) {
+    remainder = input % 10;
+    input /= 10;
     result = std::string(1, '0' + remainder) + result;
   }
 
@@ -164,7 +44,7 @@ std::string CiderInt128Utils::Int128ToString(CiderInt128 input) {
   return is_negative ? "-" + result : result;
 }
 
-std::string CiderInt128Utils::Decimal128ToString(CiderInt128 input,
+std::string CiderInt128Utils::Decimal128ToString(__int128_t input,
                                                  uint8_t width,
                                                  uint8_t scale) {
   if (!scale) {
@@ -175,17 +55,15 @@ std::string CiderInt128Utils::Decimal128ToString(CiderInt128 input,
   uint8_t scale_counter = 0;
   uint64_t remainder = 0;
   std::string result;
-  bool is_negative = input.high < 0;
+  bool is_negative = input < 0;
   if (is_negative) {
-    input = Negate(input);
+    input = -input;
   }
 
-  while (true) {
-    if (!input.low && !input.high) {
-      break;
-    }
+  while (input) {
     scale_counter++;
-    input = DivModPositive(input, 10, remainder);
+    remainder = input % 10;
+    input /= 10;
     result = std::string(1, '0' + remainder) + result;
     if (scale_counter == scale) {
       result = "." + result;
@@ -205,7 +83,7 @@ std::string CiderInt128Utils::Decimal128ToString(CiderInt128 input,
   return is_negative ? "-" + result : result;
 }
 
-double CiderInt128Utils::Decimal128ToDouble(CiderInt128 input,
+double CiderInt128Utils::Decimal128ToDouble(__int128_t input,
                                             uint8_t width,
                                             uint8_t scale) {
   auto val_str = Decimal128ToString(input, width, scale);

--- a/cider/tests/utils/CiderInt128.cpp
+++ b/cider/tests/utils/CiderInt128.cpp
@@ -204,3 +204,10 @@ std::string CiderInt128Utils::Decimal128ToString(CiderInt128 input,
 
   return is_negative ? "-" + result : result;
 }
+
+double CiderInt128Utils::Decimal128ToDouble(CiderInt128 input,
+                                            uint8_t width,
+                                            uint8_t scale) {
+  auto val_str = Decimal128ToString(input, width, scale);
+  return std::stod(val_str);
+}

--- a/cider/tests/utils/CiderInt128.cpp
+++ b/cider/tests/utils/CiderInt128.cpp
@@ -70,14 +70,18 @@ std::string CiderInt128Utils::Decimal128ToString(__int128_t input,
     }
   }
 
-  while (scale_counter < scale) {
-    // pad zeros
-    result = "0" + result;
-    scale_counter++;
-  }
-  // in cases where scale > length, append 0. to beginning
-  if (scale_counter == scale) {
+  if (scale_counter < scale) {
+    // in cases where scale > length, append 0's
+    while (scale_counter < scale) {
+      // pad zeros
+      result = "0" + result;
+      scale_counter++;
+    }
+    // append 0. to the very beginning
     result = "0." + result;
+  } else if (scale_counter == scale) {
+    // scale == length, append 0
+    result = "0" + result;
   }
 
   return is_negative ? "-" + result : result;

--- a/cider/tests/utils/CiderInt128.h
+++ b/cider/tests/utils/CiderInt128.h
@@ -25,9 +25,9 @@
 #ifndef CIDER_CIDERDECIMAL128_H
 #define CIDER_CIDERDECIMAL128_H
 
+#include <cstdint>
 #include <limits>
 #include <string>
-#include <cstdint>
 
 #include "cider/CiderBatch.h"
 
@@ -46,6 +46,8 @@ struct CiderInt128 {
 
   explicit CiderInt128(int64_t hi, uint64_t lo);
   explicit CiderInt128(int64_t value);
+
+  bool operator==(const CiderInt128& rhs) const;
 };
 
 class CiderInt128Utils {
@@ -72,11 +74,11 @@ class CiderInt128Utils {
   static CiderInt128 LeftShift(const CiderInt128& input, uint8_t n = 1);
   // negation
   static CiderInt128 Negate(const CiderInt128& input);
+  // equal
+  static bool Equal(const CiderInt128& lhs, const CiderInt128& rhs);
 
   static std::string Int128ToString(CiderInt128 input);
-  static std::string Decimal128ToString(CiderInt128 input,
-                                        uint8_t width,
-                                        uint8_t scale);
+  static std::string Decimal128ToString(CiderInt128 input, uint8_t width, uint8_t scale);
 };
 
 #endif

--- a/cider/tests/utils/CiderInt128.h
+++ b/cider/tests/utils/CiderInt128.h
@@ -31,12 +31,13 @@
 
 #include "cider/CiderBatch.h"
 
-// 128-bit integer consisting of a int64 (high) and a uint64 (low)
+// 128-bit integer consisting of a uint64 (low) and a int64 (high)
 // value = 2^64 * high + low
 // can also be used for representing fix-point decimals
 struct CiderInt128 {
-  int64_t high;
+  // duckdb hugeint_t layout, low followed by high
   uint64_t low;
+  int64_t high;
 
   CiderInt128() = default;
   CiderInt128(const CiderInt128& rhs) = default;

--- a/cider/tests/utils/CiderInt128.h
+++ b/cider/tests/utils/CiderInt128.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// code adapted from DuckDb Hugeint types
+// https://github.com/duckdb/duckdb/blob/master/src/common/types/hugeint.cpp
+
+#ifndef CIDER_CIDERDECIMAL128_H
+#define CIDER_CIDERDECIMAL128_H
+
+#include <limits>
+#include <string>
+#include <cstdint>
+
+#include "cider/CiderBatch.h"
+
+// 128-bit integer consisting of a int64 (high) and a uint64 (low)
+// value = 2^64 * high + low
+// can also be used for representing fix-point decimals
+struct CiderInt128 {
+  int64_t high;
+  uint64_t low;
+
+  CiderInt128() = default;
+  CiderInt128(const CiderInt128& rhs) = default;
+  CiderInt128(CiderInt128&& rhs) = default;
+  CiderInt128& operator=(const CiderInt128& rhs) = default;
+  CiderInt128& operator=(CiderInt128&& rhs) = default;
+
+  explicit CiderInt128(int64_t hi, uint64_t lo);
+  explicit CiderInt128(int64_t value);
+};
+
+class CiderInt128Utils {
+ private:
+  // Finds the highest bit that is set to 1 in a positive CiderInt128 instance
+  // returns 1-indexed bit position, and returns 0 if all bits are 0
+  static uint8_t HighestSetBitPositive(const CiderInt128& value);
+
+  // Checks if a bit is set at position pos
+  static bool IsBitSetAt(const CiderInt128& value, uint8_t pos);
+
+ public:
+  static CiderInt128 Int64ToCiderInt128(int64_t value);
+  static std::string ToString(const CiderInt128& value,
+                              uint8_t width = 38,
+                              uint8_t scale = 0);
+  // computes int128-uint64 division
+  // the numerator int128 must be positive
+  // returns quotient, outputs remainder via remainder out reference parameter
+  static CiderInt128 DivModPositive(const CiderInt128& numerator,
+                                    uint64_t denominator,
+                                    uint64_t& remainder);
+  // left shift
+  static CiderInt128 LeftShift(const CiderInt128& input, uint8_t n = 1);
+  // negation
+  static CiderInt128 Negate(const CiderInt128& input);
+
+  static std::string Int128ToString(CiderInt128 input);
+  static std::string Decimal128ToString(CiderInt128 input,
+                                        uint8_t width,
+                                        uint8_t scale);
+};
+
+#endif

--- a/cider/tests/utils/CiderInt128.h
+++ b/cider/tests/utils/CiderInt128.h
@@ -19,9 +19,6 @@
  * under the License.
  */
 
-// code adapted from DuckDb Hugeint types
-// https://github.com/duckdb/duckdb/blob/master/src/common/types/hugeint.cpp
-
 #ifndef CIDER_CIDERDECIMAL128_H
 #define CIDER_CIDERDECIMAL128_H
 
@@ -31,53 +28,11 @@
 
 #include "cider/CiderBatch.h"
 
-// 128-bit integer consisting of a uint64 (low) and a int64 (high)
-// value = 2^64 * high + low
-// can also be used for representing fix-point decimals
-struct CiderInt128 {
-  // duckdb hugeint_t layout, low followed by high
-  uint64_t low;
-  int64_t high;
-
-  CiderInt128() = default;
-  CiderInt128(const CiderInt128& rhs) = default;
-  CiderInt128(CiderInt128&& rhs) = default;
-  CiderInt128& operator=(const CiderInt128& rhs) = default;
-  CiderInt128& operator=(CiderInt128&& rhs) = default;
-
-  explicit CiderInt128(int64_t hi, uint64_t lo);
-  explicit CiderInt128(int64_t value);
-
-  bool operator==(const CiderInt128& rhs) const;
-};
-
 class CiderInt128Utils {
- private:
-  // Finds the highest bit that is set to 1 in a positive CiderInt128 instance
-  // returns 1-indexed bit position, and returns 0 if all bits are 0
-  static uint8_t HighestSetBitPositive(const CiderInt128& value);
-
-  // Checks if a bit is set at position pos
-  static bool IsBitSetAt(const CiderInt128& value, uint8_t pos);
-
  public:
-  static CiderInt128 Int64ToCiderInt128(int64_t value);
-  // computes int128-uint64 division
-  // the numerator int128 must be positive
-  // returns quotient, outputs remainder via remainder out reference parameter
-  static CiderInt128 DivModPositive(const CiderInt128& numerator,
-                                    uint64_t denominator,
-                                    uint64_t& remainder);
-  // left shift
-  static CiderInt128 LeftShift(const CiderInt128& input, uint8_t n = 1);
-  // negation
-  static CiderInt128 Negate(const CiderInt128& input);
-  // equal
-  static bool Equal(const CiderInt128& lhs, const CiderInt128& rhs);
-
-  static std::string Int128ToString(CiderInt128 input);
-  static std::string Decimal128ToString(CiderInt128 input, uint8_t width, uint8_t scale);
-  static double Decimal128ToDouble(CiderInt128 input, uint8_t width, uint8_t scale);
+  static std::string Int128ToString(__int128_t input);
+  static std::string Decimal128ToString(__int128_t input, uint8_t width, uint8_t scale);
+  static double Decimal128ToDouble(__int128_t input, uint8_t width, uint8_t scale);
 };
 
 #endif

--- a/cider/tests/utils/CiderInt128.h
+++ b/cider/tests/utils/CiderInt128.h
@@ -31,8 +31,10 @@
 class CiderInt128Utils {
  public:
   static std::string Int128ToString(__int128_t input);
-  static std::string Decimal128ToString(__int128_t input, uint8_t width, uint8_t scale);
-  static double Decimal128ToDouble(__int128_t input, uint8_t width, uint8_t scale);
+  static std::string Decimal128ToString(__int128_t input,
+                                        uint8_t precision,
+                                        uint8_t scale);
+  static double Decimal128ToDouble(__int128_t input, uint8_t precision, uint8_t scale);
 };
 
 #endif

--- a/cider/tests/utils/CiderInt128.h
+++ b/cider/tests/utils/CiderInt128.h
@@ -61,9 +61,6 @@ class CiderInt128Utils {
 
  public:
   static CiderInt128 Int64ToCiderInt128(int64_t value);
-  static std::string ToString(const CiderInt128& value,
-                              uint8_t width = 38,
-                              uint8_t scale = 0);
   // computes int128-uint64 division
   // the numerator int128 must be positive
   // returns quotient, outputs remainder via remainder out reference parameter

--- a/cider/tests/utils/CiderInt128.h
+++ b/cider/tests/utils/CiderInt128.h
@@ -76,6 +76,7 @@ class CiderInt128Utils {
 
   static std::string Int128ToString(CiderInt128 input);
   static std::string Decimal128ToString(CiderInt128 input, uint8_t width, uint8_t scale);
+  static double Decimal128ToDouble(CiderInt128 input, uint8_t width, uint8_t scale);
 };
 
 #endif

--- a/cider/tests/utils/CiderInt128Test.cpp
+++ b/cider/tests/utils/CiderInt128Test.cpp
@@ -24,11 +24,15 @@
 
 TEST(CiderInt128Test, ToStringTest) {
   // integer test
-  auto ival = __int128_t(33252311246);
+  auto op1 = __int128_t(191929293939);
+  auto op2 = __int128_t(191929293939);
+  // since there's no way to directly declare an int128_t value
+  // we manually create one by multiplying int64 values
+  auto ival = op1 * op2;
   auto istr = CiderInt128Utils::Int128ToString(ival);
   auto dstr = CiderInt128Utils::Decimal128ToString(ival, 38, 0);
-  EXPECT_EQ(istr, "33252311246");
-  EXPECT_EQ(dstr, "33252311246");
+  EXPECT_EQ(istr, "36836853871923062135721");
+  EXPECT_EQ(dstr, "36836853871923062135721");
 
   // decimal test
   auto dval = __int128_t(187694187358912);

--- a/cider/tests/utils/CiderInt128Test.cpp
+++ b/cider/tests/utils/CiderInt128Test.cpp
@@ -103,6 +103,22 @@ TEST(CiderInt128Test, DivModTest) {
   EXPECT_EQ(remainder, 10);
 }
 
+TEST(CiderInt128Test, ToStringTest) {
+  auto ival = CiderInt128(33252311246);
+  auto istr = CiderInt128Utils::Int128ToString(ival);
+  auto dstr = CiderInt128Utils::Decimal128ToString(ival, 38, 0);
+  EXPECT_EQ(istr, "33252311246");
+  EXPECT_EQ(dstr, "33252311246");
+
+  auto dval = CiderInt128(187694187358912);
+  dstr = CiderInt128Utils::Decimal128ToString(dval, 38, 5);
+  EXPECT_EQ(dstr, "1876941873.58912");
+  dstr = CiderInt128Utils::Decimal128ToString(dval, 38, 10);
+  EXPECT_EQ(dstr, "18769.4187358912");
+  dstr = CiderInt128Utils::Decimal128ToString(dval, 38, 20);
+  EXPECT_EQ(dstr, "0.00000187694187358912");
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
 

--- a/cider/tests/utils/CiderInt128Test.cpp
+++ b/cider/tests/utils/CiderInt128Test.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "CiderInt128.h"
+
+TEST(CiderInt128Test, ConstructorTest) {
+  auto val_1 = CiderInt128(10, 3);
+  EXPECT_EQ(val_1.high, 10);
+  EXPECT_EQ(val_1.low, 3);
+
+  auto val_2 = CiderInt128(1024);
+  EXPECT_EQ(val_2.high, 0);
+  EXPECT_EQ(val_2.low, 1024);
+
+  auto val_3 = CiderInt128(-2048);
+  EXPECT_EQ(val_3.high, -1);
+  EXPECT_EQ(val_3.low, uint64_t(18446744073709549568));
+
+  auto val_4 = CiderInt128(std::numeric_limits<int64_t>::min());
+  EXPECT_EQ(val_4.high, -1);
+  EXPECT_EQ(val_4.low, uint64_t(9223372036854775808));
+
+  auto val_5 = CiderInt128(std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(val_5.high, 0);
+  EXPECT_EQ(val_5.low, std::numeric_limits<int64_t>::max());
+}
+
+TEST(CiderInt128Test, EqualityTest) {
+  auto val_1 = CiderInt128(100, 100);
+  auto val_2 = CiderInt128(100, 100);
+  EXPECT_TRUE(CiderInt128Utils::Equal(val_1, val_2));
+  EXPECT_TRUE(CiderInt128Utils::Equal(val_2, val_1));
+
+  EXPECT_TRUE(val_1 == val_2);
+
+  auto val_3 = CiderInt128(100, 200);
+  EXPECT_FALSE(CiderInt128Utils::Equal(val_1, val_3));
+  EXPECT_FALSE(CiderInt128Utils::Equal(val_3, val_1));
+
+  EXPECT_FALSE(val_1 == val_3);
+}
+
+TEST(CiderInt128Test, LShiftTest) {
+  auto val = CiderInt128(0, 0xFFFFFFFFFFFFFFFF);
+  auto shifted_1 = CiderInt128Utils::LeftShift(val);
+  EXPECT_EQ(shifted_1, CiderInt128(1, 0xFFFFFFFFFFFFFFFE));
+
+  auto shifted_16 = CiderInt128Utils::LeftShift(val, 16);
+  EXPECT_EQ(shifted_16, CiderInt128(0xFFFF, 0xFFFFFFFFFFFF0000));
+}
+
+TEST(CiderInt128Test, NegationTest) {
+  auto val = CiderInt128(2038);
+  auto negval = CiderInt128Utils::Negate(val);
+  EXPECT_EQ(negval, CiderInt128(-2038));
+
+  auto val_2 = CiderInt128(0);
+  auto negval_2 = CiderInt128Utils::Negate(val_2);
+  EXPECT_EQ(negval_2, CiderInt128(0));
+
+  auto val_3 = CiderInt128(std::numeric_limits<int64_t>::max());
+  auto negval_3 = CiderInt128Utils::Negate(val_3);
+  EXPECT_EQ(negval_3, CiderInt128(-std::numeric_limits<int64_t>::max()));
+}
+
+TEST(CiderInt128Test, DivModTest) {
+  auto val = CiderInt128(1024);
+  uint64_t remainder = 0;
+  auto res = CiderInt128Utils::DivModPositive(val, 5, remainder);
+
+  EXPECT_EQ(res, CiderInt128(204));
+  EXPECT_EQ(remainder, 4);
+
+  res = CiderInt128Utils::DivModPositive(res, 2, remainder);
+  EXPECT_EQ(res, CiderInt128(102));
+  EXPECT_EQ(remainder, 0);
+
+  res = CiderInt128Utils::DivModPositive(res, 10, remainder);
+  EXPECT_EQ(res, CiderInt128(10));
+  EXPECT_EQ(remainder, 2);
+
+  res = CiderInt128Utils::DivModPositive(res, 100, remainder);
+  EXPECT_EQ(res, CiderInt128(0));
+  EXPECT_EQ(remainder, 10);
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+
+  int err{0};
+  try {
+    err = RUN_ALL_TESTS();
+  } catch (const std::exception& e) {
+  }
+  return err;
+}

--- a/cider/tests/utils/CiderInt128Test.cpp
+++ b/cider/tests/utils/CiderInt128Test.cpp
@@ -22,105 +22,33 @@
 #include <gtest/gtest.h>
 #include "CiderInt128.h"
 
-TEST(CiderInt128Test, ConstructorTest) {
-  auto val_1 = CiderInt128(10, 3);
-  EXPECT_EQ(val_1.high, 10);
-  EXPECT_EQ(val_1.low, 3);
-
-  auto val_2 = CiderInt128(1024);
-  EXPECT_EQ(val_2.high, 0);
-  EXPECT_EQ(val_2.low, 1024);
-
-  auto val_3 = CiderInt128(-2048);
-  EXPECT_EQ(val_3.high, -1);
-  EXPECT_EQ(val_3.low, uint64_t(18446744073709549568));
-
-  auto val_4 = CiderInt128(std::numeric_limits<int64_t>::min());
-  EXPECT_EQ(val_4.high, -1);
-  EXPECT_EQ(val_4.low, uint64_t(9223372036854775808));
-
-  auto val_5 = CiderInt128(std::numeric_limits<int64_t>::max());
-  EXPECT_EQ(val_5.high, 0);
-  EXPECT_EQ(val_5.low, std::numeric_limits<int64_t>::max());
-}
-
-TEST(CiderInt128Test, EqualityTest) {
-  auto val_1 = CiderInt128(100, 100);
-  auto val_2 = CiderInt128(100, 100);
-  EXPECT_TRUE(CiderInt128Utils::Equal(val_1, val_2));
-  EXPECT_TRUE(CiderInt128Utils::Equal(val_2, val_1));
-
-  EXPECT_TRUE(val_1 == val_2);
-
-  auto val_3 = CiderInt128(100, 200);
-  EXPECT_FALSE(CiderInt128Utils::Equal(val_1, val_3));
-  EXPECT_FALSE(CiderInt128Utils::Equal(val_3, val_1));
-
-  EXPECT_FALSE(val_1 == val_3);
-}
-
-TEST(CiderInt128Test, LShiftTest) {
-  auto val = CiderInt128(0, 0xFFFFFFFFFFFFFFFF);
-  auto shifted_1 = CiderInt128Utils::LeftShift(val);
-  EXPECT_EQ(shifted_1, CiderInt128(1, 0xFFFFFFFFFFFFFFFE));
-
-  auto shifted_16 = CiderInt128Utils::LeftShift(val, 16);
-  EXPECT_EQ(shifted_16, CiderInt128(0xFFFF, 0xFFFFFFFFFFFF0000));
-}
-
-TEST(CiderInt128Test, NegationTest) {
-  auto val = CiderInt128(2038);
-  auto negval = CiderInt128Utils::Negate(val);
-  EXPECT_EQ(negval, CiderInt128(-2038));
-
-  auto val_2 = CiderInt128(0);
-  auto negval_2 = CiderInt128Utils::Negate(val_2);
-  EXPECT_EQ(negval_2, CiderInt128(0));
-
-  auto val_3 = CiderInt128(std::numeric_limits<int64_t>::max());
-  auto negval_3 = CiderInt128Utils::Negate(val_3);
-  EXPECT_EQ(negval_3, CiderInt128(-std::numeric_limits<int64_t>::max()));
-}
-
-TEST(CiderInt128Test, DivModTest) {
-  auto val = CiderInt128(1024);
-  uint64_t remainder = 0;
-  auto res = CiderInt128Utils::DivModPositive(val, 5, remainder);
-
-  EXPECT_EQ(res, CiderInt128(204));
-  EXPECT_EQ(remainder, 4);
-
-  res = CiderInt128Utils::DivModPositive(res, 2, remainder);
-  EXPECT_EQ(res, CiderInt128(102));
-  EXPECT_EQ(remainder, 0);
-
-  res = CiderInt128Utils::DivModPositive(res, 10, remainder);
-  EXPECT_EQ(res, CiderInt128(10));
-  EXPECT_EQ(remainder, 2);
-
-  res = CiderInt128Utils::DivModPositive(res, 100, remainder);
-  EXPECT_EQ(res, CiderInt128(0));
-  EXPECT_EQ(remainder, 10);
-}
-
 TEST(CiderInt128Test, ToStringTest) {
-  auto ival = CiderInt128(33252311246);
+  // integer test
+  auto ival = __int128_t(33252311246);
   auto istr = CiderInt128Utils::Int128ToString(ival);
   auto dstr = CiderInt128Utils::Decimal128ToString(ival, 38, 0);
   EXPECT_EQ(istr, "33252311246");
   EXPECT_EQ(dstr, "33252311246");
 
-  auto dval = CiderInt128(187694187358912);
+  // decimal test
+  auto dval = __int128_t(187694187358912);
   dstr = CiderInt128Utils::Decimal128ToString(dval, 38, 5);
   EXPECT_EQ(dstr, "1876941873.58912");
   dstr = CiderInt128Utils::Decimal128ToString(dval, 38, 10);
   EXPECT_EQ(dstr, "18769.4187358912");
   dstr = CiderInt128Utils::Decimal128ToString(dval, 38, 20);
   EXPECT_EQ(dstr, "0.00000187694187358912");
+
+  // negative value test
+  auto nval = __int128_t(-1134596187461531);
+  istr = CiderInt128Utils::Int128ToString(nval);
+  dstr = CiderInt128Utils::Decimal128ToString(nval, 38, 10);
+  EXPECT_EQ(istr, "-1134596187461531");
+  EXPECT_EQ(dstr, "-113459.6187461531");
 }
 
 TEST(CiderInt128Test, ToDoubleTest) {
-  auto decimal = CiderInt128(483248120643921598);
+  auto decimal = __int128_t(483248120643921598);
   auto fp64_val = CiderInt128Utils::Decimal128ToDouble(decimal, 38, 5);
   EXPECT_EQ(fp64_val, 4832481206439.21598);
   fp64_val = CiderInt128Utils::Decimal128ToDouble(decimal, 38, 10);

--- a/cider/tests/utils/CiderInt128Test.cpp
+++ b/cider/tests/utils/CiderInt128Test.cpp
@@ -119,6 +119,16 @@ TEST(CiderInt128Test, ToStringTest) {
   EXPECT_EQ(dstr, "0.00000187694187358912");
 }
 
+TEST(CiderInt128Test, ToDoubleTest) {
+  auto decimal = CiderInt128(483248120643921598);
+  auto fp64_val = CiderInt128Utils::Decimal128ToDouble(decimal, 38, 5);
+  EXPECT_EQ(fp64_val, 4832481206439.21598);
+  fp64_val = CiderInt128Utils::Decimal128ToDouble(decimal, 38, 10);
+  EXPECT_EQ(fp64_val, 48324812.0643921598);
+  fp64_val = CiderInt128Utils::Decimal128ToDouble(decimal, 38, 20);
+  EXPECT_EQ(fp64_val, 0.00483248120643921598);
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
 

--- a/cider/tests/utils/CiderInt128Test.cpp
+++ b/cider/tests/utils/CiderInt128Test.cpp
@@ -28,27 +28,32 @@ TEST(CiderInt128Test, ToStringTest) {
   auto op2 = __int128_t(191929293939);
   // since there's no way to directly declare an int128_t value
   // we manually create one by multiplying int64 values
-  auto ival = op1 * op2;
-  auto istr = CiderInt128Utils::Int128ToString(ival);
-  auto dstr = CiderInt128Utils::Decimal128ToString(ival, 38, 0);
+  auto val1 = op1 * op2;
+  auto istr = CiderInt128Utils::Int128ToString(val1);
+  auto dstr = CiderInt128Utils::Decimal128ToString(val1, 38, 0);
   EXPECT_EQ(istr, "36836853871923062135721");
   EXPECT_EQ(dstr, "36836853871923062135721");
 
   // decimal test
-  auto dval = __int128_t(187694187358912);
-  dstr = CiderInt128Utils::Decimal128ToString(dval, 38, 5);
+  auto val2 = __int128_t(187694187358912);
+  dstr = CiderInt128Utils::Decimal128ToString(val2, 38, 5);
   EXPECT_EQ(dstr, "1876941873.58912");
-  dstr = CiderInt128Utils::Decimal128ToString(dval, 38, 10);
+  dstr = CiderInt128Utils::Decimal128ToString(val2, 38, 10);
   EXPECT_EQ(dstr, "18769.4187358912");
-  dstr = CiderInt128Utils::Decimal128ToString(dval, 38, 20);
+  dstr = CiderInt128Utils::Decimal128ToString(val2, 38, 20);
   EXPECT_EQ(dstr, "0.00000187694187358912");
 
   // negative value test
-  auto nval = __int128_t(-1134596187461531);
-  istr = CiderInt128Utils::Int128ToString(nval);
-  dstr = CiderInt128Utils::Decimal128ToString(nval, 38, 10);
+  auto val3 = __int128_t(-1134596187461531);
+  istr = CiderInt128Utils::Int128ToString(val3);
+  dstr = CiderInt128Utils::Decimal128ToString(val3, 38, 10);
   EXPECT_EQ(istr, "-1134596187461531");
   EXPECT_EQ(dstr, "-113459.6187461531");
+
+  // corner case
+  auto val4 = 123;
+  dstr = CiderInt128Utils::Decimal128ToString(val4, 14, 3);
+  EXPECT_EQ(dstr, "0.123");
 }
 
 TEST(CiderInt128Test, ToDoubleTest) {

--- a/cider/tests/utils/DuckDbArrowAdaptor.cpp
+++ b/cider/tests/utils/DuckDbArrowAdaptor.cpp
@@ -143,7 +143,9 @@ void DuckDbArrowSchemaAdaptor::SetArrowFormat(DuckDBArrowSchemaHolder& root_hold
     case ::duckdb::LogicalTypeId::DECIMAL: {
       uint8_t width, scale;
       type.GetDecimalProperties(width, scale);
-      std::string format = "d:" + to_string(width) + "," + to_string(scale);
+      // std::to_string(uint8_t) may result in converting ints to ASCII chars
+      // instead of string of ints (e.g. 97 -> 'a' instead of "97")
+      std::string format = "d:" + to_string(int(width)) + "," + to_string(int(scale));
       std::unique_ptr<char[]> format_ptr =
           std::unique_ptr<char[]>(new char[format.size() + 1]);
       for (size_t i = 0; i < format.size(); i++) {

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -575,9 +575,10 @@ CiderBatch DuckDbResultConvertor::fetchOneBatch(
         addColumnDataToCiderBatch<float>(chunk, i, row_num, col_buf);
         break;
       case ::duckdb::LogicalTypeId::DOUBLE:
-      case ::duckdb::LogicalTypeId::DECIMAL:
         addColumnDataToCiderBatch<double>(chunk, i, row_num, col_buf);
         break;
+      case ::duckdb::LogicalTypeId::DECIMAL:
+        CIDER_THROW(CiderRuntimeException, "YOOOOOOOOOOOOOOOOOOOOOOOOOO");
       case ::duckdb::LogicalTypeId::DATE:
         addColumnDataToCiderBatch<CiderDateType>(chunk, i, row_num, col_buf);
         break;

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -574,11 +574,10 @@ CiderBatch DuckDbResultConvertor::fetchOneBatch(
       case ::duckdb::LogicalTypeId::FLOAT:
         addColumnDataToCiderBatch<float>(chunk, i, row_num, col_buf);
         break;
+      case ::duckdb::LogicalTypeId::DECIMAL:
       case ::duckdb::LogicalTypeId::DOUBLE:
         addColumnDataToCiderBatch<double>(chunk, i, row_num, col_buf);
         break;
-      case ::duckdb::LogicalTypeId::DECIMAL:
-        CIDER_THROW(CiderRuntimeException, "YOOOOOOOOOOOOOOOOOOOOOOOOOO");
       case ::duckdb::LogicalTypeId::DATE:
         addColumnDataToCiderBatch<CiderDateType>(chunk, i, row_num, col_buf);
         break;

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -574,8 +574,8 @@ CiderBatch DuckDbResultConvertor::fetchOneBatch(
       case ::duckdb::LogicalTypeId::FLOAT:
         addColumnDataToCiderBatch<float>(chunk, i, row_num, col_buf);
         break;
-      case ::duckdb::LogicalTypeId::DECIMAL:
       case ::duckdb::LogicalTypeId::DOUBLE:
+      case ::duckdb::LogicalTypeId::DECIMAL:
         addColumnDataToCiderBatch<double>(chunk, i, row_num, col_buf);
         break;
       case ::duckdb::LogicalTypeId::DATE:

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -206,40 +206,42 @@ TEST(DuckDBArrowQueryRunnerTest, multiBatchFetchTest) {
   EXPECT_TRUE(CiderBatchChecker::checkArrowEq(input_batch, multi_batch_res));
 }
 
-/// TODO: (YBRua) tests to be added
-/// 1. VarChar tests
-/// 2. date / time tests
-
 TEST(DuckDBArrowQueryRunnerTest, HugeIntTest) {
   DuckDbQueryRunner runner;
   std::vector<int> expected_data{0, 1, 2, 3, 4};
-  std::vector<bool> null_vecs_1{false, false, false, false, false};
+  std::vector<bool> null_vecs{false, false, false, true, true};
 
   auto input_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int>("col_a", CREATE_SUBSTRAIT_TYPE(I32), expected_data)
+          .addColumn<int>("col_b", CREATE_SUBSTRAIT_TYPE(I32), expected_data, null_vecs)
           .build());
 
   /* Create table, run query and check results */
   std::string table_name = "table_test";
-  std::string create_ddl = "CREATE TABLE table_test(col_a INTEGER)";
+  std::string create_ddl = "CREATE TABLE table_test(col_a INTEGER, col_b INTEGER)";
 
   runner.createTableAndInsertArrowData(table_name, create_ddl, input_batch);
-  auto res = runner.runSql("select SUM(col_a) from table_test;");
+  auto res = runner.runSql("select SUM(col_a), SUM(col_b) from table_test;");
   CHECK(!res->HasError());
-  CHECK_EQ(res->ColumnCount(), 1);
+  CHECK_EQ(res->ColumnCount(), 2);
 
   auto actual_batches = DuckDbResultConvertor::fetchDataToArrowFormattedCiderBatch(res);
 
   auto expected_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(1)
-          .addColumn<int64_t>("res", CREATE_SUBSTRAIT_TYPE(I64), std::vector<int64_t>{10})
+          .addColumn<int64_t>("r1", CREATE_SUBSTRAIT_TYPE(I64), std::vector<int64_t>{10})
+          .addColumn<int64_t>("r2", CREATE_SUBSTRAIT_TYPE(I64), std::vector<int64_t>{3})
           .build());
 
   EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_batches, expected_batch));
 }
+
+/// TODO: (YBRua) tests to be added
+/// 1. VarChar tests
+/// 2. date / time tests
 
 // old DuckDBQueryRunnerTests below
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updated `DuckDbQueryRunner` and `CiderBatchChecker` to support 128-bit decimal types exported by DuckDb, including `HUGEINT` and `DECIMAL(a, b)` types (both stored as 128-bit integers in Arrow Array).

Both types are stored as 128-bit (16 byte) binaries in the exported array. For `HUGEINT`, we interpret it as an `int128` value, and compare to the `int64 ` value in Cider (we assume no overflow will occur in `int64`). For `DECIMAL`, we convert it to `double` and compare with the `double`values in Cider. Both comparisons are based on `ConcatenatedRow`s because direct `memcmp` will always fail as the size of arrow arrays are different.

NOTE: Current implementation is based on GCC's support for `__int128_t` types, and it may require GCC/Clang compilers to work properly.

### Why are the changes needed?

For supporting UTs that involved `HUGEINT` or `DECIMAL` results.

- `HUGEINT` is typically a result of summation over integer types (e.g. `SELECT SUM(int_col)`).
- `DECIMAL` is typically a result of ops between integer and decimals (e.g. `SELECT int_col + 0.123`).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests.

### Which label does this PR belong to?
