### PR TITLE
[POAE7-2540] PlanNode validation for cider plan validator

### DIFF
--- a/ci/scripts/intel_copyright_files.txt
+++ b/ci/scripts/intel_copyright_files.txt
@@ -21,6 +21,7 @@ cider/exec/plan/parser/Plan*
 cider/exec/plan/parser/*Visitor*
 cider/exec/plan/parser/Substrait*
 cider/exec/plan/parser/ConverterHelper.*
+cider/exec/plan/validator/*
 cider/exec/nextgen/*
 cider/function/FunctionLookupEngine.*
 cider/function/SubstraitFunctionCiderMappings.h

--- a/cider/exec/plan/parser/SubstraitToRelAlgExecutionUnit.h
+++ b/cider/exec/plan/parser/SubstraitToRelAlgExecutionUnit.h
@@ -39,6 +39,8 @@
 
 namespace generator {
 
+enum FrontendEngine { PRESTO, VELOX };
+
 enum ExprType { FilterExpr, ProjectExpr, AggregationExpr };
 static const std::string enum_str[] = {"FilterExpr", "ProjectExpr", "AggregationExpr"};
 

--- a/cider/exec/plan/validator/CMakeLists.txt
+++ b/cider/exec/plan/validator/CMakeLists.txt
@@ -16,5 +16,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-add_subdirectory(parser)
-add_subdirectory(validator)
+find_package(FMT REQUIRED)
+
+set(CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -Wno-attributes -Wno-write-strings -Wno-unused-function -Wno-unused-label -Wno-sign-compare"
+)
+
+set(CIDER_PLAN_VALIDATOR_SRCS CiderPlanValidator.cpp SingleNodeValidator.cpp)
+add_library(cider_plan_validator STATIC ${CIDER_PLAN_VALIDATOR_SRCS})
+target_link_libraries(cider_plan_validator substrait fmt::fmt)

--- a/cider/exec/plan/validator/CiderPlanValidator.cpp
+++ b/cider/exec/plan/validator/CiderPlanValidator.cpp
@@ -30,8 +30,8 @@
 
 namespace validator {
 
-bool CiderPlanValidator::isSupported(const substrait::Plan& plan,
-                                     const generator::FrontendEngine& from_platform) {
+bool CiderPlanValidator::validate(const substrait::Plan& plan,
+                                  const generator::FrontendEngine& from_platform) {
   // Assumed that plan pattern already validated, do function look up first
   // Apply specific rule check on the plan
   return isSupportedSlice(constructPlanSlice(plan, from_platform), from_platform);

--- a/cider/exec/plan/validator/CiderPlanValidator.cpp
+++ b/cider/exec/plan/validator/CiderPlanValidator.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "CiderPlanValidator.h"
+#include "SingleNodeValidator.h"
+#include "cider/CiderException.h"
+#include "substrait/algebra.pb.h"
+#include "substrait/plan.pb.h"
+#include "util/Logger.h"
+
+namespace validator {
+
+bool CiderPlanValidator::isSupported(const substrait::Plan& plan,
+                                     const std::string& from_platform) {
+  // Assumed that plan pattern already validated, do function look up first
+  // Apply specific rule check on the plan
+  return isSupportedSlice(constructPlanSlice(plan, from_platform), from_platform);
+}
+
+PlanSlice CiderPlanValidator::constructPlanSlice(const substrait::Plan& plan,
+                                                 const std::string& from_platform) {
+  const substrait::Rel& root_rel = getRootRel(plan);
+  std::vector<substrait::Rel> rel_vec;
+  putRelNodesInVec(root_rel, rel_vec);
+  return PlanSlice{rel_vec, from_platform};
+}
+
+bool CiderPlanValidator::isSupportedSlice(const PlanSlice& plan_slice,
+                                          const std::string& from_platform) {
+  // TODO: (yma11) add function look up and rule based check
+  return true;
+}
+
+void CiderPlanValidator::putRelNodesInVec(const substrait::Rel& rel_node,
+                                          std::vector<substrait::Rel>& rel_vec) {
+  const substrait::Rel::RelTypeCase& rel_type = rel_node.rel_type_case();
+  switch (rel_type) {
+    case substrait::Rel::RelTypeCase::kRead: {
+      rel_vec.push_back(rel_node);
+      break;
+    }
+    case substrait::Rel::RelTypeCase::kFilter: {
+      rel_vec.push_back(rel_node);
+      putRelNodesInVec(rel_node.filter().input(), rel_vec);
+      break;
+    }
+    case substrait::Rel::RelTypeCase::kProject: {
+      rel_vec.push_back(rel_node);
+      putRelNodesInVec(rel_node.project().input(), rel_vec);
+      break;
+    }
+    case substrait::Rel::RelTypeCase::kAggregate: {
+      rel_vec.push_back(rel_node);
+      putRelNodesInVec(rel_node.aggregate().input(), rel_vec);
+      break;
+    }
+    case substrait::Rel::RelTypeCase::kJoin: {
+      rel_vec.push_back(rel_node);
+      putRelNodesInVec(rel_node.join().left(), rel_vec);
+      break;
+    }
+    default:
+      CIDER_THROW(CiderCompileException,
+                  fmt::format("Unsupported substrait rel type {}", rel_type));
+  }
+}
+
+substrait::Rel CiderPlanValidator::getRootRel(const substrait::Plan& plan) {
+  if (plan.relations_size() == 0) {
+    CIDER_THROW(CiderCompileException, "invalid plan with no root node.");
+  }
+  if (!plan.relations(0).has_root()) {
+    CIDER_THROW(CiderCompileException, "invalid plan with no root node.");
+  }
+  return plan.relations(0).root().input();
+}
+
+PlanSlice CiderPlanValidator::getCiderSupportedSlice(substrait::Plan& plan,
+                                                     std::string& from_platform) {
+  substrait::Rel root = getRootRel(plan);
+  // Put plan rels in a vector with pair <substrait::Rel, isSupported>
+  std::vector<substrait::Rel> rel_vec;
+  putRelNodesInVec(root, rel_vec);
+  // Compose plan slices based on SingleNodeValidator validate result
+  std::vector<PlanSlice> slice_candidates;
+  for (int i = 0; i < rel_vec.size(); i++) {
+    if (!SingleNodeValidator::validate(rel_vec[i])) {
+      continue;
+    }
+    PlanSlice plan_slice{};
+    plan_slice.rel_nodes.emplace_back(rel_vec[i]);
+    plan_slice.from_platform = from_platform;
+    int j = i + 1;
+    while (j < rel_vec.size() && SingleNodeValidator::validate(rel_vec[j])) {
+      plan_slice.rel_nodes.emplace_back(rel_vec[j]);
+      j++;
+    }
+    slice_candidates.emplace_back(plan_slice);
+    i = j;
+    continue;
+  }
+  // TODO: (yma11) validate the pattern on plan slices
+  // Call isSupportedSlice() to do further validation on plan slices
+  // return the longest plan slice
+  int final_slice_index = 0, max_len = 0;
+  for (int i = 0; i < slice_candidates.size(); i++) {
+    if (slice_candidates[i].rel_nodes.size() > max_len) {
+      max_len = slice_candidates[i].rel_nodes.size();
+      final_slice_index = i;
+    }
+  }
+  return slice_candidates[final_slice_index];
+}
+}  // namespace validator

--- a/cider/exec/plan/validator/CiderPlanValidator.h
+++ b/cider/exec/plan/validator/CiderPlanValidator.h
@@ -40,8 +40,8 @@ class CiderPlanValidator {
    * @param from_platform specific frontend framework for future function lookup
    * @return whether the plan can be executed by Cider
    **/
