### PR TITLE
[POAE7-2560] Scalar function support: string concatenation

### DIFF
--- a/cider/exec/plan/parser/SubstraitToAnalyzerExpr.cpp
+++ b/cider/exec/plan/parser/SubstraitToAnalyzerExpr.cpp
@@ -810,8 +810,8 @@ std::shared_ptr<Analyzer::Expr> Substrait2AnalyzerExprConverter::buildStrExpr(
       //      return makeExpr<Analyzer::ReverseStringOper>(args);
       //    case SqlStringOpKind::REPEAT:
       //      return makeExpr<Analyzer::RepeatStringOper>(args);
-      //    case SqlStringOpKind::CONCAT:
-      //      return makeExpr<Analyzer::ConcatStringOper>(args);
+         case SqlStringOpKind::CONCAT:
+           return makeExpr<Analyzer::ConcatStringOper>(args);
       //    case SqlStringOpKind::LPAD:
       //    case SqlStringOpKind::RPAD: {
       //      return makeExpr<Analyzer::PadStringOper>(string_op_kind, args);

--- a/cider/exec/plan/parser/SubstraitToAnalyzerExpr.cpp
+++ b/cider/exec/plan/parser/SubstraitToAnalyzerExpr.cpp
@@ -810,8 +810,8 @@ std::shared_ptr<Analyzer::Expr> Substrait2AnalyzerExprConverter::buildStrExpr(
       //      return makeExpr<Analyzer::ReverseStringOper>(args);
       //    case SqlStringOpKind::REPEAT:
       //      return makeExpr<Analyzer::RepeatStringOper>(args);
-         case SqlStringOpKind::CONCAT:
-           return makeExpr<Analyzer::ConcatStringOper>(args);
+    case SqlStringOpKind::CONCAT:
+      return makeExpr<Analyzer::ConcatStringOper>(args);
       //    case SqlStringOpKind::LPAD:
       //    case SqlStringOpKind::RPAD: {
       //      return makeExpr<Analyzer::PadStringOper>(string_op_kind, args);

--- a/cider/exec/plan/parser/SubstraitToAnalyzerExpr.cpp
+++ b/cider/exec/plan/parser/SubstraitToAnalyzerExpr.cpp
@@ -38,7 +38,7 @@ bool getExprUpdatable(std::unordered_map<std::shared_ptr<Analyzer::Expr>, bool> 
 
 bool isStringFunction(const std::string& function_name) {
   std::unordered_set<std::string> supportedStrFunctionSet{
-      "substring", "substr", "lower", "upper", "trim", "ltrim", "rtrim"};
+      "substring", "substr", "lower", "upper", "trim", "ltrim", "rtrim", "concat", "||"};
   return supportedStrFunctionSet.find(function_name) != supportedStrFunctionSet.end();
 }
 

--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -538,7 +538,7 @@ TEST_F(CiderStringNullableTestArrow, ArrowCaseConvertionTest) {
 }
 
 TEST_F(CiderStringTestArrow, ConcatTest) {
-  // Isthmus does not support concatenating two literals
+  // Skipped because Isthmus does not support concatenating two literals
   // assertQueryArrow("SELECT 'foo' || 'bar' FROM test;");
 
   assertQueryArrow("SELECT col_2 || 'foobar' FROM test;");

--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -529,6 +529,22 @@ TEST_F(CiderStringNullableTestArrow, ArrowCaseConvertionTest) {
                    "stringop_upper_condition_null.json");
 }
 
+TEST_F(CiderStringNullableTestArrow, ConcatTest) {
+  // Isthmus does not support concatenating two literals
+  // assertQueryArrow("SELECT 'foo' || 'bar' FROM test;");
+
+  assertQueryArrow("SELECT col_2 || 'foobar' FROM test;");
+  assertQueryArrow("SELECT 'foobar' || col_2 FROM test;");
+
+  // assertQueryArrow("SELECT 'foo' || 'bar' || col_2 FROM test;");
+  assertQueryArrow("SELECT 'foo' || col_2 || 'bar' FROM test;");
+  assertQueryArrow("SELECT col_2 || 'foo' || 'bar' FROM test;");
+
+  assertQueryArrow("SELECT SUBSTRING(col_2, 1, 3) || 'yo' FROM test;");
+  // Isthmus does not support this either
+  // assertQueryArrow("SELECT col_2 FROM test WHERE SUBSTRING('yo' || col_2, 3) = col_2;");
+}
+
 class CiderTrimOpTestArrow : public CiderTestBase {
  public:
   CiderTrimOpTestArrow() {

--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -498,6 +498,14 @@ TEST_F(CiderStringTestArrow, ArrowCaseConvertionTest) {
   assertQueryArrow("SELECT col_2 FROM test WHERE UPPER(col_2) = 'AAAAAAAAAA'",
                    "stringop_upper_condition.json");
 
+  // nested stringops
+  assertQueryArrow(
+      "SELECT col_2 FROM test "
+      "WHERE UPPER(SUBSTRING(col_2, 1, 4)) = LOWER(SUBSTRING(col_2, 1, 4));",
+      "stringop_upper_nested_1.json");
+  assertQueryArrow("SELECT col_2 FROM test WHERE UPPER(LOWER(col_2)) = col_2;",
+                   "stringop_upper_nested_2.json");
+
   /// NOTE: (YBRua) Skipped for now because we dont expect queries without FROM clauses.
   /// 1. Behaviors of Cider and DuckDb are different w.r.t. this query.
   ///    DuckDb produces only 1 row, while Cider produces input_row_num rows.
@@ -529,7 +537,7 @@ TEST_F(CiderStringNullableTestArrow, ArrowCaseConvertionTest) {
                    "stringop_upper_condition_null.json");
 }
 
-TEST_F(CiderStringNullableTestArrow, ConcatTest) {
+TEST_F(CiderStringTestArrow, ConcatTest) {
   // Isthmus does not support concatenating two literals
   // assertQueryArrow("SELECT 'foo' || 'bar' FROM test;");
 
@@ -541,8 +549,23 @@ TEST_F(CiderStringNullableTestArrow, ConcatTest) {
   assertQueryArrow("SELECT col_2 || 'foo' || 'bar' FROM test;");
 
   assertQueryArrow("SELECT SUBSTRING(col_2, 1, 3) || 'yo' FROM test;");
-  // Isthmus does not support this either
-  // assertQueryArrow("SELECT col_2 FROM test WHERE SUBSTRING('yo' || col_2, 3) = col_2;");
+  assertQueryArrow("SELECT col_2 FROM test WHERE UPPER('yo' || col_2) <> col_2;",
+                   "stringop_concat_filter.json");
+}
+
+TEST_F(CiderStringNullableTestArrow, ConcatTest) {
+  // assertQueryArrow("SELECT 'foo' || 'bar' FROM test;");
+
+  assertQueryArrow("SELECT col_2 || 'foobar' FROM test;");
+  assertQueryArrow("SELECT 'foobar' || col_2 FROM test;");
+
+  // assertQueryArrow("SELECT 'foo' || 'bar' || col_2 FROM test;");
+  assertQueryArrow("SELECT 'foo' || col_2 || 'bar' FROM test;");
+  assertQueryArrow("SELECT col_2 || 'foo' || 'bar' FROM test;");
+
+  assertQueryArrow("SELECT SUBSTRING(col_2, 1, 3) || 'yo' FROM test;");
+  assertQueryArrow("SELECT col_2 FROM test WHERE UPPER(col_2 || 'yo') <> col_2;",
+                   "stringop_concat_filter_null.json");
 }
 
 class CiderTrimOpTestArrow : public CiderTestBase {
@@ -629,6 +652,9 @@ TEST_F(CiderTrimOpTestArrow, NestedTrimTest) {
       "SELECT col_2, col_3 FROM test "
       "WHERE LOWER(col_2) = 'xxxxxxxxxx' OR RTRIM(col_3) = 'xxx3456'",
       "stringop_rtrim_nested_2.json");
+
+  assertQueryArrow("SELECT col_3 FROM test WHERE TRIM(TRIM(col_3, ' '), 'x') = '3456'",
+                   "stringop_trim_nested_3.json");
 }
 
 class CiderConstantStringTest : public CiderTestBase {

--- a/cider/tests/substrait_plan_files/stringop_concat_filter.json
+++ b/cider/tests/substrait_plan_files/stringop_concat_filter.json
@@ -1,0 +1,225 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 2,
+      "uri": "/functions_string.yaml"
+    },
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_comparison.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "not_equal:any_any"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 1,
+        "name": "upper:opt_vchar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 2,
+        "name": "concat:vchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3
+                ]
+              }
+            },
+            "input": {
+              "filter": {
+                "common": {
+                  "direct": {}
+                },
+                "input": {
+                  "read": {
+                    "common": {
+                      "direct": {}
+                    },
+                    "baseSchema": {
+                      "names": [
+                        "COL_1",
+                        "COL_2",
+                        "COL_3"
+                      ],
+                      "struct": {
+                        "types": [
+                          {
+                            "i32": {
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        ],
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "namedTable": {
+                      "names": [
+                        "TEST"
+                      ]
+                    }
+                  }
+                },
+                "condition": {
+                  "scalarFunction": {
+                    "functionReference": 0,
+                    "args": [],
+                    "outputType": {
+                      "bool": {
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "varchar": {
+                                "length": 12,
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 12,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "cast": {
+                                            "type": {
+                                              "varchar": {
+                                                "length": 10,
+                                                "typeVariationReference": 0,
+                                                "nullability": "NULLABILITY_REQUIRED"
+                                              }
+                                            },
+                                            "input": {
+                                              "literal": {
+                                                "fixedChar": "yo",
+                                                "nullable": false,
+                                                "typeVariationReference": 0
+                                              }
+                                            },
+                                            "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 1
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "value": {
+                          "cast": {
+                            "type": {
+                              "varchar": {
+                                "length": 12,
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "input": {
+                              "selection": {
+                                "directReference": {
+                                  "structField": {
+                                    "field": 1
+                                  }
+                                },
+                                "rootReference": {}
+                              }
+                            },
+                            "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "expressions": [
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
+                    }
+                  },
+                  "rootReference": {}
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "COL_2"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_concat_filter_null.json
+++ b/cider/tests/substrait_plan_files/stringop_concat_filter_null.json
@@ -1,0 +1,225 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 2,
+      "uri": "/functions_string.yaml"
+    },
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_comparison.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "not_equal:any_any"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 1,
+        "name": "upper:opt_vchar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 2,
+        "name": "concat:vchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3
+                ]
+              }
+            },
+            "input": {
+              "filter": {
+                "common": {
+                  "direct": {}
+                },
+                "input": {
+                  "read": {
+                    "common": {
+                      "direct": {}
+                    },
+                    "baseSchema": {
+                      "names": [
+                        "COL_1",
+                        "COL_2",
+                        "COL_3"
+                      ],
+                      "struct": {
+                        "types": [
+                          {
+                            "i32": {
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        ],
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "namedTable": {
+                      "names": [
+                        "TEST"
+                      ]
+                    }
+                  }
+                },
+                "condition": {
+                  "scalarFunction": {
+                    "functionReference": 0,
+                    "args": [],
+                    "outputType": {
+                      "bool": {
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_NULLABLE"
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "varchar": {
+                                "length": 12,
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 12,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 1
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "cast": {
+                                            "type": {
+                                              "varchar": {
+                                                "length": 10,
+                                                "typeVariationReference": 0,
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "input": {
+                                              "literal": {
+                                                "fixedChar": "yo",
+                                                "nullable": false,
+                                                "typeVariationReference": 0
+                                              }
+                                            },
+                                            "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "value": {
+                          "cast": {
+                            "type": {
+                              "varchar": {
+                                "length": 12,
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "input": {
+                              "selection": {
+                                "directReference": {
+                                  "structField": {
+                                    "field": 1
+                                  }
+                                },
+                                "rootReference": {}
+                              }
+                            },
+                            "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "expressions": [
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
+                    }
+                  },
+                  "rootReference": {}
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "COL_2"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_trim_nested_3.json
+++ b/cider/tests/substrait_plan_files/stringop_trim_nested_3.json
@@ -1,0 +1,203 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 2,
+      "uri": "/functions_string.yaml"
+    },
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_comparison.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "equal:any_any"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 1,
+        "name": "trim:vchar_vchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3
+                ]
+              }
+            },
+            "input": {
+              "filter": {
+                "common": {
+                  "direct": {}
+                },
+                "input": {
+                  "read": {
+                    "common": {
+                      "direct": {}
+                    },
+                    "baseSchema": {
+                      "names": [
+                        "COL_1",
+                        "COL_2",
+                        "COL_3"
+                      ],
+                      "struct": {
+                        "types": [
+                          {
+                            "i32": {
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        ],
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "namedTable": {
+                      "names": [
+                        "TEST"
+                      ]
+                    }
+                  }
+                },
+                "condition": {
+                  "scalarFunction": {
+                    "functionReference": 0,
+                    "args": [],
+                    "outputType": {
+                      "bool": {
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_NULLABLE"
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "varchar": {
+                                "length": 10,
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 1,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 10,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 2
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "fixedChar": " ",
+                                            "nullable": false,
+                                            "typeVariationReference": 0
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "literal": {
+                                    "fixedChar": "x",
+                                    "nullable": false,
+                                    "typeVariationReference": 0
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "value": {
+                          "literal": {
+                            "varChar": {
+                              "value": "3456",
+                              "length": 10
+                            },
+                            "nullable": false,
+                            "typeVariationReference": 0
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "expressions": [
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 2
+                    }
+                  },
+                  "rootReference": {}
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "COL_3"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_upper_nested_1.json
+++ b/cider/tests/substrait_plan_files/stringop_upper_nested_1.json
@@ -1,0 +1,269 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 2,
+      "uri": "/functions_string.yaml"
+    },
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_comparison.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "equal:any_any"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 1,
+        "name": "upper:opt_vchar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 2,
+        "name": "substring:vchar_i32_i32"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 3,
+        "name": "lower:opt_vchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3
+                ]
+              }
+            },
+            "input": {
+              "filter": {
+                "common": {
+                  "direct": {}
+                },
+                "input": {
+                  "read": {
+                    "common": {
+                      "direct": {}
+                    },
+                    "baseSchema": {
+                      "names": [
+                        "COL_1",
+                        "COL_2",
+                        "COL_3"
+                      ],
+                      "struct": {
+                        "types": [
+                          {
+                            "i32": {
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        ],
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "namedTable": {
+                      "names": [
+                        "TEST"
+                      ]
+                    }
+                  }
+                },
+                "condition": {
+                  "scalarFunction": {
+                    "functionReference": 0,
+                    "args": [],
+                    "outputType": {
+                      "bool": {
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "varchar": {
+                                "length": 10,
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 10,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 1
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "i32": 1,
+                                            "nullable": false,
+                                            "typeVariationReference": 0
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "i32": 4,
+                                            "nullable": false,
+                                            "typeVariationReference": 0
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 3,
+                            "args": [],
+                            "outputType": {
+                              "varchar": {
+                                "length": 10,
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 10,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 1
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "i32": 1,
+                                            "nullable": false,
+                                            "typeVariationReference": 0
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "i32": 4,
+                                            "nullable": false,
+                                            "typeVariationReference": 0
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "expressions": [
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
+                    }
+                  },
+                  "rootReference": {}
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "COL_2"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_upper_nested_2.json
+++ b/cider/tests/substrait_plan_files/stringop_upper_nested_2.json
@@ -1,0 +1,192 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 2,
+      "uri": "/functions_string.yaml"
+    },
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_comparison.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "equal:any_any"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 1,
+        "name": "upper:opt_vchar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 2,
+        "functionAnchor": 2,
+        "name": "lower:opt_vchar"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3
+                ]
+              }
+            },
+            "input": {
+              "filter": {
+                "common": {
+                  "direct": {}
+                },
+                "input": {
+                  "read": {
+                    "common": {
+                      "direct": {}
+                    },
+                    "baseSchema": {
+                      "names": [
+                        "COL_1",
+                        "COL_2",
+                        "COL_3"
+                      ],
+                      "struct": {
+                        "types": [
+                          {
+                            "i32": {
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          {
+                            "varchar": {
+                              "length": 10,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        ],
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "namedTable": {
+                      "names": [
+                        "TEST"
+                      ]
+                    }
+                  }
+                },
+                "condition": {
+                  "scalarFunction": {
+                    "functionReference": 0,
+                    "args": [],
+                    "outputType": {
+                      "bool": {
+                        "typeVariationReference": 0,
+                        "nullability": "NULLABILITY_REQUIRED"
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "args": [],
+                            "outputType": {
+                              "varchar": {
+                                "length": 10,
+                                "typeVariationReference": 0,
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "args": [],
+                                    "outputType": {
+                                      "varchar": {
+                                        "length": 10,
+                                        "typeVariationReference": 0,
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 1
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "value": {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 1
+                              }
+                            },
+                            "rootReference": {}
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "expressions": [
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
+                    }
+                  },
+                  "rootReference": {}
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "COL_2"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/type/plan/Analyzer.cpp
+++ b/cider/type/plan/Analyzer.cpp
@@ -417,6 +417,11 @@ std::shared_ptr<Analyzer::Expr> TryStringCastOper::deep_copy() const {
       std::dynamic_pointer_cast<Analyzer::StringOper>(StringOper::deep_copy()));
 }
 
+std::shared_ptr<Analyzer::Expr> ConcatStringOper::deep_copy() const {
+  return makeExpr<Analyzer::ConcatStringOper>(
+      std::dynamic_pointer_cast<Analyzer::StringOper>(StringOper::deep_copy()));
+}
+
 std::shared_ptr<Analyzer::Expr> LowerExpr::deep_copy() const {
   return makeExpr<LowerExpr>(arg->deep_copy());
 }

--- a/cider/type/plan/Analyzer.h
+++ b/cider/type/plan/Analyzer.h
@@ -1311,7 +1311,7 @@ class StringOper : public Expr {
     CHECK(false);
     return {};
   }
-  virtual std::vector<std::string> getArgNames() const {
+  virtual const std::vector<std::string>& getArgNames() const {
     CHECK(false);
     return {};
   }
@@ -1359,7 +1359,7 @@ class LowerStringOper : public StringOper {
     return {OperandTypeFamily::STRING_FAMILY};
   }
 
-  std::vector<std::string> getArgNames() const override { return {"operand"}; }
+  const std::vector<std::string>& getArgNames() const override { return {"operand"}; }
 };
 
 class UpperStringOper : public StringOper {
@@ -1389,7 +1389,7 @@ class UpperStringOper : public StringOper {
     return {OperandTypeFamily::STRING_FAMILY};
   }
 
-  std::vector<std::string> getArgNames() const override { return {"operand"}; }
+  const std::vector<std::string>& getArgNames() const override { return {"operand"}; }
 };
 
 class TrimStringOper : public StringOper {
@@ -1422,7 +1422,7 @@ class TrimStringOper : public StringOper {
     return {OperandTypeFamily::STRING_FAMILY, OperandTypeFamily::STRING_FAMILY};
   }
 
-  std::vector<std::string> getArgNames() const override {
+  const std::vector<std::string>& getArgNames() const override {
     // args[0]: the string to remove characters from
     // args[1]: the set of characters to remove
     return {"input", "characters"};
@@ -1474,7 +1474,7 @@ class SubstringStringOper : public StringOper {
             OperandTypeFamily::INT_FAMILY,
             OperandTypeFamily::INT_FAMILY};
   }
-  std::vector<std::string> getArgNames() const override {
+  const std::vector<std::string>& getArgNames() const override {
     return {"operand", "start position", "substring length"};
   }
 };
@@ -1507,7 +1507,7 @@ class ConcatStringOper : public StringOper {
     return {OperandTypeFamily::STRING_FAMILY, OperandTypeFamily::STRING_FAMILY};
   }
 
-  std::vector<std::string> getArgNames() const override {
+  const std::vector<std::string>& getArgNames() const override {
     return {"operand_0", "operand_1"};
   }
 
@@ -1550,7 +1550,7 @@ class TryStringCastOper : public StringOper {
   std::vector<OperandTypeFamily> getExpectedTypeFamilies() const override {
     return {OperandTypeFamily::STRING_FAMILY};
   }
-  std::vector<std::string> getArgNames() const override { return {"operand"}; }
+  const std::vector<std::string>& getArgNames() const override { return {"operand"}; }
 };
 
 class FunctionOper : public Expr {

--- a/cider/type/plan/Analyzer.h
+++ b/cider/type/plan/Analyzer.h
@@ -1359,7 +1359,10 @@ class LowerStringOper : public StringOper {
     return {OperandTypeFamily::STRING_FAMILY};
   }
 
-  const std::vector<std::string>& getArgNames() const override { return {"operand"}; }
+  const std::vector<std::string>& getArgNames() const override {
+    static std::vector<std::string> names{"operand"};
+    return names;
+  }
 };
 
 class UpperStringOper : public StringOper {
@@ -1389,7 +1392,10 @@ class UpperStringOper : public StringOper {
     return {OperandTypeFamily::STRING_FAMILY};
   }
 
-  const std::vector<std::string>& getArgNames() const override { return {"operand"}; }
+  const std::vector<std::string>& getArgNames() const override {
+    static std::vector<std::string> names{"operand"};
+    return names;
+  }
 };
 
 class TrimStringOper : public StringOper {
@@ -1425,7 +1431,8 @@ class TrimStringOper : public StringOper {
   const std::vector<std::string>& getArgNames() const override {
     // args[0]: the string to remove characters from
     // args[1]: the set of characters to remove
-    return {"input", "characters"};
+    static std::vector<std::string> names{"input", "characters"};
+    return names;
   }
 
  private:
@@ -1475,7 +1482,8 @@ class SubstringStringOper : public StringOper {
             OperandTypeFamily::INT_FAMILY};
   }
   const std::vector<std::string>& getArgNames() const override {
-    return {"operand", "start position", "substring length"};
+    static std::vector<std::string> names{"operand", "start_pos", "substr_len"};
+    return names;
   }
 };
 
@@ -1508,7 +1516,8 @@ class ConcatStringOper : public StringOper {
   }
 
   const std::vector<std::string>& getArgNames() const override {
-    return {"operand_0", "operand_1"};
+    static std::vector<std::string> names{"operand_0", "operand_1"};
+    return names;
   }
 
  private:
@@ -1550,7 +1559,10 @@ class TryStringCastOper : public StringOper {
   std::vector<OperandTypeFamily> getExpectedTypeFamilies() const override {
     return {OperandTypeFamily::STRING_FAMILY};
   }
-  const std::vector<std::string>& getArgNames() const override { return {"operand"}; }
+  const std::vector<std::string>& getArgNames() const override {
+    static std::vector<std::string> names{"operand"};
+    return names;
+  }
 };
 
 class FunctionOper : public Expr {

--- a/cider/type/plan/Analyzer.h
+++ b/cider/type/plan/Analyzer.h
@@ -1433,17 +1433,16 @@ class TrimStringOper : public StringOper {
     CHECK(op_kind == SqlStringOpKind::TRIM || op_kind == SqlStringOpKind::LTRIM ||
           op_kind == SqlStringOpKind::RTRIM);
     return op_kind;
+    return {"operand_0", "operand_1"};
   }
-};
 
-class SubstringStringOper : public StringOper {
- public:
-  SubstringStringOper(const std::shared_ptr<Analyzer::Expr>& operand,
-                      const std::shared_ptr<Analyzer::Expr>& start_pos)
-      : StringOper(SqlStringOpKind::SUBSTRING,
-                   {operand, start_pos},
-                   getMinArgs(),
-                   getExpectedTypeFamilies(),
+ private:
+  SqlStringOpKind getConcatOpKind(
+      const std::vector<std::shared_ptr<Analyzer::Expr>>& operands) {
+    CHECK_EQ(operands.size(), 2);
+    auto constant_arg0 = dynamic_cast<const Analyzer::Constant*>(operands[0].get());
+    auto constant_arg1 = dynamic_cast<const Analyzer::Constant*>(operands[1].get());
+
                    getArgNames()) {}
 
   SubstringStringOper(const std::shared_ptr<Analyzer::Expr>& operand,

--- a/cider/util/sqldefs.h
+++ b/cider/util/sqldefs.h
@@ -139,6 +139,7 @@ enum ViewRefreshOption { kMANUAL = 0, kAUTO = 1, kIMMEDIATE = 2 };
 enum class JoinType { INNER, LEFT, SEMI, ANTI, INVALID };
 
 #include <string>
+#include <unordered_map>
 #include "util/Logger.h"
 
 inline std::string toString(const JoinType& join_type) {
@@ -306,74 +307,40 @@ inline std::ostream& operator<<(std::ostream& os, const SqlStringOpKind kind) {
 }
 
 inline SqlStringOpKind name_to_string_op_kind(const std::string& func_name) {
-  if (func_name == "LOWER") {
-    return SqlStringOpKind::LOWER;
+  const static std::unordered_map<std::string, SqlStringOpKind> name_to_string_map{
+      {"LOWER", SqlStringOpKind::LOWER},
+      {"UPPER", SqlStringOpKind::UPPER},
+      {"INITCAP", SqlStringOpKind::INITCAP},
+      {"REVERSE", SqlStringOpKind::REVERSE},
+      {"REPEAT", SqlStringOpKind::REPEAT},
+      {"||", SqlStringOpKind::CONCAT},
+      {"CONCAT", SqlStringOpKind::CONCAT},
+      {"LPAD", SqlStringOpKind::LPAD},
+      {"RPAD", SqlStringOpKind::RPAD},
+      {"TRIM", SqlStringOpKind::TRIM},
+      {"LTRIM", SqlStringOpKind::LTRIM},
+      {"RTRIM", SqlStringOpKind::RTRIM},
+      {"SUBSTRING", SqlStringOpKind::SUBSTRING},
+      {"SUBSTR", SqlStringOpKind::SUBSTRING},
+      {"OVERLAY", SqlStringOpKind::OVERLAY},
+      {"REPLACE", SqlStringOpKind::REPLACE},
+      {"SPLIT_PART", SqlStringOpKind::SPLIT_PART},
+      {"REGEXP_REPLACE", SqlStringOpKind::REGEXP_REPLACE},
+      {"REGEXP_SUBSTR", SqlStringOpKind::REGEXP_SUBSTR},
+      {"REGEXP_MATCH", SqlStringOpKind::REGEXP_SUBSTR},
+      {"JSON_VALUE", SqlStringOpKind::JSON_VALUE},
+      {"BASE64_ENCODE", SqlStringOpKind::BASE64_ENCODE},
+      {"BASE64_DECODE", SqlStringOpKind::BASE64_DECODE},
+      {"TRY_CAST", SqlStringOpKind::TRY_STRING_CAST}};
+
+  auto op_kind_entry = name_to_string_map.find(func_name);
+
+  if (op_kind_entry == name_to_string_map.end()) {
+    LOG(FATAL) << "Invalid string function " << func_name << ".";
+    return SqlStringOpKind::INVALID;
   }
-  if (func_name == "UPPER") {
-    return SqlStringOpKind::UPPER;
-  }
-  if (func_name == "INITCAP") {
-    return SqlStringOpKind::INITCAP;
-  }
-  if (func_name == "REVERSE") {
-    return SqlStringOpKind::REVERSE;
-  }
-  if (func_name == "REPEAT") {
-    return SqlStringOpKind::REPEAT;
-  }
-  if (func_name == "||" || func_name == "CONCAT") {
-    return SqlStringOpKind::CONCAT;
-  }
-  if (func_name == "LPAD") {
-    return SqlStringOpKind::LPAD;
-  }
-  if (func_name == "RPAD") {
-    return SqlStringOpKind::RPAD;
-  }
-  if (func_name == "TRIM") {
-    return SqlStringOpKind::TRIM;
-  }
-  if (func_name == "LTRIM") {
-    return SqlStringOpKind::LTRIM;
-  }
-  if (func_name == "RTRIM") {
-    return SqlStringOpKind::RTRIM;
-  }
-  if (func_name == "SUBSTRING" || func_name == "SUBSTR") {
-    return SqlStringOpKind::SUBSTRING;
-  }
-  if (func_name == "OVERLAY") {
-    return SqlStringOpKind::OVERLAY;
-  }
-  if (func_name == "REPLACE") {
-    return SqlStringOpKind::REPLACE;
-  }
-  if (func_name == "SPLIT_PART") {
-    return SqlStringOpKind::SPLIT_PART;
-  }
-  if (func_name == "REGEXP_REPLACE") {
-    return SqlStringOpKind::REGEXP_REPLACE;
-  }
-  if (func_name == "REGEXP_SUBSTR") {
-    return SqlStringOpKind::REGEXP_SUBSTR;
-  }
-  if (func_name == "REGEXP_MATCH") {
-    return SqlStringOpKind::REGEXP_SUBSTR;
-  }
-  if (func_name == "JSON_VALUE") {
-    return SqlStringOpKind::JSON_VALUE;
-  }
-  if (func_name == "BASE64_ENCODE") {
-    return SqlStringOpKind::BASE64_ENCODE;
-  }
-  if (func_name == "BASE64_DECODE") {
-    return SqlStringOpKind::BASE64_DECODE;
-  }
-  if (func_name == "TRY_CAST") {
-    return SqlStringOpKind::TRY_STRING_CAST;
-  }
-  LOG(FATAL) << "Invalid string function " << func_name << ".";
-  return SqlStringOpKind::INVALID;
+
+  return op_kind_entry->second;
 }
 
 inline std::string toString(const SqlStringOpKind& kind) {

--- a/cider/util/sqldefs.h
+++ b/cider/util/sqldefs.h
@@ -321,7 +321,7 @@ inline SqlStringOpKind name_to_string_op_kind(const std::string& func_name) {
   if (func_name == "REPEAT") {
     return SqlStringOpKind::REPEAT;
   }
-  if (func_name == "||") {
+  if (func_name == "||" || func_name == "CONCAT") {
     return SqlStringOpKind::CONCAT;
   }
   if (func_name == "LPAD") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added support for string concatenation ops (`col_1 || 'blah'`, which means `CONCAT(col_1, 'blah')`).

1. Added support for concatenating literals with literals (`literal || literal`) and literals with variables (`literal || column`). Note that currently concatenating two columns is not supported.
2. substrait-java only recognizes the `||` operator as string concatenation, and does not support parsing `CONCAT` function. So all test cases used `||` operator.
3. Fixed bug in nested stringop expression folding. When a nested stringop exists in a `WHERE` clause, inner stringops will be accidentally folded and dropped. Check the notes in the source code for details.
4. Added more complicated nested stringop test cases.

### Why are the changes needed?

Adding stringop features.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT.

### Which label does this PR belong to?

