### PR TITLE
[POAE7-2470] Arrow STRING/VARCHAR support for DuckDb runner & CiderBatchChecker

### DIFF
--- a/cider/exec/module/batch/CiderBatchUtils.cpp
+++ b/cider/exec/module/batch/CiderBatchUtils.cpp
@@ -314,6 +314,8 @@ const char* convertSubstraitTypeToArrowType(const substrait::Type& type) {
     case Type::kDate:
       return "tdm";
     case Type::kVarchar:
+    case Type::kFixedChar:
+    case Type::kString:
       return "u";
     default:
       CIDER_THROW(CiderRuntimeException,

--- a/cider/tests/utils/CiderBatchChecker.cpp
+++ b/cider/tests/utils/CiderBatchChecker.cpp
@@ -298,6 +298,8 @@ bool CiderBatchChecker::checkOneStructBatchEqual(CiderBatch* expected_batch,
         // duckdb decimals use 16 bytes, but cider decimals use 8 bytes
         // therefore buffer compare will never pass, no need to check it
         return false;
+      case SQLTypes::kTEXT:
+      case SQLTypes::kCHAR:
       case SQLTypes::kVARCHAR:
         is_equal = checkOneVarcharBatchEqual(expected_child->as<VarcharBatch>(),
                                              actual_child->as<VarcharBatch>());

--- a/cider/tests/utils/CiderBatchChecker.h
+++ b/cider/tests/utils/CiderBatchChecker.h
@@ -206,6 +206,9 @@ class CiderBatchChecker {
   static bool checkOneStructBatchEqual(CiderBatch* expected_batch,
                                        CiderBatch* actual_batch);
 
+  static bool checkOneVarcharBatchEqual(const VarcharBatch* expected_batch,
+                                        const VarcharBatch* actual_batch);
+
   static bool checkByteArrayEqual(const int8_t* expected_buffer,
                                   const int64_t expected_buffer_offset,
                                   const int8_t* actual_buffer,

--- a/cider/tests/utils/CiderBatchCheckerTest.cpp
+++ b/cider/tests/utils/CiderBatchCheckerTest.cpp
@@ -30,19 +30,19 @@
 
 TEST(CiderBatchCheckerArrowTest, colNumCheck) {
   auto data = std::vector<int>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-  auto expected = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(10)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), data)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), data)
           .build());
-  auto actual_1 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual_1 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(10)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), data)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), data)
           .build());
-  auto actual_2 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual_2 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(10)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), data)
@@ -58,12 +58,12 @@ TEST(CiderBatchCheckerArrowTest, rowNumCheck) {
   auto data_1 = std::vector<int>{0, 1, 2, 3, 4};
   auto data_2 = std::vector<int>{0, 1, 2, 3, 4, 5};
 
-  auto expected = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), data_1)
           .build());
-  auto actual = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(6)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), data_2)
@@ -79,12 +79,12 @@ TEST(CiderBatchCheckerArrowTest, rowNumCheck) {
     auto nulls = std::vector<bool>{                                                    \
         false, true, false, true, false, true, false, true, false, true};              \
                                                                                        \
-    auto expected##C_TYPE = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(       \
+    auto expected##C_TYPE = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(       \
         ArrowArrayBuilder()                                                            \
             .setRowNum(10)                                                             \
             .addColumn<C_TYPE>("", CREATE_SUBSTRAIT_TYPE(SUBSTRAIT_TYPE), data, nulls) \
             .build());                                                                 \
-    auto actual##C_TYPE = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(         \
+    auto actual##C_TYPE = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(         \
         ArrowArrayBuilder()                                                            \
             .setRowNum(10)                                                             \
             .addColumn<C_TYPE>("", CREATE_SUBSTRAIT_TYPE(SUBSTRAIT_TYPE), data, nulls) \
@@ -114,23 +114,23 @@ TEST(CiderBatchCheckerArrowTest, booleanTest) {
   auto batch_null_2 =
       std::vector<bool>{true, false, true, false, true, false, true, false, true, false};
 
-  auto batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addBoolColumn<bool>("", batch_vec, batch_null)
           .addBoolColumn<bool>("", batch_vec)
           .build());