-  static bool isSupported(const substrait::Plan& plan,
-                          const generator::FrontendEngine& from_platform);
+  static bool validate(const substrait::Plan& plan,
+                       const generator::FrontendEngine& from_platform);
 
   /**
    * @param plan original plan without any validation

--- a/cider/exec/plan/validator/CiderPlanValidator.h
+++ b/cider/exec/plan/validator/CiderPlanValidator.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "substrait/algebra.pb.h"
+#include "substrait/plan.pb.h"
+#include "substrait/type.pb.h"
+
+namespace validator {
+
+struct PlanSlice {
+  std::vector<substrait::Rel> rel_nodes;
+  std::string from_platform;
+};
+
+class CiderPlanValidator {
+ public:
+  /**
+   * @param plan plan with pattern already validated
+   * @param from_platform specific frontend framework for future function lookup
+   *
+   **/
+  static bool isSupported(const substrait::Plan& plan, const std::string& from_platform);
+
+  /**
+   * @param plan original plan without any validation
+   * @param from_platform specific frontend framework for future function lookup
+   *
+   **/
+  static PlanSlice getCiderSupportedSlice(substrait::Plan& plan,
+                                          std::string& from_platform);
+
+ private:
+  // Validate plan slice by function lookup and rule based check
+  static bool isSupportedSlice(const PlanSlice& plan_slice,
+                               const std::string& from_platform);
+
+  static substrait::Rel getRootRel(const substrait::Plan& plan);
+
+  static PlanSlice constructPlanSlice(const substrait::Plan& plan,
+                                      const std::string& from_platform);
+
+  static void putRelNodesInVec(const substrait::Rel& rel_node,
+                               std::vector<substrait::Rel>& rel_vec);
+};
+}  // namespace validator

