### PR TITLE
[POAE7-2528] JITValue Compare and Logical Operations Support

### DIFF
--- a/cider/exec/nextgen/jitlib/base/JITValue.h
+++ b/cider/exec/nextgen/jitlib/base/JITValue.h
@@ -81,8 +81,8 @@ class JITValue {
   virtual JITValue& assign(JITValue& value) = 0;
 
   // // Logical Operators
-  // virtual JITValuePointer andOp(JITValue& rh) = 0;
-  // virtual JITValuePointer orOp(JITValue& rh) = 0;
+  virtual JITValuePointer andOp(JITValue& rh) = 0;
+  virtual JITValuePointer orOp(JITValue& rh) = 0;
   virtual JITValuePointer notOp() = 0;
 
   // // Arithmetic Operations
@@ -94,12 +94,12 @@ class JITValue {
   virtual JITValuePointer mod(JITValue& rh) = 0;
 
   // // Compare Operators
-  // virtual JITValuePointer eq(JITValue& rh) = 0;
-  // virtual JITValuePointer ne(JITValue& rh) = 0;
-  // virtual JITValuePointer lt(JITValue& rh) = 0;
-  // virtual JITValuePointer le(JITValue& rh) = 0;
-  // virtual JITValuePointer gt(JITValue& rh) = 0;
-  // virtual JITValuePointer ge(JITValue& rh) = 0;
+  virtual JITValuePointer eq(JITValue& rh) = 0;
+  virtual JITValuePointer ne(JITValue& rh) = 0;
+  virtual JITValuePointer lt(JITValue& rh) = 0;
+  virtual JITValuePointer le(JITValue& rh) = 0;
+  virtual JITValuePointer gt(JITValue& rh) = 0;
+  virtual JITValuePointer ge(JITValue& rh) = 0;
 
  private:
   std::string value_name_;

--- a/cider/exec/nextgen/jitlib/base/JITValueOperations.h
+++ b/cider/exec/nextgen/jitlib/base/JITValueOperations.h
@@ -65,6 +65,42 @@ inline std::any castConstant(JITTypeTag target_type, T value) {
 }
 };  // namespace op_utils
 
+JITValuePointer operator&&(JITValue& lh, JITValue& rh) {
+  return lh.andOp(rh);
+}
+
+JITValuePointer operator&&(JITValue& lh, bool rh) {
+  auto& parent_func = lh.getParentJITFunction();
+  auto type = lh.getValueTypeTag();
+  JITValuePointer rh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, rh));
+  return lh && *rh_pointer;
+}
+
+JITValuePointer operator&&(bool lh, JITValue& rh) {
+  return rh && lh;
+}
+
+JITValuePointer operator||(JITValue& lh, JITValue& rh) {
+  return lh.orOp(rh);
+}
+
+JITValuePointer operator||(JITValue& lh, bool rh) {
+  auto& parent_func = lh.getParentJITFunction();
+  auto type = lh.getValueTypeTag();
+  JITValuePointer rh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, rh));
+  return lh || *rh_pointer;
+}
+
+JITValuePointer operator||(bool lh, JITValue& rh) {
+  return rh || lh;
+}
+
+JITValuePointer operator!(JITValue& value) {
+  return value.notOp();
+}
+
 JITValuePointer operator+(JITValue& lh, JITValue& rh) {
   return lh.add(rh);
 }
@@ -167,8 +203,128 @@ JITValuePointer operator%(T lh, JITValue& rh) {
   return *lh_pointer % rh;
 }
 
