### PR TITLE
[POAE7-2559] Scalar Function String Op: TRIM

### DIFF
--- a/cider/exec/plan/parser/SubstraitToAnalyzerExpr.cpp
+++ b/cider/exec/plan/parser/SubstraitToAnalyzerExpr.cpp
@@ -38,7 +38,7 @@ bool getExprUpdatable(std::unordered_map<std::shared_ptr<Analyzer::Expr>, bool> 
 
 bool isStringFunction(const std::string& function_name) {
   std::unordered_set<std::string> supportedStrFunctionSet{
-      "substring", "substr", "lower", "upper"};
+      "substring", "substr", "lower", "upper", "trim", "ltrim", "rtrim"};
   return supportedStrFunctionSet.find(function_name) != supportedStrFunctionSet.end();
 }
 
@@ -816,11 +816,11 @@ std::shared_ptr<Analyzer::Expr> Substrait2AnalyzerExprConverter::buildStrExpr(
       //    case SqlStringOpKind::RPAD: {
       //      return makeExpr<Analyzer::PadStringOper>(string_op_kind, args);
       //    }
-      //    case SqlStringOpKind::TRIM:
-      //    case SqlStringOpKind::LTRIM:
-      //    case SqlStringOpKind::RTRIM: {
-      //      return makeExpr<Analyzer::TrimStringOper>(string_op_kind, args);
-      //    }
+    case SqlStringOpKind::TRIM:
+    case SqlStringOpKind::LTRIM:
+    case SqlStringOpKind::RTRIM: {
+      return makeExpr<Analyzer::TrimStringOper>(string_op_kind, args);
+    }
     case SqlStringOpKind::SUBSTRING: {
       return makeExpr<Analyzer::SubstringStringOper>(args);
     }

--- a/cider/function/string/StringOps.cpp
+++ b/cider/function/string/StringOps.cpp
@@ -231,7 +231,7 @@ NullableStrType Trim::operator()(const std::string& str) const {
     // no trimming should be applied
     return str;
   }
-  if (trim_begin == trim_end) {
+  if (trim_begin >= trim_end) {
     // all chars should be trimmed
     return std::string("");
   }

--- a/cider/function/string/StringOps.cpp
+++ b/cider/function/string/StringOps.cpp
@@ -228,7 +228,12 @@ NullableStrType Trim::operator()(const std::string& str) const {
     }
   }
   if (trim_begin == 0 && trim_end == str_len - 1) {
+    // no trimming should be applied
     return str;
+  }
+  if (trim_begin == trim_end) {
+    // all chars should be trimmed
+    return std::string("");
   }
   return str.substr(trim_begin, trim_end + 1 - trim_begin);
 }

--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -492,6 +492,10 @@ TEST_F(CiderStringNullableTestArrow, ArrowCaseConvertionTest) {
                    "stringop_upper_condition_null.json");
 }
 
+TEST_F(CiderStringTestArrow, TrimTest) {
+  assertQueryArrow("SELECT TRIM('  345678  ') FROM test;", "stringop_trim_literal.json");
+}
+
 class CiderConstantStringTest : public CiderTestBase {
  public:
   CiderConstantStringTest() {

--- a/cider/tests/substrait_plan_files/stringop_ltrim_1.json
+++ b/cider/tests/substrait_plan_files/stringop_ltrim_1.json
@@ -10,7 +10,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 0,
-        "name": "trim:fchar_fchar"
+        "name": "ltrim:vchar_fchar"
       }
     }
   ],
@@ -22,7 +22,8 @@
             "common": {
               "emit": {
                 "outputMapping": [
-                  3
+                  3,
+                  4
                 ]
               }
             },
@@ -86,17 +87,56 @@
                   "arguments": [
                     {
                       "value": {
-                        "literal": {
-                          "fixedChar": "xxx3456   ",
-                          "nullable": false,
-                          "typeVariationReference": 0
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
                         }
                       }
                     },
                     {
                       "value": {
                         "literal": {
-                          "fixedChar": " x",
+                          "fixedChar": " ",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": " ",
                           "nullable": false,
                           "typeVariationReference": 0
                         }
@@ -109,7 +149,8 @@
           }
         },
         "names": [
-          "EXPR$0"
+          "EXPR$0",
+          "EXPR$1"
         ]
       }
     }