--- a/cider/exec/plan/validator/CiderPlanValidator.h
+++ b/cider/exec/plan/validator/CiderPlanValidator.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "exec/plan/parser/SubstraitToRelAlgExecutionUnit.h"
 #include "substrait/algebra.pb.h"
 #include "substrait/plan.pb.h"
 #include "substrait/type.pb.h"
@@ -29,7 +30,7 @@ namespace validator {
 
 struct PlanSlice {
   std::vector<substrait::Rel> rel_nodes;
-  std::string from_platform;
+  const generator::FrontendEngine& from_platform;
 };
 
 class CiderPlanValidator {
@@ -37,27 +38,28 @@ class CiderPlanValidator {
   /**
    * @param plan plan with pattern already validated
    * @param from_platform specific frontend framework for future function lookup
-   *
+   * @return whether the plan can be executed by Cider
    **/
-  static bool isSupported(const substrait::Plan& plan, const std::string& from_platform);
+  static bool isSupported(const substrait::Plan& plan,
+                          const generator::FrontendEngine& from_platform);
 
   /**
    * @param plan original plan without any validation
    * @param from_platform specific frontend framework for future function lookup
-   *
+   * @return the longest plan slice that can be executed by Cider
    **/
   static PlanSlice getCiderSupportedSlice(substrait::Plan& plan,
-                                          std::string& from_platform);
+                                          const generator::FrontendEngine& from_platform);
 
  private:
   // Validate plan slice by function lookup and rule based check
   static bool isSupportedSlice(const PlanSlice& plan_slice,
-                               const std::string& from_platform);
+                               const generator::FrontendEngine& from_platform);
 
-  static substrait::Rel getRootRel(const substrait::Plan& plan);
+  static const substrait::Rel& getRootRel(const substrait::Plan& plan);
 
   static PlanSlice constructPlanSlice(const substrait::Plan& plan,
-                                      const std::string& from_platform);
+                                      const generator::FrontendEngine& from_platform);
 
   static void putRelNodesInVec(const substrait::Rel& rel_node,
                                std::vector<substrait::Rel>& rel_vec);

