### PR TITLE
[POAE7-2479] Use CiderBatch as data type for join bridge to bypass existing Velox memory ownership mechnism

### DIFF
--- a/cider-velox/src/CiderJoinBuild.h
+++ b/cider-velox/src/CiderJoinBuild.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "CiderPlanNode.h"
+#include "cider/CiderInterface.h"
 #include "velox/exec/JoinBridge.h"
 #include "velox/exec/Operator.h"
 
@@ -31,12 +32,12 @@ namespace facebook::velox::plugin {
 // multi-threaded probe pipeline.
 class CiderJoinBridge : public exec::JoinBridge {
  public:
-  void setData(std::vector<VectorPtr> data);
+  void setData(CiderBatch& data);
 
-  std::optional<std::vector<VectorPtr>> dataOrFuture(ContinueFuture* future);
+  std::optional<CiderBatch> dataOrFuture(ContinueFuture* future);
 
  private:
-  std::optional<std::vector<VectorPtr>> data_;
+  std::optional<CiderBatch> data_;
 };
 
 class CiderJoinBuild : public exec::Operator {
@@ -66,6 +67,9 @@ class CiderJoinBuild : public exec::Operator {
   // Future for synchronizing with other Drivers of the same pipeline. All build
   // Drivers must be completed before making the hash table.
   ContinueFuture future_{ContinueFuture::makeEmpty()};
+
+  std::shared_ptr<DataConvertor> dataConvertor_;
+  std::chrono::microseconds convertorInternalCounter;
 
   std::vector<VectorPtr> data_;
 };

--- a/cider-velox/src/CiderOperator.h
+++ b/cider-velox/src/CiderOperator.h
@@ -62,7 +62,7 @@ class CiderOperator : public exec::Operator {
   std::chrono::microseconds convertorInternalCounter;
 
   // these properties are used for join with w/o agg case
-  std::optional<std::vector<VectorPtr>> buildData_;
+  std::optional<CiderBatch> buildData_;
   bool buildSideEmpty_{false};
   bool buildTableFed_{false};
   bool finished_{false};

--- a/cider-velox/test/CiderOperatorHashJoinTest.cpp
+++ b/cider-velox/test/CiderOperatorHashJoinTest.cpp
@@ -80,15 +80,17 @@ class CiderOperatorHashJoinTest : public CiderOperatorTestBase {
 
     auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
 
-    auto planNode =
-        PlanBuilder(planNodeIdGenerator)
-            .values({leftBatch})
-            .hashJoin(makeKeyNames(keyTypes.size(), "t_"),
-                      makeKeyNames(keyTypes.size(), "u_"),
-                      PlanBuilder(planNodeIdGenerator).values({rightBatch}).planNode(),
-                      filter,
-                      concat(leftType->names(), rightType->names()))
-            .planNode();
+    auto planNode = PlanBuilder(planNodeIdGenerator)
+                        .values({leftBatch})
+                        .hashJoin(makeKeyNames(keyTypes.size(), "t_"),
+                                  makeKeyNames(keyTypes.size(), "u_"),
+                                  PlanBuilder(planNodeIdGenerator)
+                                      .values({rightBatch})
+                                      .project(rightType->names())
+                                      .planNode(),
+                                  filter,
+                                  concat(leftType->names(), rightType->names()))
+                        .planNode();
 
     createDuckDbTable("t", {leftBatch});
     createDuckDbTable("u", {rightBatch});


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make CiderJoinBridge to deliver CiderBatch.


### Why are the changes needed?
Upstream op will destroy CiderBatch after it closed which may cause memory issue for downstream op.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing UT. 

### Which label does this PR belong to?
veloxIntegration