-  auto eq_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto eq_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addBoolColumn<bool>("", batch_vec, batch_null)
           .addBoolColumn<bool>("", batch_vec)
           .build());
-  auto neq_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto neq_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addBoolColumn<bool>("", std::vector<bool>(10, true), batch_null)
           .addBoolColumn<bool>("", std::vector<bool>(10, true))
           .build());
 
-  auto ignore_order_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto ignore_order_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addBoolColumn<bool>("", batch_vec_2, batch_null_2)
           .addBoolColumn("", batch_vec_2)
@@ -145,13 +145,13 @@ TEST(CiderBatchCheckerArrowTest, booleanTest) {
 
 TEST(CiderBatchCheckerArrowTest, rowValue) {
   std::vector<int> vec1{1, 2, 3, 4, 5};
-  auto expected_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addColumn<int>("int", CREATE_SUBSTRAIT_TYPE(I32), vec1)
           .build());
 
   std::vector<int> vec2{0, 2, 3, 4, 5};
-  auto actual_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addColumn<int>("int", CREATE_SUBSTRAIT_TYPE(I32), vec2)
           .build());
@@ -164,12 +164,12 @@ TEST(CiderBatchCheckerArrowTest, integerTypeCheck) {
   std::vector<int> vec1{1, 2, 3, 4, 5};
   std::vector<int64_t> vec2{1, 2, 3, 4, 5};
 
-  auto expected_batch1 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected_batch1 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addColumn<int>("int", CREATE_SUBSTRAIT_TYPE(I32), vec1)
           .build());
 
-  auto actual_batch1 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual_batch1 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addColumn<int64_t>("long", CREATE_SUBSTRAIT_TYPE(I64), vec2)
           .build());
@@ -177,13 +177,13 @@ TEST(CiderBatchCheckerArrowTest, integerTypeCheck) {
   EXPECT_TRUE(CiderBatchChecker::checkArrowEq(expected_batch1, actual_batch1));
   EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_batch1, expected_batch1));
 
-  auto expected_batch2 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected_batch2 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addColumn<int>("int", CREATE_SUBSTRAIT_TYPE(I32), vec1)
           .addColumn<int>("int", CREATE_SUBSTRAIT_TYPE(I32), vec1)
           .build());
 
-  auto actual_batch2 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual_batch2 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addColumn<int>("int", CREATE_SUBSTRAIT_TYPE(I32), vec1)
           .addColumn<int64_t>("long", CREATE_SUBSTRAIT_TYPE(I64), vec2)
@@ -197,12 +197,12 @@ TEST(CiderBatchCheckerArrowTest, floatTypeCheck) {
   std::vector<double> vec1{1, 2, 3, 4, 5};
   std::vector<float> vec2{1, 2, 3, 4, 5};
 
-  auto expected_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addColumn<double>("double", CREATE_SUBSTRAIT_TYPE(Fp64), vec1)
           .build());
 
-  auto actual_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .addColumn<float>("float", CREATE_SUBSTRAIT_TYPE(Fp32), vec2)
           .build());
@@ -219,13 +219,13 @@ TEST(CiderBatchCheckerArrowTest, nullTest) {
   auto no_null = std::vector<bool>(5, false);
 
   // no nulls
-  auto expected_1 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected_1 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int32_t>("", CREATE_SUBSTRAIT_TYPE(I32), data_int32, no_null)
           .addColumn<float>("", CREATE_SUBSTRAIT_TYPE(Fp32), data_fp32, no_null)
           .build());
-  auto actual_1 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual_1 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int32_t>("", CREATE_SUBSTRAIT_TYPE(I32), data_int32, no_null)
@@ -235,13 +235,13 @@ TEST(CiderBatchCheckerArrowTest, nullTest) {
   EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_1, expected_1));
 
   // all nulls
-  auto expected_2 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected_2 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int32_t>("", CREATE_SUBSTRAIT_TYPE(I32), data_int32, all_null)
           .addColumn<float>("", CREATE_SUBSTRAIT_TYPE(Fp32), data_fp32, all_null)
           .build());