-JITValuePointer operator!(JITValue& value) {
-  return value.notOp();
+JITValuePointer operator==(JITValue& lh, JITValue& rh) {
+  return lh.eq(rh);
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator==(JITValue& lh, T rh) {
+  auto& parent_func = lh.getParentJITFunction();
+  auto type = lh.getValueTypeTag();
+  JITValuePointer rh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, rh));
+  return lh == *rh_pointer;
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator==(T lh, JITValue& rh) {
+  return lh == rh;
+}
+
+JITValuePointer operator!=(JITValue& lh, JITValue& rh) {
+  return lh.ne(rh);
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator!=(JITValue& lh, T rh) {
+  auto& parent_func = lh.getParentJITFunction();
+  auto type = lh.getValueTypeTag();
+  JITValuePointer rh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, rh));
+  return lh != *rh_pointer;
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator!=(T lh, JITValue& rh) {
+  return lh != rh;
+}
+
+JITValuePointer operator<(JITValue& lh, JITValue& rh) {
+  return lh.lt(rh);
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator<(JITValue& lh, T rh) {
+  auto& parent_func = lh.getParentJITFunction();
+  auto type = lh.getValueTypeTag();
+  JITValuePointer rh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, rh));
+  return lh < *rh_pointer;
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator<(T lh, JITValue& rh) {
+  auto& parent_func = rh.getParentJITFunction();
+  auto type = rh.getValueTypeTag();
+  JITValuePointer lh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, lh));
+  return *lh_pointer < rh;
+}
+
+JITValuePointer operator<=(JITValue& lh, JITValue& rh) {
+  return lh.le(rh);
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator<=(JITValue& lh, T rh) {
+  auto& parent_func = lh.getParentJITFunction();
+  auto type = lh.getValueTypeTag();
+  JITValuePointer rh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, rh));
+  return lh <= *rh_pointer;
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator<=(T lh, JITValue& rh) {
+  auto& parent_func = rh.getParentJITFunction();
+  auto type = rh.getValueTypeTag();
+  JITValuePointer lh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, lh));
+  return *lh_pointer <= rh;
+}
+
+JITValuePointer operator>(JITValue& lh, JITValue& rh) {
+  return lh.gt(rh);
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator>(JITValue& lh, T rh) {
+  auto& parent_func = lh.getParentJITFunction();
+  auto type = lh.getValueTypeTag();
+  JITValuePointer rh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, rh));
+  return lh > *rh_pointer;
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator>(T lh, JITValue& rh) {
+  auto& parent_func = rh.getParentJITFunction();
+  auto type = rh.getValueTypeTag();
+  JITValuePointer lh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, lh));
+  return *lh_pointer > rh;
+}
+
+JITValuePointer operator>=(JITValue& lh, JITValue& rh) {
+  return lh.ge(rh);
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator>=(JITValue& lh, T rh) {
+  auto& parent_func = lh.getParentJITFunction();
+  auto type = lh.getValueTypeTag();
+  JITValuePointer rh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, rh));
+  return lh >= *rh_pointer;
+}
+
+template <typename T, IsJITValueConvertable<T> = true>
+JITValuePointer operator>=(T lh, JITValue& rh) {
+  auto& parent_func = rh.getParentJITFunction();
+  auto type = rh.getValueTypeTag();
+  JITValuePointer lh_pointer =
+      parent_func.createConstant(type, op_utils::castConstant(type, lh));
+  return *lh_pointer >= rh;
 }
 
 };  // namespace cider::jitlib