--- a/cider/tests/substrait_plan_files/stringop_ltrim_2.json
+++ b/cider/tests/substrait_plan_files/stringop_ltrim_2.json
@@ -10,7 +10,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 0,
-        "name": "trim:fchar_fchar"
+        "name": "ltrim:vchar_fchar"
       }
     }
   ],
@@ -22,7 +22,8 @@
             "common": {
               "emit": {
                 "outputMapping": [
-                  3
+                  3,
+                  4
                 ]
               }
             },
@@ -86,10 +87,49 @@
                   "arguments": [
                     {
                       "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
                         "literal": {
-                          "fixedChar": "xxx3456   ",
+                          "fixedChar": " x",
                           "nullable": false,
                           "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
                         }
                       }
                     },
@@ -109,7 +149,8 @@
           }
         },
         "names": [
-          "EXPR$0"
+          "EXPR$0",
+          "EXPR$1"
         ]
       }
     }

--- a/cider/tests/substrait_plan_files/stringop_ltrim_literal.json
+++ b/cider/tests/substrait_plan_files/stringop_ltrim_literal.json
@@ -10,7 +10,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 0,
-        "name": "trim:fchar_fchar"
+        "name": "ltrim:fchar_fchar"
       }
     }
   ],
@@ -87,7 +87,7 @@
                     {
                       "value": {
                         "literal": {
-                          "fixedChar": "xxx3456   ",
+                          "fixedChar": "xxx3456xxx",
                           "nullable": false,
                           "typeVariationReference": 0
                         }
@@ -96,7 +96,7 @@
                     {
                       "value": {
                         "literal": {
-                          "fixedChar": " x",
+                          "fixedChar": "x",
                           "nullable": false,
                           "typeVariationReference": 0
                         }

--- a/cider/tests/substrait_plan_files/stringop_ltrim_nested_1.json
+++ b/cider/tests/substrait_plan_files/stringop_ltrim_nested_1.json
@@ -1,0 +1,200 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "ltrim:vchar_fchar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 1,
+        "name": "upper:opt_vchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 1,
+                          "args": [],
+                          "outputType": {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": " X",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 0,
+                          "args": [],
+                          "outputType": {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            },
+                            {
+                              "value": {
+                                "literal": {
+                                  "fixedChar": "x",
+                                  "nullable": false,
+                                  "typeVariationReference": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0",
+          "EXPR$1"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_ltrim_nested_2.json
+++ b/cider/tests/substrait_plan_files/stringop_ltrim_nested_2.json
@@ -1,0 +1,280 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_boolean.yaml"
+    },
+    {
+      "extensionUriAnchor": 3,
+      "uri": "/functions_string.yaml"
+    },
+    {
+      "extensionUriAnchor": 2,
+      "uri": "/functions_comparison.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "or:bool"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 1,
+        "name": "equal:any_any"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 2,
+        "name": "lower:opt_vchar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 3,
+        "name": "ltrim:vchar_fchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "filter": {
+                "common": {
+                  "direct": {}
+                },
+                "input": {
+                  "read": {
+                    "common": {
+                      "direct": {}
+                    },
+                    "baseSchema": {
+                      "names": [
+                        "COL_1",
+                        "COL_2",
+                        "COL_3"
+                      ],
+                      "struct": {
+                        "types": [
+                          {
+                            "i32": {
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        ],
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "namedTable": {
+                      "names": [
+                        "TEST"
+                      ]
+                    }
+                  }
+                },
+                "condition": {
+                  "scalarFunction": {
+                    "functionReference": 0,
+                    "args": [],
+                    "outputType": {
+                      "bool": {
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_NULLABLE"
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "bool": {
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 10,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 1
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "literal": {
+                                    "varChar": {
+                                      "value": "xxxxxxxxxx",
+                                      "length": 10
+                                    },
+                                    "nullable": false,
+                                    "typeVariationReference": 0
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "bool": {
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 3,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 10,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 2
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "fixedChar": " ",
+                                            "nullable": false,
+                                            "typeVariationReference": 0
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "literal": {
+                                    "varChar": {
+                                      "value": "xxx3456",
+                                      "length": 10
+                                    },
+                                    "nullable": false,
+                                    "typeVariationReference": 0
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "expressions": [
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
+                    }
+                  },
+                  "rootReference": {}
+                }
+              },
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 2
+                    }
+                  },
+                  "rootReference": {}
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "COL_2",
+          "COL_3"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_rtrim_1.json
+++ b/cider/tests/substrait_plan_files/stringop_rtrim_1.json
@@ -10,7 +10,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 0,
-        "name": "trim:fchar_fchar"
+        "name": "rtrim:vchar_fchar"
       }
     }
   ],
@@ -22,7 +22,8 @@
             "common": {
               "emit": {
                 "outputMapping": [
-                  3
+                  3,
+                  4
                 ]
               }
             },
@@ -86,17 +87,56 @@
                   "arguments": [
                     {
                       "value": {
-                        "literal": {
-                          "fixedChar": "xxx3456   ",
-                          "nullable": false,
-                          "typeVariationReference": 0
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
                         }
                       }
                     },
                     {
                       "value": {
                         "literal": {
-                          "fixedChar": " x",
+                          "fixedChar": " ",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": " ",
                           "nullable": false,
                           "typeVariationReference": 0
                         }
@@ -109,7 +149,8 @@
           }
         },
         "names": [
-          "EXPR$0"
+          "EXPR$0",
+          "EXPR$1"
         ]
       }
     }

--- a/cider/tests/substrait_plan_files/stringop_rtrim_2.json
+++ b/cider/tests/substrait_plan_files/stringop_rtrim_2.json
@@ -10,7 +10,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 0,
-        "name": "trim:fchar_fchar"
+        "name": "rtrim:vchar_fchar"
       }
     }
   ],
@@ -22,7 +22,8 @@
             "common": {
               "emit": {
                 "outputMapping": [
-                  3
+                  3,
+                  4
                 ]
               }
             },
@@ -86,10 +87,49 @@
                   "arguments": [
                     {
                       "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
                         "literal": {
-                          "fixedChar": "xxx3456   ",
+                          "fixedChar": " x",
                           "nullable": false,
                           "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
                         }
                       }
                     },
@@ -109,7 +149,8 @@
           }
         },
         "names": [
-          "EXPR$0"
+          "EXPR$0",
+          "EXPR$1"
         ]
       }
     }

--- a/cider/tests/substrait_plan_files/stringop_rtrim_literal.json
+++ b/cider/tests/substrait_plan_files/stringop_rtrim_literal.json
@@ -10,7 +10,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 0,
-        "name": "trim:fchar_fchar"
+        "name": "rtrim:fchar_fchar"
       }
     }
   ],
@@ -87,7 +87,7 @@
                     {
                       "value": {
                         "literal": {
-                          "fixedChar": "xxx3456   ",
+                          "fixedChar": "xxx3456xxx",
                           "nullable": false,
                           "typeVariationReference": 0
                         }
@@ -96,7 +96,7 @@
                     {
                       "value": {
                         "literal": {
-                          "fixedChar": " x",
+                          "fixedChar": "x",
                           "nullable": false,
                           "typeVariationReference": 0
                         }

--- a/cider/tests/substrait_plan_files/stringop_rtrim_nested_1.json
+++ b/cider/tests/substrait_plan_files/stringop_rtrim_nested_1.json
@@ -1,0 +1,200 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "rtrim:vchar_fchar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 1,
+        "name": "upper:opt_vchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 1,
+                          "args": [],
+                          "outputType": {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": " X",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 0,
+                          "args": [],
+                          "outputType": {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            },
+                            {
+                              "value": {
+                                "literal": {
+                                  "fixedChar": "x",
+                                  "nullable": false,
+                                  "typeVariationReference": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0",
+          "EXPR$1"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_rtrim_nested_2.json
+++ b/cider/tests/substrait_plan_files/stringop_rtrim_nested_2.json
@@ -1,0 +1,280 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_boolean.yaml"
+    },
+    {
+      "extensionUriAnchor": 3,
+      "uri": "/functions_string.yaml"
+    },
+    {
+      "extensionUriAnchor": 2,
+      "uri": "/functions_comparison.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "or:bool"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 1,
+        "name": "equal:any_any"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 2,
+        "name": "lower:opt_vchar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 3,
+        "name": "rtrim:vchar_fchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "filter": {
+                "common": {
+                  "direct": {}
+                },
+                "input": {
+                  "read": {
+                    "common": {
+                      "direct": {}
+                    },
+                    "baseSchema": {
+                      "names": [
+                        "COL_1",
+                        "COL_2",
+                        "COL_3"
+                      ],
+                      "struct": {
+                        "types": [
+                          {
+                            "i32": {
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        ],
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "namedTable": {
+                      "names": [
+                        "TEST"
+                      ]
+                    }
+                  }
+                },
+                "condition": {
+                  "scalarFunction": {
+                    "functionReference": 0,
+                    "args": [],
+                    "outputType": {
+                      "bool": {
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_NULLABLE"
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "bool": {
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 10,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 1
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "literal": {
+                                    "varChar": {
+                                      "value": "xxxxxxxxxx",
+                                      "length": 10
+                                    },
+                                    "nullable": false,
+                                    "typeVariationReference": 0
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "bool": {
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 3,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 10,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 2
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "fixedChar": " ",
+                                            "nullable": false,
+                                            "typeVariationReference": 0
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "literal": {
+                                    "varChar": {
+                                      "value": "xxx3456",
+                                      "length": 10
+                                    },
+                                    "nullable": false,
+                                    "typeVariationReference": 0
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "expressions": [
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
+                    }
+                  },
+                  "rootReference": {}
+                }
+              },
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 2
+                    }
+                  },
+                  "rootReference": {}
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "COL_2",
+          "COL_3"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_trim_1.json
+++ b/cider/tests/substrait_plan_files/stringop_trim_1.json
@@ -10,7 +10,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 0,
-        "name": "trim:fchar_fchar"
+        "name": "trim:vchar_fchar"
       }
     }
   ],
@@ -22,7 +22,8 @@
             "common": {
               "emit": {
                 "outputMapping": [
-                  3
+                  3,
+                  4
                 ]
               }
             },
@@ -86,17 +87,56 @@
                   "arguments": [
                     {
                       "value": {
-                        "literal": {
-                          "fixedChar": "xxx3456   ",
-                          "nullable": false,
-                          "typeVariationReference": 0
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
                         }
                       }
                     },
                     {
                       "value": {
                         "literal": {
-                          "fixedChar": " x",
+                          "fixedChar": " ",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": " ",
                           "nullable": false,
                           "typeVariationReference": 0
                         }
@@ -109,7 +149,8 @@
           }
         },
         "names": [
-          "EXPR$0"
+          "EXPR$0",
+          "EXPR$1"
         ]
       }
     }

--- a/cider/tests/substrait_plan_files/stringop_trim_2.json
+++ b/cider/tests/substrait_plan_files/stringop_trim_2.json
@@ -10,7 +10,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 0,
-        "name": "trim:fchar_fchar"
+        "name": "trim:vchar_fchar"
       }
     }
   ],
@@ -22,7 +22,8 @@
             "common": {
               "emit": {
                 "outputMapping": [
-                  3
+                  3,
+                  4
                 ]
               }
             },
@@ -86,10 +87,49 @@
                   "arguments": [
                     {
                       "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
                         "literal": {
-                          "fixedChar": "xxx3456   ",
+                          "fixedChar": " x",
                           "nullable": false,
                           "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
                         }
                       }
                     },
@@ -109,7 +149,8 @@
           }
         },
         "names": [
-          "EXPR$0"
+          "EXPR$0",
+          "EXPR$1"
         ]
       }
     }

--- a/cider/tests/substrait_plan_files/stringop_trim_literal.json
+++ b/cider/tests/substrait_plan_files/stringop_trim_literal.json
@@ -1,0 +1,110 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "trim:fchar_fchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  2
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "fixedChar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": "  345678  ",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": " ",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_trim_literal_1.json
+++ b/cider/tests/substrait_plan_files/stringop_trim_literal_1.json
@@ -1,0 +1,118 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "trim:fchar_fchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": "   3456   ",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": " ",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_trim_literal_2.json
+++ b/cider/tests/substrait_plan_files/stringop_trim_literal_2.json
@@ -1,0 +1,118 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "trim:fchar_fchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": "xxx3456   ",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": "x",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_trim_literal_3.json
+++ b/cider/tests/substrait_plan_files/stringop_trim_literal_3.json
@@ -22,7 +22,7 @@
             "common": {
               "emit": {
                 "outputMapping": [
-                  2
+                  3
                 ]
               }
             },
@@ -34,7 +34,8 @@
                 "baseSchema": {
                   "names": [
                     "COL_1",
-                    "COL_2"
+                    "COL_2",
+                    "COL_3"
                   ],
                   "struct": {
                     "types": [
@@ -49,6 +50,13 @@
                           "length": 10,
                           "typeVariationReference": 0,
                           "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
                         }
                       }
                     ],
@@ -69,7 +77,7 @@
                   "functionReference": 0,
                   "args": [],
                   "outputType": {
-                    "fixedChar": {
+                    "varchar": {
                       "length": 10,
                       "typeVariationReference": 0,
                       "nullability": "NULLABILITY_REQUIRED"
@@ -79,7 +87,7 @@
                     {
                       "value": {
                         "literal": {
-                          "fixedChar": "  345678  ",
+                          "fixedChar": "xxx3456   ",
                           "nullable": false,
                           "typeVariationReference": 0
                         }
@@ -88,7 +96,7 @@
                     {
                       "value": {
                         "literal": {
-                          "fixedChar": " ",
+                          "fixedChar": " x",
                           "nullable": false,
                           "typeVariationReference": 0
                         }

--- a/cider/tests/substrait_plan_files/stringop_trim_nested_1.json
+++ b/cider/tests/substrait_plan_files/stringop_trim_nested_1.json
@@ -1,0 +1,200 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "trim:vchar_fchar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 1,
+        "name": "upper:opt_vchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 10,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 1,
+                          "args": [],
+                          "outputType": {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "fixedChar": " X",
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 10,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 0,
+                          "args": [],
+                          "outputType": {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            },
+                            {
+                              "value": {
+                                "literal": {
+                                  "fixedChar": "x",
+                                  "nullable": false,
+                                  "typeVariationReference": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0",
+          "EXPR$1"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_trim_nested_2.json
+++ b/cider/tests/substrait_plan_files/stringop_trim_nested_2.json
@@ -1,0 +1,280 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_boolean.yaml"
+    },
+    {
+      "extensionUriAnchor": 3,
+      "uri": "/functions_string.yaml"
+    },
+    {
+      "extensionUriAnchor": 2,
+      "uri": "/functions_comparison.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "or:bool"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 1,
+        "name": "equal:any_any"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 2,
+        "name": "lower:opt_vchar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 3,
+        "name": "trim:vchar_fchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "filter": {
+                "common": {
+                  "direct": {}
+                },
+                "input": {
+                  "read": {
+                    "common": {
+                      "direct": {}
+                    },
+                    "baseSchema": {
+                      "names": [
+                        "COL_1",
+                        "COL_2",
+                        "COL_3"
+                      ],
+                      "struct": {
+                        "types": [
+                          {
+                            "i32": {
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        ],
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "namedTable": {
+                      "names": [
+                        "TEST"
+                      ]
+                    }
+                  }
+                },
+                "condition": {
+                  "scalarFunction": {
+                    "functionReference": 0,
+                    "args": [],
+                    "outputType": {
+                      "bool": {
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_NULLABLE"
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "bool": {
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 10,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 1
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "literal": {
+                                    "varChar": {
+                                      "value": "xxxxxxxxxx",
+                                      "length": 10
+                                    },
+                                    "nullable": false,
+                                    "typeVariationReference": 0
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "bool": {
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 3,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 10,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 2
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "fixedChar": " ",
+                                            "nullable": false,
+                                            "typeVariationReference": 0
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "literal": {
+                                    "varChar": {
+                                      "value": "xxx3456",
+                                      "length": 10
+                                    },
+                                    "nullable": false,
+                                    "typeVariationReference": 0
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "expressions": [
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
+                    }
+                  },
+                  "rootReference": {}
+                }
+              },
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 2
+                    }
+                  },
+                  "rootReference": {}
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "COL_2",
+          "COL_3"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/type/plan/Analyzer.cpp
+++ b/cider/type/plan/Analyzer.cpp
@@ -402,6 +402,11 @@ std::shared_ptr<Analyzer::Expr> UpperStringOper::deep_copy() const {
       std::dynamic_pointer_cast<Analyzer::StringOper>(StringOper::deep_copy()));
 }
 
+std::shared_ptr<Analyzer::Expr> TrimStringOper::deep_copy() const {
+  return makeExpr<Analyzer::TrimStringOper>(
+      std::dynamic_pointer_cast<Analyzer::StringOper>(StringOper::deep_copy()));
+}
+
 std::shared_ptr<Analyzer::Expr> SubstringStringOper::deep_copy() const {
   return makeExpr<Analyzer::SubstringStringOper>(
       std::dynamic_pointer_cast<Analyzer::StringOper>(StringOper::deep_copy()));

--- a/cider/type/plan/Analyzer.h
+++ b/cider/type/plan/Analyzer.h
@@ -1842,6 +1842,50 @@ class UpperStringOper : public StringOper {
   std::vector<std::string> getArgNames() const override { return {"operand"}; }
 };
 
+class TrimStringOper : public StringOper {
+ public:
+  TrimStringOper(const SqlStringOpKind& op_kind,
+                 const std::shared_ptr<Analyzer::Expr>& input,
+                 const std::shared_ptr<Analyzer::Expr>& characters)
+      : StringOper(checkOpKindValidity(op_kind),
+                   {input, characters},
+                   getMinArgs(),
+                   getExpectedTypeFamilies(),
+                   getArgNames()) {}
+
+  TrimStringOper(const SqlStringOpKind& op_kind,
+                 const std::vector<std::shared_ptr<Analyzer::Expr>>& operands)
+      : StringOper(checkOpKindValidity(op_kind),
+                   operands,
+                   getMinArgs(),
+                   getExpectedTypeFamilies(),
+                   getArgNames()) {}
+
+  TrimStringOper(const std::shared_ptr<Analyzer::StringOper>& string_oper)
+      : StringOper(string_oper) {}
+
+  std::shared_ptr<Analyzer::Expr> deep_copy() const override;
+
+  size_t getMinArgs() const override { return 2UL; }
+
+  std::vector<OperandTypeFamily> getExpectedTypeFamilies() const override {
+    return {OperandTypeFamily::STRING_FAMILY, OperandTypeFamily::STRING_FAMILY};
+  }
+
+  std::vector<std::string> getArgNames() const override {
+    // args[0]: the string to remove characters from
+    // args[1]: the set of characters to remove
+    return {"input", "characters"};
+  }
+
+ private:
+  SqlStringOpKind checkOpKindValidity(const SqlStringOpKind& op_kind) {
+    CHECK(op_kind == SqlStringOpKind::TRIM || op_kind == SqlStringOpKind::LTRIM ||
+          op_kind == SqlStringOpKind::RTRIM);
+    return op_kind;
+  }
+};
+
 class SubstringStringOper : public StringOper {
  public:
   SubstringStringOper(const std::shared_ptr<Analyzer::Expr>& operand,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Arrow format support for scalar function TRIM (String Op) and its variants (LTRIM/RTRIM).

1. Enabled existing code for TRIM plan nodes to EU conversion.
2. Added patches for TRIM ops.
3. Added tests for TRIM/LTRIM/RTRIM. Substrait plans for TRIM UTs are currently **manually created** because modifying substrait-java to support conversion of TRIM ops is a bit nontrivial.
4. Fixed bug in `Trim::operator()` when dealing with RTRIM. It erroneously retained 1 char in cases where all characters should be trimmed (e.g. `RTRIM('xxxxx', 'x')` returns `'x'` instead of `''`).

### Why are the changes needed?

Arrow format migration.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UTs.

### Which label does this PR belong to?