-  auto actual_2 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual_2 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int32_t>("", CREATE_SUBSTRAIT_TYPE(I32), data_int32, all_null)
@@ -260,12 +260,12 @@ TEST(CiderBatchCheckerArrowTest, ignoreOrder) {
       std::vector<bool>{true, true, true, true, true, false, false, false, false, false};
 
   // different order, without nulls
-  auto expected_1 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected_1 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(10)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), vec_1)
           .build());
-  auto actual_1 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual_1 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(10)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), vec_2)
@@ -276,12 +276,12 @@ TEST(CiderBatchCheckerArrowTest, ignoreOrder) {
   EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_1, expected_1, true));
 
   // different order, with nulls
-  auto expected_2 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected_2 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(10)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), vec_1, nulls_1)
           .build());
-  auto actual_2 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto actual_2 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(10)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), vec_2, nulls_2)
@@ -302,7 +302,7 @@ TEST(CiderBatchCheckerArrowTest, multiBatches) {
   auto nulls =
       std::vector<bool>{true, true, false, false, false, false, false, false, true, true};
 
-  auto one_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto one_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(10)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), vec, nulls)
@@ -312,22 +312,22 @@ TEST(CiderBatchCheckerArrowTest, multiBatches) {
   std::vector<std::shared_ptr<CiderBatch>> many_batches_1;
   // different order
   std::vector<std::shared_ptr<CiderBatch>> many_batches_2;
-  auto manys_1 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto manys_1 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), vec_1, nulls_1)
           .build());
-  auto manys_2 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto manys_2 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), vec_2, nulls_2)
           .build());
-  auto manys_3 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto manys_3 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), vec_1, nulls_1)
           .build());
-  auto manys_4 = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto manys_4 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int>("", CREATE_SUBSTRAIT_TYPE(I32), vec_2, nulls_2)
@@ -354,9 +354,146 @@ TEST(CiderBatchCheckerArrowTest, multiBatches) {
   EXPECT_TRUE(CiderBatchChecker::checkArrowEq(many_batches_1, many_batches_2, true));
 }
 