--- a/cider/exec/nextgen/jitlib/base/JITValueOperations.h
+++ b/cider/exec/nextgen/jitlib/base/JITValueOperations.h
@@ -218,7 +218,7 @@ JITValuePointer operator==(JITValue& lh, T rh) {
 
 template <typename T, IsJITValueConvertable<T> = true>
 JITValuePointer operator==(T lh, JITValue& rh) {
-  return lh == rh;
+  return rh == lh;
 }
 
 JITValuePointer operator!=(JITValue& lh, JITValue& rh) {
@@ -236,7 +236,7 @@ JITValuePointer operator!=(JITValue& lh, T rh) {
 
 template <typename T, IsJITValueConvertable<T> = true>
 JITValuePointer operator!=(T lh, JITValue& rh) {
-  return lh != rh;
+  return rh != lh;
 }
 
 JITValuePointer operator<(JITValue& lh, JITValue& rh) {

--- a/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
+++ b/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
@@ -45,7 +45,7 @@ JITValuePointer LLVMJITValue::andOp(JITValue& rh) {
       ans = getFunctionBuilder(parent_function_).CreateAnd(load(), llvm_rh.load());
       break;
     default:
-      LOG(FATAL) << "Invalid JITValue type for not operation. Name=" << getValueName()
+      LOG(FATAL) << "Invalid JITValue type for and operation. Name=" << getValueName()
                  << ", Type=" << getJITTypeName(getValueTypeTag()) << ".";
   }
 
@@ -61,7 +61,7 @@ JITValuePointer LLVMJITValue::orOp(JITValue& rh) {
       ans = getFunctionBuilder(parent_function_).CreateOr(load(), llvm_rh.load());
       break;
     default:
-      LOG(FATAL) << "Invalid JITValue type for not operation. Name=" << getValueName()
+      LOG(FATAL) << "Invalid JITValue type for or operation. Name=" << getValueName()
                  << ", Type=" << getJITTypeName(getValueTypeTag()) << ".";
   }
 
@@ -126,7 +126,7 @@ JITValuePointer LLVMJITValue::div(JITValue& rh) {
       ans = getFunctionBuilder(parent_function_).CreateFDiv(load(), llvm_rh.load());
       break;
     default:
-      LOG(FATAL) << "Invalid JITValue type for mul operation. Name=" << getValueName()
+      LOG(FATAL) << "Invalid JITValue type for div operation. Name=" << getValueName()
                  << ", Type=" << getJITTypeName(getValueTypeTag()) << ".";
   }
 
@@ -231,7 +231,7 @@ JITValuePointer LLVMJITValue::createCmpInstruction(llvm::CmpInst::Predicate ICmp
                 .CreateFCmp(FCmpType, load(), llvm_rh.load());
       break;
     default:
-      LOG(FATAL) << "Invalid JITValue type for add operation. Name=" << getValueName()
+      LOG(FATAL) << "Invalid JITValue type for compare operation. Name=" << getValueName()
                  << ", Type=" << getJITTypeName(getValueTypeTag()) << ".";
   }
 

--- a/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.h
+++ b/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.h
@@ -46,6 +46,8 @@ class LLVMJITValue final : public JITValue {
  public:
   JITValue& assign(JITValue& value) override;
 
+  JITValuePointer andOp(JITValue& rh) override;
+  JITValuePointer orOp(JITValue& rh) override;
   JITValuePointer notOp() override;
 
   JITValuePointer add(JITValue& rh) override;
@@ -54,10 +56,22 @@ class LLVMJITValue final : public JITValue {
   JITValuePointer div(JITValue& rh) override;
   JITValuePointer mod(JITValue& rh) override;
 
+  JITValuePointer eq(JITValue& rh) override;
+  JITValuePointer ne(JITValue& rh) override;
+  JITValuePointer lt(JITValue& rh) override;
+  JITValuePointer le(JITValue& rh) override;
+  JITValuePointer gt(JITValue& rh) override;
+  JITValuePointer ge(JITValue& rh) override;
+
  private:
   static llvm::IRBuilder<>& getFunctionBuilder(const LLVMJITFunction& function) {
     return static_cast<llvm::IRBuilder<>&>(function);
   }
+
+  JITValuePointer createCmpInstruction(llvm::CmpInst::Predicate ICmpType,
+                                       llvm::CmpInst::Predicate FCmpType,
+                                       JITValue& rh,
+                                       const char* value);
 
   static void checkOprandsType(JITTypeTag lh, JITTypeTag rh, const char* op);
 

--- a/cider/tests/nextgen/jitlib/JITLibTest.cpp
+++ b/cider/tests/nextgen/jitlib/JITLibTest.cpp
@@ -179,21 +179,21 @@ TEST_F(JITLibTests, LogicalOpTest) {
   executeBinaryOp<JITTypeTag::BOOL>(
       true, false, false, [](JITValue& a, JITValue& b) { return a && b && true; });
   executeBinaryOp<JITTypeTag::BOOL>(
-      true, true, true, [](JITValue& a, JITValue& b) { return a && b && true; });
+      true, true, true, [](JITValue& a, JITValue& b) { return a && true && b; });
   executeBinaryOp<JITTypeTag::BOOL>(
-      true, false, false, [](JITValue& a, JITValue& b) { return a && b && false; });
+      true, false, false, [](JITValue& a, JITValue& b) { return false && a && b; });
   executeBinaryOp<JITTypeTag::BOOL>(
-      false, false, false, [](JITValue& a, JITValue& b) { return a && b && true; });
+      false, false, false, [](JITValue& a, JITValue& b) { return true && a && b; });
 
   // or
   executeBinaryOp<JITTypeTag::BOOL>(
-      true, false, true, [](JITValue& a, JITValue& b) { return a || b || false; });
+      true, false, true, [](JITValue& a, JITValue& b) { return a || false || b; });
   executeBinaryOp<JITTypeTag::BOOL>(
       true, true, true, [](JITValue& a, JITValue& b) { return a || b || false; });
   executeBinaryOp<JITTypeTag::BOOL>(
-      false, true, true, [](JITValue& a, JITValue& b) { return a || b || true; });
+      false, true, true, [](JITValue& a, JITValue& b) { return true || a || b; });
   executeBinaryOp<JITTypeTag::BOOL>(
-      false, false, false, [](JITValue& a, JITValue& b) { return a || b || false; });
+      false, false, false, [](JITValue& a, JITValue& b) { return a || false || b; });
 }
 
 TEST_F(JITLibTests, CompareOpTest) {
@@ -204,16 +204,22 @@ TEST_F(JITLibTests, CompareOpTest) {
       100, 100, true, [](JITValue& a, JITValue& b) { return a == b; });
   executeCompareOp<JITTypeTag::INT32>(
       100, 100, true, [](JITValue& a, JITValue& b) { return a == b; });
+  executeCompareOp<JITTypeTag::INT32>(
+      100, 100, true, [](JITValue& a, JITValue& b) { return a == 100; });
   executeCompareOp<JITTypeTag::INT64>(
       100, 100, true, [](JITValue& a, JITValue& b) { return a == b; });
   executeCompareOp<JITTypeTag::FLOAT>(
       100.0, 100.0, true, [](JITValue& a, JITValue& b) { return a == b; });
   executeCompareOp<JITTypeTag::DOUBLE>(
       100.0, 20.0, false, [](JITValue& a, JITValue& b) { return a == b; });
+  executeCompareOp<JITTypeTag::DOUBLE>(
+      100.0, 20.0, true, [](JITValue& a, JITValue& b) { return 20.0 == b; });
 
   // ne
   executeCompareOp<JITTypeTag::INT8>(
       100, 2, true, [](JITValue& a, JITValue& b) { return a != b; });
+  executeCompareOp<JITTypeTag::INT8>(
+      100, 2, true, [](JITValue& a, JITValue& b) { return a != 40; });
   executeCompareOp<JITTypeTag::INT16>(
       100, 100, false, [](JITValue& a, JITValue& b) { return a != b; });
   executeCompareOp<JITTypeTag::INT32>(
@@ -222,6 +228,8 @@ TEST_F(JITLibTests, CompareOpTest) {
       100, 100, false, [](JITValue& a, JITValue& b) { return a != b; });
   executeCompareOp<JITTypeTag::FLOAT>(
       100.0, 100.0, false, [](JITValue& a, JITValue& b) { return a != b; });
+  executeCompareOp<JITTypeTag::FLOAT>(
+      100.0, 100.0, false, [](JITValue& a, JITValue& b) { return 100.0 != b; });
   executeCompareOp<JITTypeTag::DOUBLE>(
       100.0, 2.0, true, [](JITValue& a, JITValue& b) { return a != b; });
 
@@ -230,12 +238,16 @@ TEST_F(JITLibTests, CompareOpTest) {
       100, 2, true, [](JITValue& a, JITValue& b) { return a > b; });
   executeCompareOp<JITTypeTag::INT16>(
       100, 100, false, [](JITValue& a, JITValue& b) { return a > b; });
+  executeCompareOp<JITTypeTag::INT16>(
+      100, 100, false, [](JITValue& a, JITValue& b) { return a > 200; });
   executeCompareOp<JITTypeTag::INT32>(
       100, 2, true, [](JITValue& a, JITValue& b) { return a > b; });
   executeCompareOp<JITTypeTag::INT64>(
       100, 99, true, [](JITValue& a, JITValue& b) { return a > b; });
   executeCompareOp<JITTypeTag::FLOAT>(
       100.0, 101.0, false, [](JITValue& a, JITValue& b) { return a > b; });
+  executeCompareOp<JITTypeTag::FLOAT>(
+      100.0, 101.0, true, [](JITValue& a, JITValue& b) { return 102.0 > b; });
   executeCompareOp<JITTypeTag::DOUBLE>(
       100.0, 100.0, false, [](JITValue& a, JITValue& b) { return a > b; });
 
@@ -246,16 +258,22 @@ TEST_F(JITLibTests, CompareOpTest) {
       100, 100, true, [](JITValue& a, JITValue& b) { return a >= b; });
   executeCompareOp<JITTypeTag::INT32>(
       100, 2, true, [](JITValue& a, JITValue& b) { return a >= b; });
+  executeCompareOp<JITTypeTag::INT32>(
+      100, 2, true, [](JITValue& a, JITValue& b) { return a >= 30; });
   executeCompareOp<JITTypeTag::INT64>(
       100, 99, true, [](JITValue& a, JITValue& b) { return a >= b; });
   executeCompareOp<JITTypeTag::FLOAT>(
       100.0, 101.0, false, [](JITValue& a, JITValue& b) { return a >= b; });
+  executeCompareOp<JITTypeTag::FLOAT>(
+      100.0, 101.0, false, [](JITValue& a, JITValue& b) { return 99.2 >= b; });
   executeCompareOp<JITTypeTag::DOUBLE>(
       100.0, 100.0, true, [](JITValue& a, JITValue& b) { return a >= b; });
 
   // lt
   executeCompareOp<JITTypeTag::INT8>(
       100, 2, false, [](JITValue& a, JITValue& b) { return a < b; });
+  executeCompareOp<JITTypeTag::INT8>(
+      100, 2, false, [](JITValue& a, JITValue& b) { return 4 < b; });
   executeCompareOp<JITTypeTag::INT16>(
       100, 100, false, [](JITValue& a, JITValue& b) { return a < b; });
   executeCompareOp<JITTypeTag::INT32>(
@@ -264,6 +282,8 @@ TEST_F(JITLibTests, CompareOpTest) {
       100, 101, true, [](JITValue& a, JITValue& b) { return a < b; });
   executeCompareOp<JITTypeTag::FLOAT>(
       100.0, 101.0, true, [](JITValue& a, JITValue& b) { return a < b; });
+  executeCompareOp<JITTypeTag::FLOAT>(
+      100.0, 101.0, true, [](JITValue& a, JITValue& b) { return b < 103.2; });
   executeCompareOp<JITTypeTag::DOUBLE>(
       100.0, 100.0, false, [](JITValue& a, JITValue& b) { return a < b; });
 
@@ -276,10 +296,14 @@ TEST_F(JITLibTests, CompareOpTest) {
       100, 101, true, [](JITValue& a, JITValue& b) { return a <= b; });
   executeCompareOp<JITTypeTag::INT64>(
       100, 99, false, [](JITValue& a, JITValue& b) { return a <= b; });
+  executeCompareOp<JITTypeTag::INT64>(
+      100, 99, true, [](JITValue& a, JITValue& b) { return 97 <= b; });
   executeCompareOp<JITTypeTag::FLOAT>(
       100.0, 101.0, true, [](JITValue& a, JITValue& b) { return a <= b; });
   executeCompareOp<JITTypeTag::DOUBLE>(
       100.0, 100.0, true, [](JITValue& a, JITValue& b) { return a <= b; });
+  executeCompareOp<JITTypeTag::DOUBLE>(
+      100.0, 100.0, true, [](JITValue& a, JITValue& b) { return a <= 100.0; });
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
add JITValue Compare and Logical Operations like ==,!=,&&,||, >,<, <=,>=
Add UTs about the added operations 

### Why are the changes needed?
Support the next gen framework

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
UTs.

### Which label does this PR belong to?
INFRA