--- a/cider/exec/plan/validator/SingleNodeValidator.cpp
+++ b/cider/exec/plan/validator/SingleNodeValidator.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "SingleNodeValidator.h"
+#include "../parser/ConverterHelper.h"
+#include "cider/CiderException.h"
+#include "substrait/algebra.pb.h"
+#include "substrait/plan.pb.h"
+
+namespace validator {
+
+std::vector<substrait::Type> SingleNodeValidator::getRelOutputTypes(
+    const substrait::Rel& rel_node) {
+  const substrait::Rel::RelTypeCase& rel_type = rel_node.rel_type_case();
+  std::vector<substrait::Type> output_types;
+  switch (rel_type) {
+    case substrait::Rel::RelTypeCase::kRead: {
+      for (int i = 0; i < rel_node.read().base_schema().struct_().types().size(); i++) {
+        output_types.emplace_back(rel_node.read().base_schema().struct_().types(i));
+      }
+      return output_types;
+    }
+    case substrait::Rel::RelTypeCase::kFilter: {
+      return getRelOutputTypes(rel_node.filter().input());
+    }
+    case substrait::Rel::RelTypeCase::kProject: {
+      return getRelOutputTypes(rel_node, getRelOutputTypes(rel_node.project().input()));
+    }
+    case substrait::Rel::RelTypeCase::kAggregate: {
+      return getRelOutputTypes(rel_node, getRelOutputTypes(rel_node.aggregate().input()));
+    }
+    case substrait::Rel::RelTypeCase::kJoin: {
+      auto r_types = getRelOutputTypes(rel_node.join().right());
+      auto l_types = getRelOutputTypes(rel_node.join().left());
+      std::vector<substrait::Type> types;
+      types.reserve(l_types.size() + r_types.size());
+      types.insert(types.end(), l_types.begin(), l_types.end());
+      types.insert(types.end(), r_types.begin(), r_types.end());
+      return types;
+    }
+    default:
+      CIDER_THROW(CiderCompileException,
+                  fmt::format("Failed to get output types of rel type {}", rel_type));
+  }
+}
+
+std::vector<substrait::Type> SingleNodeValidator::getRelOutputTypes(
+    const substrait::Rel& rel_node,
+    const std::vector<substrait::Type>& input_types) {
+  std::vector<substrait::Type> output_types;
+  const substrait::Rel::RelTypeCase& rel_type = rel_node.rel_type_case();
+  switch (rel_type) {
+    case substrait::Rel::RelTypeCase::kProject: {
+      auto& proj = rel_node.project();
+      if (proj.common().has_emit()) {
+        auto& emit = proj.common().emit();
+        auto max_index = generator::getSizeOfOutputColumns(proj.input());
+        for (int i = 0; i < emit.output_mapping_size(); i++) {
+          if (emit.output_mapping(i) < max_index) {
+            output_types.emplace_back(input_types[emit.output_mapping(i)]);
+          } else {
+            auto& s_expr = proj.expressions(emit.output_mapping(i) - max_index);
+            if (!s_expr.has_selection()) {
+              output_types.emplace_back(getExprOutputType(s_expr, input_types));
+            } else {
+              CHECK(s_expr.has_selection());
+              output_types.emplace_back(
+                  input_types
+                      [s_expr.selection().direct_reference().struct_field().field()]);
+            }
+          }
+        }
+      } else if (proj.common().has_direct()) {
+        auto max_index = generator::getSizeOfOutputColumns(proj.input());
+        for (int i = 0; i < max_index; i++) {
+          output_types.emplace_back(input_types[i]);
+        }
+        for (int i = 0; i < proj.expressions_size(); i++) {
+          auto& s_expr = proj.expressions(i);
+          if (!s_expr.has_selection()) {
+            output_types.emplace_back(getExprOutputType(s_expr, input_types));
+          } else {
+            CHECK(s_expr.has_selection());
+            output_types.emplace_back(
+                input_types
+                    [s_expr.selection().direct_reference().struct_field().field()]);
+          }
+        }
+      }
+
+      return output_types;
+    }
+    case substrait::Rel::RelTypeCase::kAggregate: {
+      auto& agg = rel_node.aggregate();
+      // add groupby expr output types
+      for (int i = 0; i < agg.groupings(0).grouping_expressions_size(); i++) {
+        auto& groupby_expr = agg.groupings(0).grouping_expressions(i);
+        if (groupby_expr.has_selection()) {
+          output_types.emplace_back(
+              input_types
+                  [groupby_expr.selection().direct_reference().struct_field().field()]);
+        } else {
+          if (!groupby_expr.has_selection()) {
+            output_types.emplace_back(getExprOutputType(groupby_expr, input_types));
+          }
+        }
+      }
+      // add aggregation function output types
+      for (int i = 0; i < agg.measures_size(); i++) {
+        output_types.emplace_back(agg.measures(i).measure().output_type());
+      }
+      return output_types;
+    }
+    case substrait::Rel::RelTypeCase::kJoin: {
+      // For join, we only support direct mapping so just use input_types
+      return input_types;
+    }
+    default:
+      CIDER_THROW(CiderCompileException,
+                  fmt::format("Failed to get output types of rel type {}", rel_type));
+  }
+  return output_types;
+}
+
+substrait::Type SingleNodeValidator::getExprOutputType(
+    const substrait::Expression& s_expr,
+    const std::vector<substrait::Type>& input_types) {
+  switch (s_expr.rex_type_case()) {
+    case substrait::Expression::RexTypeCase::kScalarFunction:
+      return s_expr.scalar_function().output_type();
+    case substrait::Expression::RexTypeCase::kCast:
+      return s_expr.cast().type();
+    default:
+      CIDER_THROW(CiderCompileException,
+                  fmt::format("Unsupported expression type {} for getExprOutputType()",
+                              s_expr.rex_type_case()));
+  }
+}
+
+bool SingleNodeValidator::isSupportedAllTypes(const std::vector<substrait::Type>& types) {
+  int i = 0;
+  for (; i < types.size(); i++) {
+    if (supported_types.find(types[i].kind_case()) == supported_types.end()) {
+      break;
+    }
+  }
+  return i != 0 && i == types.size() ? true : false;
+}
+
+bool SingleNodeValidator::validate(const substrait::Rel& rel_node) {
+  // Validation on each plan node includes data types check and some basic
+  // properties check. Data types contains current node output types and its
+  // parents' output types. Actually there should be other data types involved
+  // in nested functions, which we don't cover here. This won't cause problem
+  // since it will be checked in later function level validation.
+  const substrait::Rel::RelTypeCase& rel_type = rel_node.rel_type_case();
+  switch (rel_type) {
+    case substrait::Rel::RelTypeCase::kRead:
+      return true;
+    case substrait::Rel::RelTypeCase::kFilter: {
+      return validate(rel_node.filter()) &&
+             isSupportedAllTypes(getRelOutputTypes(rel_node.filter().input()));
+    }
+    case substrait::Rel::RelTypeCase::kProject: {
+      return validate(rel_node.project()) &&
+             isSupportedAllTypes(getRelOutputTypes(rel_node)) &&
+             isSupportedAllTypes(getRelOutputTypes(rel_node.project().input()));
+    }
+    case substrait::Rel::RelTypeCase::kAggregate: {
+      return validate(rel_node.aggregate()) &&
+             isSupportedAllTypes(getRelOutputTypes(rel_node)) &&
+             isSupportedAllTypes(getRelOutputTypes(rel_node.aggregate().input()));
+    }
+    case substrait::Rel::RelTypeCase::kJoin: {
+      // For join, we only support direct mapping
+      return validate(rel_node.join()) &&
+             isSupportedAllTypes(getRelOutputTypes(rel_node.join().left())) &&
+             isSupportedAllTypes(getRelOutputTypes(rel_node.join().right()));
+    }
+    default:
+      CIDER_THROW(CiderCompileException,
+                  fmt::format("Unsupported substrait rel type {}", rel_type));
+  }
+}
+
+bool SingleNodeValidator::validate(const substrait::ReadRel& read_rel) {
+  return true;
+}
+
+bool SingleNodeValidator::validate(const substrait::FilterRel& filter_rel) {
+  return filter_rel.has_condition();
+}
+
+bool SingleNodeValidator::validate(const substrait::ProjectRel& proj_rel) {
+  return true;
+}
+
+bool SingleNodeValidator::validate(const substrait::AggregateRel& agg_rel) {
+  // Only support partial aggregation
+  int i = 0;
+  for (; i < agg_rel.measures_size(); i++) {
+    if (agg_rel.measures(i).measure().phase() !=
+        substrait::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE) {
+      break;
+    }
+  }
+  return agg_rel.common().has_direct() && (i != 0 && i == agg_rel.measures_size())
+             ? true
+             : false;
+}
+
+bool SingleNodeValidator::validate(const substrait::JoinRel& join_rel) {
+  // Only support join with direct. For emit, it uses join with post project
+  return join_rel.has_expression() && join_rel.common().has_direct() &&
+         join_rel.type() !=
+             substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_UNSPECIFIED &&
+         join_rel.type() !=
+             substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_OUTER &&
+         join_rel.type() != substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT;
+}
+}  // namespace validator