-/// TODO: (YBRua) tests to be added
-/// 1. VarChar tests
-/// 2. date / time tests
+TEST(CiderBatchCheckerArrowTest, UTF8CharTest) {
+  // common resource
+  auto vec = std::vector<std::string>{"aaaaa", "bbbbb", "aaaaabbbbb"};
+  auto [data, offsets] = ArrowBuilderUtils::createDataAndOffsetFromStrVector(vec);
+  auto expected_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+      ArrowArrayBuilder().setRowNum(3).addUTF8Column("col_str", data, offsets).build());
+
+  // one to one ordered
+  {
+    auto actual_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+        ArrowArrayBuilder().setRowNum(3).addUTF8Column("col_str", data, offsets).build());
+
+    EXPECT_TRUE(CiderBatchChecker::checkArrowEq(expected_batch, actual_batch));
+    EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_batch, expected_batch));
+  }
+
+  // one to one non-ordered
+  {
+    auto vec = std::vector<std::string>{"aaaaabbbbb", "bbbbb", "aaaaa"};
+    auto [data, offsets] = ArrowBuilderUtils::createDataAndOffsetFromStrVector(vec);
+
+    auto actual_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+        ArrowArrayBuilder().setRowNum(3).addUTF8Column("col_str", data, offsets).build());
+
+    EXPECT_FALSE(CiderBatchChecker::checkArrowEq(expected_batch, actual_batch));
+    EXPECT_FALSE(CiderBatchChecker::checkArrowEq(actual_batch, expected_batch));
+    EXPECT_TRUE(CiderBatchChecker::checkArrowEq(expected_batch, actual_batch, true));
+    EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_batch, expected_batch, true));
+  }
+
+  // not equal
+  {
+    auto vec = std::vector<std::string>{"ababa", "babab", "aaaababbbb"};
+    auto [data, offsets] = ArrowBuilderUtils::createDataAndOffsetFromStrVector(vec);
+
+    auto actual_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+        ArrowArrayBuilder().setRowNum(3).addUTF8Column("col_str", data, offsets).build());
+
+    EXPECT_FALSE(CiderBatchChecker::checkArrowEq(expected_batch, actual_batch));
+    EXPECT_FALSE(CiderBatchChecker::checkArrowEq(actual_batch, expected_batch));
+  }
+
+  // bad offset
+  {
+    auto vec = std::vector<std::string>{"aaaaab", "bbbb", "aaaaabbbbb"};
+    auto [data, offsets] = ArrowBuilderUtils::createDataAndOffsetFromStrVector(vec);
+
+    auto actual_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+        ArrowArrayBuilder().setRowNum(3).addUTF8Column("col_str", data, offsets).build());
+
+    EXPECT_FALSE(CiderBatchChecker::checkArrowEq(expected_batch, actual_batch));
+    EXPECT_FALSE(CiderBatchChecker::checkArrowEq(actual_batch, expected_batch));
+  }
+
+  // null value
+  {
+    auto vec = std::vector<std::string>{"aaaaa", "bbbbb", "aaaaabbbbb", "ccccc"};
+    auto nulls = std::vector<bool>{false, false, false, true};
+    auto [data, offsets] = ArrowBuilderUtils::createDataAndOffsetFromStrVector(vec);
+
+    auto expected_batch_nulls = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+        ArrowArrayBuilder()
+            .setRowNum(4)
+            .addUTF8Column("col_str", data, offsets, nulls)
+            .build());
+    auto actual_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+        ArrowArrayBuilder()
+            .setRowNum(4)
+            .addUTF8Column("col_str", data, offsets, nulls)
+            .build());
+
+    EXPECT_TRUE(CiderBatchChecker::checkArrowEq(expected_batch_nulls, actual_batch));
+    EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_batch, expected_batch_nulls));
+  }
+
+  // data for more complex cases
+  auto vec_batch_1 = std::vector<std::string>{"bbbbb", "aaaaa"};
+  auto vec_batch_2 = std::vector<std::string>{"aaaaabbbbb"};
+  std::vector<std::shared_ptr<CiderBatch>> actual_vecs_1;
+
+  auto [data_1, offsets_1] =
+      ArrowBuilderUtils::createDataAndOffsetFromStrVector(vec_batch_1);
+  auto [data_2, offsets_2] =
+      ArrowBuilderUtils::createDataAndOffsetFromStrVector(vec_batch_2);
+
+  auto actual_batch_1 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+      ArrowArrayBuilder()
+          .setRowNum(2)
+          .addUTF8Column("col_str", data_1, offsets_1)
+          .build());
+  auto actual_batch_2 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+      ArrowArrayBuilder()
+          .setRowNum(1)
+          .addUTF8Column("col_str", data_2, offsets_2)
+          .build());
+
+  actual_vecs_1.emplace_back(actual_batch_1);
+  actual_vecs_1.emplace_back(actual_batch_2);
+
+  auto vec_batch_3 = std::vector<std::string>{"bbbbb", "aaaaabbbbb"};
+  auto vec_batch_4 = std::vector<std::string>{"aaaaa"};
+  std::vector<std::shared_ptr<CiderBatch>> actual_vecs_2;
+
+  auto [data_3, offsets_3] =
+      ArrowBuilderUtils::createDataAndOffsetFromStrVector(vec_batch_3);
+  auto [data_4, offsets_4] =
+      ArrowBuilderUtils::createDataAndOffsetFromStrVector(vec_batch_4);
+
+  auto actual_batch_3 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+      ArrowArrayBuilder()
+          .setRowNum(2)
+          .addUTF8Column("col_str", data_3, offsets_3)
+          .build());
+  auto actual_batch_4 = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+      ArrowArrayBuilder()
+          .setRowNum(1)
+          .addUTF8Column("col_str", data_4, offsets_4)
+          .build());
+
+  actual_vecs_2.emplace_back(actual_batch_3);
+  actual_vecs_2.emplace_back(actual_batch_4);
+
+  // one to many non-ordered
+  EXPECT_FALSE(CiderBatchChecker::checkArrowEq(expected_batch, actual_vecs_1));
+  EXPECT_FALSE(CiderBatchChecker::checkArrowEq(expected_batch, actual_vecs_2));
+  EXPECT_TRUE(CiderBatchChecker::checkArrowEq(expected_batch, actual_vecs_1, true));
+  EXPECT_TRUE(CiderBatchChecker::checkArrowEq(expected_batch, actual_vecs_2, true));
+
+  // many to one non-ordered
+  EXPECT_FALSE(CiderBatchChecker::checkArrowEq(actual_vecs_1, expected_batch));
+  EXPECT_FALSE(CiderBatchChecker::checkArrowEq(actual_vecs_2, expected_batch));
+  EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_vecs_1, expected_batch, true));
+  EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_vecs_2, expected_batch, true));
+
+  // many to many non-ordered
+  EXPECT_FALSE(CiderBatchChecker::checkArrowEq(actual_vecs_1, actual_vecs_2));
+  EXPECT_FALSE(CiderBatchChecker::checkArrowEq(actual_vecs_2, actual_vecs_1));
+  EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_vecs_1, actual_vecs_2, true));
+  EXPECT_TRUE(CiderBatchChecker::checkArrowEq(actual_vecs_2, actual_vecs_1, true));
+}
 
 // Old CiderBatch tests below
 

--- a/cider/tests/utils/CiderBatchStringifier.cpp
+++ b/cider/tests/utils/CiderBatchStringifier.cpp
@@ -77,7 +77,7 @@ std::string StructBatchStringifier::stringifyValueAt(CiderBatch* batch, int row_
     CIDER_THROW(CiderRuntimeException, "StructBatch is nullptr.");
   }
 
-  auto valid_bitmap = batch->getNulls();
+  const uint8_t* valid_bitmap = batch->getNulls();
   if (valid_bitmap && !CiderBitUtils::isBitSetAt(valid_bitmap, row_index)) {
     // this usually should not happen, values in struct batch are expected to be valid
     // but just in case
@@ -91,20 +91,22 @@ std::string StructBatchStringifier::stringifyValueAt(CiderBatch* batch, int row_
   for (auto col_index = 0; col_index < col_num; ++col_index) {
     auto child = batch->getChildAt(col_index);
     auto& col_stringifier = child_stringifiers_[col_index];
-    auto value_str = col_stringifier->stringifyValueAt(child.get(), row_index);
+    std::string value_str = col_stringifier->stringifyValueAt(child.get(), row_index);
     row.addCol(value_str);
   }
   row.finish();
   return row.getString();
 }
 
-uint8_t DecimalBatchStringifier::getScale(const ScalarBatch<__int128_t>* batch) {
+const uint8_t DecimalBatchStringifier::getScale(
+    const ScalarBatch<__int128_t>* batch) const {
   auto type_str = std::string(batch->getArrowFormatString());
   uint8_t scale = std::stoi(type_str.substr(type_str.find(',') + 1));
   return scale;
 }
 
-uint8_t DecimalBatchStringifier::getPrecision(const ScalarBatch<__int128_t>* batch) {
+const uint8_t DecimalBatchStringifier::getPrecision(
+    const ScalarBatch<__int128_t>* batch) const {
   auto type_str = std::string(batch->getArrowFormatString());
   auto start = type_str.find(':') + 1;
   auto end = type_str.find(',');
@@ -119,10 +121,10 @@ std::string DecimalBatchStringifier::stringifyValueAt(CiderBatch* batch, int row
                 "ScalarBatch is nullptr, maybe check your casting?");
   }
 
-  auto scale = getScale(scalar_batch);
-  auto precision = getPrecision(scalar_batch);
-  auto data_buffer = scalar_batch->getRawData();
-  auto valid_bitmap = scalar_batch->getNulls();
+  const uint8_t scale = getScale(scalar_batch);
+  const uint8_t precision = getPrecision(scalar_batch);
+  const __int128_t* data_buffer = scalar_batch->getRawData();
+  const uint8_t* valid_bitmap = scalar_batch->getNulls();
 
   if (valid_bitmap && !CiderBitUtils::isBitSetAt(valid_bitmap, row_index)) {
     return NULL_VALUE;
@@ -154,8 +156,8 @@ std::string ScalarBatchStringifier<T>::stringifyValueAt(CiderBatch* batch,
                 "ScalarBatch is nullptr, maybe check your casting?");
   }
 
-  auto data_buffer = scalar_batch->getRawData();
-  auto valid_bitmap = scalar_batch->getNulls();
+  const T* data_buffer = scalar_batch->getRawData();
+  const uint8_t* valid_bitmap = scalar_batch->getNulls();
 
   if (valid_bitmap && !CiderBitUtils::isBitSetAt(valid_bitmap, row_index)) {
     return NULL_VALUE;
@@ -174,8 +176,8 @@ std::string ScalarBatchStringifier<float>::stringifyValueAt(CiderBatch* batch,
                 "ScalarBatch is nullptr, maybe check your casting?");
   }
 
-  auto data_buffer = scalar_batch->getRawData();
-  auto valid_bitmap = scalar_batch->getNulls();
+  const float* data_buffer = scalar_batch->getRawData();
+  const uint8_t* valid_bitmap = scalar_batch->getNulls();
 
   if (valid_bitmap && !CiderBitUtils::isBitSetAt(valid_bitmap, row_index)) {
     return NULL_VALUE;
@@ -197,8 +199,8 @@ std::string ScalarBatchStringifier<double>::stringifyValueAt(CiderBatch* batch,
                 "ScalarBatch is nullptr, maybe check your casting?");
   }
 
-  auto data_buffer = scalar_batch->getRawData();
-  auto valid_bitmap = scalar_batch->getNulls();
+  const double* data_buffer = scalar_batch->getRawData();
+  const uint8_t* valid_bitmap = scalar_batch->getNulls();
 
   if (valid_bitmap && !CiderBitUtils::isBitSetAt(valid_bitmap, row_index)) {
     return NULL_VALUE;
@@ -220,8 +222,8 @@ std::string ScalarBatchStringifier<bool>::stringifyValueAt(CiderBatch* batch,
                 "ScalarBatch is nullptr, maybe check your casting?");
   }
 
-  auto data_buffer = scalar_batch->getRawData();
-  auto valid_bitmap = scalar_batch->getNulls();
+  const uint8_t* data_buffer = scalar_batch->getRawData();
+  const uint8_t* valid_bitmap = scalar_batch->getNulls();
 
   if (valid_bitmap && !CiderBitUtils::isBitSetAt(valid_bitmap, row_index)) {
     return NULL_VALUE;
@@ -238,22 +240,17 @@ std::string VarcharBatchStringifier::stringifyValueAt(CiderBatch* batch, int row
                 "ScalarBatch is nullptr, maybe check your casting?");
   }
 
-  auto data_buffer = varchar_batch->getRawData();
-  auto offset_buffer = varchar_batch->getRawOffset();
-  auto valid_bitmap = varchar_batch->getNulls();
+  const uint8_t* data_buffer = varchar_batch->getRawData();
+  const int32_t* offset_buffer = varchar_batch->getRawOffset();
+  const uint8_t* valid_bitmap = varchar_batch->getNulls();
 
   if (valid_bitmap && !CiderBitUtils::isBitSetAt(valid_bitmap, row_index)) {
     return NULL_VALUE;
   } else {
-    auto start = offset_buffer[row_index];
-    auto end = offset_buffer[row_index + 1];
-    auto len = end - start;
-    char str_buffer[len + 1];
+    int32_t start = offset_buffer[row_index];
+    int32_t end = offset_buffer[row_index + 1];
+    int32_t len = end - start;
 
-    // copy char values and append \0
-    memcpy(&str_buffer, data_buffer + start, len);
-    str_buffer[len] = '\0';
-
-    return std::string(str_buffer);
+    return std::string(reinterpret_cast<const char*>(data_buffer) + start, len);
   }
 }

--- a/cider/tests/utils/CiderBatchStringifier.cpp
+++ b/cider/tests/utils/CiderBatchStringifier.cpp
@@ -247,11 +247,11 @@ std::string VarcharBatchStringifier::stringifyValueAt(CiderBatch* batch, int row
   } else {
     auto start = offset_buffer[row_index];
     auto end = offset_buffer[row_index + 1];
-    auto len = offset_buffer[row_index + 1] - offset_buffer[row_index];
+    auto len = end - start;
     char str_buffer[len + 1];
 
     // copy char values and append \0
-    memcpy(&str_buffer, &data_buffer[start], len);
+    memcpy(&str_buffer, data_buffer + start, len);
     str_buffer[len] = '\0';
 
     return std::string(str_buffer);

--- a/cider/tests/utils/CiderBatchStringifier.h
+++ b/cider/tests/utils/CiderBatchStringifier.h
@@ -53,8 +53,8 @@ class ScalarBatchStringifier : public CiderBatchStringifier {
 // so we use gcc's __int128_t to directly decode the values in arrow array
 class DecimalBatchStringifier : public CiderBatchStringifier {
  private:
-  uint8_t getScale(const ScalarBatch<__int128_t>* batch);
-  uint8_t getPrecision(const ScalarBatch<__int128_t>* batch);
+  const uint8_t getScale(const ScalarBatch<__int128_t>* batch) const;
+  const uint8_t getPrecision(const ScalarBatch<__int128_t>* batch) const;
 
  public:
   std::string stringifyValueAt(CiderBatch* batch, int row_index) override;

--- a/cider/tests/utils/CiderBatchStringifier.h
+++ b/cider/tests/utils/CiderBatchStringifier.h
@@ -60,4 +60,9 @@ class DecimalBatchStringifier : public CiderBatchStringifier {
   std::string stringifyValueAt(CiderBatch* batch, int row_index) override;
 };
 
+class VarcharBatchStringifier : public CiderBatchStringifier {
+ public:
+  std::string stringifyValueAt(CiderBatch* batch, int row_index) override;
+};
+
 #endif

--- a/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -329,9 +329,9 @@ void DuckDbQueryRunner::createTableAndInsertArrowData(
       for (int col_idx = 0; col_idx < col_num; ++col_idx) {
         auto child = current_batch->getChildAt(col_idx);
         auto child_type = child->getCiderType();
-        auto valid_bitmap = child->getNulls();
+        const uint8_t* valid_bitmap = child->getNulls();
         if (!valid_bitmap || CiderBitUtils::isBitSetAt(valid_bitmap, row_idx)) {
-          auto value = GEN_DUCK_DB_VALUE_FROM_ARROW_FUNC();
+          ::duckdb::Value value = GEN_DUCK_DB_VALUE_FROM_ARROW_FUNC();
           appender.Append(value);
         } else {
           appender.Append(nullptr);
@@ -492,7 +492,7 @@ void addColumnDataToCiderBatch<CiderByteArray>(
 void DuckDbResultConvertor::updateChildrenNullCounts(CiderBatch& batch) {
   for (int i = 0; i < batch.getChildrenNum(); ++i) {
     auto child = batch.getChildAt(i);
-    auto validity_map = child->getNulls();
+    const uint8_t* validity_map = child->getNulls();
     int null_count = 0;
     if (validity_map) {
       for (int j = 0; j < batch.getLength(); ++j) {

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -212,7 +212,7 @@ TEST(DuckDBArrowQueryRunnerTest, HugeIntTest) {
   std::vector<int> expected_data{0, 1, 2, 3, 4};
   std::vector<bool> null_vecs{false, false, false, true, true};
 
-  auto input_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto input_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int>("col_a", CREATE_SUBSTRAIT_TYPE(I32), expected_data)
@@ -230,7 +230,7 @@ TEST(DuckDBArrowQueryRunnerTest, HugeIntTest) {
 
   auto actual_batches = DuckDbResultConvertor::fetchDataToArrowFormattedCiderBatch(res);
 
-  auto expected_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(1)
           .addColumn<int64_t>("r1", CREATE_SUBSTRAIT_TYPE(I64), std::vector<int64_t>{10})
@@ -245,7 +245,7 @@ TEST(DuckDBArrowQueryRunnerTest, FixedPointDecimalTest) {
   std::vector<int> expected_data{0, 1, 2, 3, 4};
   std::vector<bool> null_vecs{false, false, false, true, true};
 
-  auto input_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto input_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<int>("col_a", CREATE_SUBSTRAIT_TYPE(I32), expected_data)
@@ -267,7 +267,7 @@ TEST(DuckDBArrowQueryRunnerTest, FixedPointDecimalTest) {
 
   auto res_a = std::vector<double>{0.123, 1.123, 2.123, 3.123, 4.123};
   auto res_b = std::vector<double>{0.2, 0.7, 1.2, 1.7, 2.2};
-  auto expected_batch = ArrowToCiderBatch::createCiderBatchFromArrowBuilder(
+  auto expected_batch = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
       ArrowArrayBuilder()
           .setRowNum(5)
           .addColumn<double>("r1", CREATE_SUBSTRAIT_TYPE(Fp64), res_a)
@@ -277,8 +277,6 @@ TEST(DuckDBArrowQueryRunnerTest, FixedPointDecimalTest) {
   EXPECT_TRUE(CiderBatchChecker::checkArrowEq(expected_batch, actual_batches));
 }
 
-/// TODO: (YBRua) tests to be added
-/// 1. VarChar tests
 TEST(DuckDBArrowQueryRunnerTest, VarCharTest) {
   DuckDbQueryRunner runner;
 

--- a/cider/tests/utils/DuckDbQueryRunnerTest.cpp
+++ b/cider/tests/utils/DuckDbQueryRunnerTest.cpp
@@ -322,8 +322,9 @@ TEST(DuckDBArrowQueryRunnerTest, VarCharStringCompatTest) {
       GeneratePattern::Random,
       0,
       10);
-  
-  auto batch = std::make_shared<CiderBatch>(schema, array, std::make_shared<CiderDefaultAllocator>());
+
+  auto batch = std::make_shared<CiderBatch>(
+      schema, array, std::make_shared<CiderDefaultAllocator>());
 
   std::string table_name = "table_test";
   std::string create_ddl = "CREATE TABLE table_test(col_a VARCHAR, col_b STRING)";

--- a/cider/tests/utils/QueryArrowDataGenerator.h
+++ b/cider/tests/utils/QueryArrowDataGenerator.h
@@ -116,6 +116,8 @@ class QueryArrowDataGenerator {
         case ::substrait::Type::KindCase::kFp64:
           GENERATE_AND_ADD_COLUMN(double)
         case ::substrait::Type::KindCase::kString:
+        case ::substrait::Type::KindCase::kVarchar:
+        case ::substrait::Type::KindCase::kFixedChar:
           GENERATE_AND_ADD_UTF8_COLUMN()
         default:
           CIDER_THROW(CiderCompileException, "Type not supported.");

--- a/cider/tests/utils/Utils.h
+++ b/cider/tests/utils/Utils.h
@@ -141,7 +141,7 @@ class SchemaUtils {
   }
 };
 
-class ArrowToCiderBatch {
+class ArrowBuilderUtils {
  public:
   static std::shared_ptr<CiderBatch> createCiderBatchFromArrowBuilder(
       std::tuple<ArrowSchema*&, ArrowArray*&> array_with_schema) {
@@ -152,10 +152,18 @@ class ArrowToCiderBatch {
     return std::make_shared<CiderBatch>(
         schema, array, std::make_shared<CiderDefaultAllocator>());
   }
-};
 
-std::shared_ptr<CiderBatch> createSimpleBooleanTestData(
-    const std::vector<bool>& data = {},
-    const std::vector<bool>& null = {});
+  static std::tuple<std::string, std::vector<int32_t>> createDataAndOffsetFromStrVector(
+      const std::vector<std::string>& input) {
+    std::vector<int32_t> offsets{0};
+    std::string str_buffer;
+    for (auto& s : input) {
+      str_buffer = str_buffer + s;
+      offsets.push_back(offsets.back() + s.size());
+    }
+
+    return {str_buffer, offsets};
+  }
+};
 
 #endif  // CIDER_UTILS_H


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Updated `DuckDbQueryRunner` and `CiderBatchChecker` support for arrow-formatted UTF-8 char sequences.
  - Supports inserting/fetching string arrow arrays into/from DuckDb databases
  - Supports checking validity, offset and data buffer of UTF-8 arrow arrays
- Fixed STRING/VARCHAR compatibility issues in `QueryArrowDataGenerator`
- Renamed helper class `ArrowToCiderBatch` to `ArrowBuilderUtils` in `Utils.h`

### Why are the changes needed?

Part of UT framework migration to arrow format.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit tests.

### Which label does this PR belong to?