--- a/cider/exec/plan/validator/SingleNodeValidator.h
+++ b/cider/exec/plan/validator/SingleNodeValidator.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "substrait/algebra.pb.h"
+#include "substrait/plan.pb.h"
+#include "substrait/type.pb.h"
+
+namespace validator {
+
+const std::unordered_set<int> supported_types{substrait::Type::kBool,
+                                              substrait::Type::kDecimal,
+                                              substrait::Type::kFp32,
+                                              substrait::Type::kFp64,
+                                              substrait::Type::kI8,
+                                              substrait::Type::kI16,
+                                              substrait::Type::kI32,
+                                              substrait::Type::kI64,
+                                              substrait::Type::kTimestamp,
+                                              substrait::Type::kVarchar,
+                                              substrait::Type::kFixedChar,
+                                              substrait::Type::kDate,
+                                              substrait::Type::kTime,
+                                              substrait::Type::kString};
+
+class SingleNodeValidator {
+ public:
+  static bool validate(const substrait::Rel& rel_node);
+
+ private:
+  // get outputTypes of a rel node
+  static std::vector<substrait::Type> getRelOutputTypes(const substrait::Rel& rel_node);
+  static std::vector<substrait::Type> getRelOutputTypes(
+      const substrait::Rel& rel_node,
+      const std::vector<substrait::Type>& input_types);
+
+  static substrait::Type getExprOutputType(
+      const substrait::Expression& s_expr,
+      const std::vector<substrait::Type>& input_types);
+
+  static bool isSupportedAllTypes(const std::vector<substrait::Type>& types);
+
+  static bool validate(const substrait::ReadRel& read_rel);
+  static bool validate(const substrait::FilterRel& filter_rel);
+  static bool validate(const substrait::ProjectRel& proj_rel);
+  static bool validate(const substrait::AggregateRel& agg_rel);
+  static bool validate(const substrait::JoinRel& join_rel);
+};
+}  // namespace validator

--- a/cider/tests/plan/CMakeLists.txt
+++ b/cider/tests/plan/CMakeLists.txt
@@ -16,5 +16,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-add_subdirectory(parser)
-add_subdirectory(validator)
+
+set(DEP_LIBS ${EXECUTE_TEST_LIBS} cider_plan_validator)
+
+set(TEST_ARGS "--gtest_output=xml:../")
+
+add_executable(CiderPlanValidatorTest CiderPlanValidatorTest.cpp)
+target_link_libraries(CiderPlanValidatorTest ${DEP_LIBS})
+add_test(CiderPlanValidatorTest
+         ${EXECUTABLE_OUTPUT_PATH}/CiderPlanValidatorTest ${TEST_ARGS})

--- a/cider/tests/plan/CiderPlanValidatorTest.cpp
+++ b/cider/tests/plan/CiderPlanValidatorTest.cpp
@@ -41,9 +41,8 @@ TEST(CiderPlanValidator, InvalidAggAndJoinTest) {
   std::string sub_data = buffer.str();
   ::substrait::Plan sub_plan;
   google::protobuf::util::JsonStringToMessage(sub_data, &sub_plan);
-  std::string from_platform = "velox";
-  auto plan_slice =
-      validator::CiderPlanValidator::getCiderSupportedSlice(sub_plan, from_platform);
+  auto plan_slice = validator::CiderPlanValidator::getCiderSupportedSlice(
+      sub_plan, generator::FrontendEngine::VELOX);
   // Agg(invalid phase) <- proj <- filter <- proj <- join(type not supported) <-project
   // <-read
   CHECK_EQ(plan_slice.rel_nodes.size(), 3);

--- a/cider/tests/plan/CiderPlanValidatorTest.cpp
+++ b/cider/tests/plan/CiderPlanValidatorTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <google/protobuf/util/json_util.h>
+#include <gtest/gtest.h>
+#include <boost/filesystem.hpp>
+#include <string>
+#include "exec/plan/validator/CiderPlanValidator.h"
+#include "util/Logger.h"
+
+namespace bf = boost::filesystem;
+
+std::string getDataFilesPath() {
+  const std::string absolute_path = __FILE__;
+  auto const pos = absolute_path.find_last_of('/');
+  return absolute_path.substr(0, pos) + "/../substrait_plan_files/";
+}
+
+TEST(CiderPlanValidator, InvalidAggAndJoinTest) {
+  std::ifstream sub_json(getDataFilesPath() + "cider_plan_validator_join.json");
+  std::stringstream buffer;
+  buffer << sub_json.rdbuf();
+  std::string sub_data = buffer.str();
+  ::substrait::Plan sub_plan;
+  google::protobuf::util::JsonStringToMessage(sub_data, &sub_plan);
+  std::string from_platform = "velox";
+  auto plan_slice =
+      validator::CiderPlanValidator::getCiderSupportedSlice(sub_plan, from_platform);
+  // Agg(invalid phase) <- proj <- filter <- proj <- join(type not supported) <-project
+  // <-read
+  CHECK_EQ(plan_slice.rel_nodes.size(), 3);
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  logger::LogOptions log_options(argv[0]);
+  log_options.parse_command_line(argc, argv);
+  log_options.max_files_ = 0;  // stderr only by default
+  logger::init(log_options);
+
+  int err{0};
+  try {
+    err = RUN_ALL_TESTS();
+  } catch (const std::exception& e) {
+    LOG(ERROR) << e.what();
+  }
+  return err;
+}

--- a/cider/tests/substrait_plan_files/cider_plan_validator_join.json
+++ b/cider/tests/substrait_plan_files/cider_plan_validator_join.json
@@ -1,0 +1,593 @@
+{
+    "extensionUris": [{
+      "extensionUriAnchor": 1,
+      "uri": "/functions_arithmetic.yaml"
+    }, {
+      "extensionUriAnchor": 2,
+      "uri": "/functions_comparison.yaml"
+    }],
+    "extensions": [{
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "add:opt_i64_i64"
+      }
+    }, {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 1,
+        "name": "equal:any_any"
+      }
+    }, {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 2,
+        "name": "lt:any_any"
+      }
+    }, {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 3,
+        "name": "subtract:opt_i64_i64"
+      }
+    }, {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 4,
+        "name": "sum:opt_i64"
+      }
+    }],
+    "relations": [{
+      "root": {
+        "input": {
+          "aggregate": {
+            "common": {
+              "direct": {
+              }
+            },
+            "input": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [11]
+                  }
+                },
+                "input": {
+                  "filter": {
+                    "common": {
+                      "direct": {
+                      }
+                    },
+                    "input": {
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+                          }
+                        },
+                        "input": {
+                          "join": {
+                            "common": {
+                              "direct": {
+                              }
+                            },
+                            "left": {
+                              "project": {
+                                "common": {
+                                  "emit": {
+                                    "outputMapping": [5, 6, 7, 8, 9, 10]
+                                  }
+                                },
+                                "input": {
+                                  "read": {
+                                    "common": {
+                                      "direct": {
+                                      }
+                                    },
+                                    "baseSchema": {
+                                      "names": ["L_A", "L_B", "L_C", "L_D", "L_E"],
+                                      "struct": {
+                                        "types": [{
+                                          "i64": {
+                                            "typeVariationReference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        }, {
+                                          "i32": {
+                                            "typeVariationReference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        }, {
+                                          "fp64": {
+                                            "typeVariationReference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        }, {
+                                          "fp32": {
+                                            "typeVariationReference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        }, {
+                                          "bool": {
+                                            "typeVariationReference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        }],
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "namedTable": {
+                                      "names": ["TABLE_PROBE"]
+                                    }
+                                  }
+                                },
+                                "expressions": [{
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 0
+                                      }
+                                    },
+                                    "rootReference": {
+                                    }
+                                  }
+                                }, {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 1
+                                      }
+                                    },
+                                    "rootReference": {
+                                    }
+                                  }
+                                }, {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 2
+                                      }
+                                    },
+                                    "rootReference": {
+                                    }
+                                  }
+                                }, {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 3
+                                      }
+                                    },
+                                    "rootReference": {
+                                    }
+                                  }
+                                }, {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 4
+                                      }
+                                    },
+                                    "rootReference": {
+                                    }
+                                  }
+                                }, {
+                                  "scalarFunction": {
+                                    "functionReference": 0,
+                                    "args": [],
+                                    "outputType": {
+                                      "i64": {
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [{
+                                      "value": {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 0
+                                            }
+                                          },
+                                          "rootReference": {
+                                          }
+                                        }
+                                      }
+                                    }, {
+                                      "value": {
+                                        "cast": {
+                                          "type": {
+                                            "i64": {
+                                              "typeVariationReference": 0,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "input": {
+                                            "literal": {
+                                              "i32": 1,
+                                              "nullable": false,
+                                              "typeVariationReference": 0
+                                            }
+                                          },
+                                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                                        }
+                                      }
+                                    }]
+                                  }
+                                }]
+                              }
+                            },
+                            "right": {
+                              "read": {
+                                "common": {
+                                  "direct": {
+                                  }
+                                },
+                                "baseSchema": {
+                                  "names": ["R_A", "R_B", "R_C", "R_D", "R_E", "R_F"],
+                                  "struct": {
+                                    "types": [{
+                                      "i64": {
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    }, {
+                                      "i32": {
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    }, {
+                                      "fp64": {
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    }, {
+                                      "fp32": {
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    }, {
+                                      "bool": {
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    }, {
+                                      "i32": {
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    }],
+                                    "typeVariationReference": 0,
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": ["TABLE_HASH"]
+                                }
+                              }
+                            },
+                            "expression": {
+                              "scalarFunction": {
+                                "functionReference": 1,
+                                "args": [],
+                                "outputType": {
+                                  "bool": {
+                                    "typeVariationReference": 0,
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [{
+                                  "value": {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 5
+                                        }
+                                      },
+                                      "rootReference": {
+                                      }
+                                    }
+                                  }
+                                }, {
+                                  "value": {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 6
+                                        }
+                                      },
+                                      "rootReference": {
+                                      }
+                                    }
+                                  }
+                                }]
+                              }
+                            },
+                            "type": "JOIN_TYPE_UNSPECIFIED"
+                          }
+                        },
+                        "expressions": [{
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 0
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }, {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 1
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }, {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 2
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }, {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 3
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }, {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 4
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }, {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 6
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }, {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 7
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }, {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 8
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }, {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 9
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }, {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 10
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }, {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 11
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        }]
+                      }
+                    },
+                    "condition": {
+                      "scalarFunction": {
+                        "functionReference": 2,
+                        "args": [],
+                        "outputType": {
+                          "bool": {
+                            "typeVariationReference": 0,
+                            "nullability": "NULLABILITY_NULLABLE"
+                          }
+                        },
+                        "arguments": [{
+                          "value": {
+                            "scalarFunction": {
+                              "functionReference": 3,
+                              "args": [],
+                              "outputType": {
+                                "i64": {
+                                  "typeVariationReference": 0,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "arguments": [{
+                                "value": {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 0
+                                      }
+                                    },
+                                    "rootReference": {
+                                    }
+                                  }
+                                }
+                              }, {
+                                "value": {
+                                  "cast": {
+                                    "type": {
+                                      "i64": {
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "input": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 1
+                                          }
+                                        },
+                                        "rootReference": {
+                                        }
+                                      }
+                                    },
+                                    "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                                  }
+                                }
+                              }]
+                            }
+                          }
+                        }, {
+                          "value": {
+                            "cast": {
+                              "type": {
+                                "i64": {
+                                  "typeVariationReference": 0,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "input": {
+                                "literal": {
+                                  "i32": 50,
+                                  "nullable": false,
+                                  "typeVariationReference": 0
+                                }
+                              },
+                              "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                            }
+                          }
+                        }]
+                      }
+                    }
+                  }
+                },
+                "expressions": [{
+                  "scalarFunction": {
+                    "functionReference": 0,
+                    "args": [],
+                    "outputType": {
+                      "i64": {
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_NULLABLE"
+                      }
+                    },
+                    "arguments": [{
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 0
+                            }
+                          },
+                          "rootReference": {
+                          }
+                        }
+                      }
+                    }, {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "i64": {
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {
+                              }
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    }]
+                  }
+                }]
+              }
+            },
+            "groupings": [{
+              "groupingExpressions": []
+            }],
+            "measures": [{
+              "measure": {
+                "functionReference": 4,
+                "args": [],
+                "sorts": [],
+                "phase": "AGGREGATION_PHASE_INTERMEDIATE_TO_INTERMEDIATE",
+                "outputType": {
+                  "i64": {
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_NULLABLE"
+                  }
+                },
+                "invocation": "AGGREGATION_INVOCATION_ALL",
+                "arguments": [{
+                  "value": {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 0
+                        }
+                      },
+                      "rootReference": {
+                      }
+                    }
+                  }
+                }]
+              }
+            }]
+          }
+        },
+        "names": ["EXPR$0"]
+      }
+    }],
+    "expectedTypeUrls": []
+  }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add plan validator module for cider, with single plan node validation as first step


### Why are the changes needed?
provide plan validation capability for Cider


### Does this PR introduce _any_ user-facing change?
Yes.
Public APIs:
 static bool isSupported(const substrait::Plan& plan, const std::string& from_platform);
 static PlanSlice getCiderSupportedSlice(substrait::Plan& plan, std::string& from_platform);


### How was this patch tested?
UT

### Which label does this PR belong to?

