### PR TITLE
[POAE7-2623] support ISNULL/ISNOTNULL in nextgen

### DIFF
--- a/cider/exec/nextgen/operators/RowToColumnNode.cpp
+++ b/cider/exec/nextgen/operators/RowToColumnNode.cpp
@@ -43,7 +43,7 @@ class ColumnWriter {
       , arrow_array_len_(arrow_array_len) {}
 
   void write() {
-    CHECK(0 == expr_->getLocalIndex());
+    // CHECK(0 == expr_->getLocalIndex());
     switch (expr_->get_type_info().get_type()) {
       case kTINYINT:
       case kSMALLINT:

--- a/cider/exec/nextgen/parsers/RelAlgEUParser.cpp
+++ b/cider/exec/nextgen/parsers/RelAlgEUParser.cpp
@@ -70,12 +70,11 @@ class InputAnalyzer {
       }
     }
 
-    for (size_t i = 0; i < input_exprs_.size(); ++i) {
-      if (nullptr == input_exprs_[i]) {
-        LOG(FATAL) << "Input column expr missed. Column descriptor = "
-                   << input_desc_[i].toString();
-      }
-    }
+    input_exprs_.erase(
+        std::remove_if(input_exprs_.begin(),
+                       input_exprs_.end(),
+                       [](const ExprPtr& input_expr) { return input_expr == nullptr; }),
+        input_exprs_.end());
 
     pipeline_.insert(pipeline_.begin(), createOpNode<ArrowSourceNode>(input_exprs_));
   }
@@ -129,6 +128,9 @@ OpPipeline toOpPipeline(const RelAlgExecutionUnit& eu) {
   OpPipeline ops;
 
   ExprPtrVector filters;
+  for (auto& filter_expr : eu.simple_quals) {
+    filters.push_back(filter_expr);
+  }
   for (auto& filter_expr : eu.quals) {
     filters.push_back(filter_expr);
   }

--- a/cider/tests/nextgen/functional/CMakeLists.txt
+++ b/cider/tests/nextgen/functional/CMakeLists.txt
@@ -17,9 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# TODO: Temporarily disable benchmark target until we finish nextgen test
-# framework and integrate the target with the new framework.
-# add_subdirectory(benchmark)
-add_subdirectory(jitlib)
-add_subdirectory(compiler)
-add_subdirectory(functional)
+set(NEXTGEN_TEST_DEPS nextgen test_utils cider_plan_parser)
+
+add_executable(CiderUOperNextgenTest CiderUOperNextgenTest.cpp)
+target_link_libraries(CiderUOperNextgenTest ${EXECUTE_TEST_LIBS}
+                      ${NEXTGEN_TEST_DEPS})
+add_test(CiderUOperNextgenTest ${EXECUTABLE_OUTPUT_PATH}/CiderUOperNextgenTest
+         ${TEST_ARGS})

--- a/cider/tests/nextgen/functional/CiderUOperNextgenTest.cpp
+++ b/cider/tests/nextgen/functional/CiderUOperNextgenTest.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <google/protobuf/util/json_util.h>
+#include <gtest/gtest.h>
+
+#include "exec/nextgen/Nextgen.h"
+#include "exec/plan/parser/SubstraitToRelAlgExecutionUnit.h"
+#include "exec/plan/parser/TypeUtils.h"
+#include "tests/TestHelpers.h"
+#include "tests/utils/ArrowArrayBuilder.h"
+#include "tests/utils/Utils.h"
+
+using namespace cider::exec::nextgen;
+
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
+
+class CiderUOperNextgenTest : public ::testing::Test {
+ public:
+  void executeTest(const std::string& create_ddl,
+                   const std::string& sql,
+                   const int32_t& expected_length) {
+    // SQL Parsing
+    auto json = RunIsthmus::processSql(sql, create_ddl);
+    ::substrait::Plan plan;
+    google::protobuf::util::JsonStringToMessage(json, &plan);
+
+    generator::SubstraitToRelAlgExecutionUnit substrait2eu(plan);
+    auto eu = substrait2eu.createRelAlgExecutionUnit();
+
+    // Pipeline Building
+    auto pipeline = parsers::toOpPipeline(eu);
+    transformer::Transformer transformer;
+    auto translators = transformer.toTranslator(pipeline);
+
+    // Codegen
+    context::CodegenContext codegen_ctx;
+    auto module = cider::jitlib::LLVMJITModule("test", true);
+    cider::jitlib::JITFunctionPointer function =
+        cider::jitlib::JITFunctionBuilder()
+            .registerModule(module)
+            .setFuncName("query_func")
+            .addReturn(cider::jitlib::JITTypeTag::VOID)
+            .addParameter(cider::jitlib::JITTypeTag::POINTER,
+                          "context",
+                          cider::jitlib::JITTypeTag::INT8)
+            .addParameter(cider::jitlib::JITTypeTag::POINTER,
+                          "input",
+                          cider::jitlib::JITTypeTag::INT8)
+            .addProcedureBuilder(
+                [&codegen_ctx, &translators](cider::jitlib::JITFunction* func) {
+                  codegen_ctx.setJITFunction(func);
+                  translators->consume(codegen_ctx);
+                  func->createReturn();
+                })
+            .build();
+    module.finish();
+    auto query_func = function->getFunctionPointer<void, int8_t*, int8_t*>();
+
+    // Execution
+    auto runtime_ctx = codegen_ctx.generateRuntimeCTX(allocator);
+
+    std::vector<int> vec0{1, 3, 2, 1, 6};
+    std::vector<int> vec1{1, 2, 3, 4, 5};
+    std::vector<bool> vec_null{false, false, true, false, true};
+
+    ArrowArray* array = nullptr;
+    ArrowSchema* schema = nullptr;
+    std::tie(schema, array) =
+        ArrowArrayBuilder()
+            .setRowNum(5)
+            .addColumn<int>("col_int_a", CREATE_SUBSTRAIT_TYPE(I32), vec0, vec_null)
+            .addColumn<int>("col_int_b", CREATE_SUBSTRAIT_TYPE(I32), vec1, vec_null)
+            .build();
+
+    query_func((int8_t*)runtime_ctx.get(), (int8_t*)array);
+
+    auto output_batch_array = runtime_ctx->getOutputBatch()->getArray();
+    EXPECT_EQ(output_batch_array->length, expected_length);
+  }
+};
+
+TEST_F(CiderUOperNextgenTest, isNullTest) {
+  executeTest("CREATE TABLE test(col_int_a INTEGER, col_int_b INTEGER);",
+              "select col_int_b from test where col_int_a IS NULL",
+              2);
+  executeTest("CREATE TABLE test(col_int_a INTEGER, col_int_b INTEGER);",
+              "select col_int_b from test where col_int_a IS NOT NULL",
+              3);
+  executeTest(
+      "CREATE TABLE test(col_int_a INTEGER NOT NULL, col_int_b INTEGER NOT NULL);",
+      "select col_int_b from test where col_int_a IS NULL",
+      0);
+  executeTest(
+      "CREATE TABLE test(col_int_a INTEGER NOT NULL, col_int_b INTEGER NOT NULL);",
+      "select col_int_b from test where col_int_a IS NOT NULL",
+      5);
+}
+
+int main(int argc, char** argv) {
+  TestHelpers::init_logger_stderr_only(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  int err = RUN_ALL_TESTS();
+  return err;
+}

--- a/cider/tests/nextgen/functional/CiderUOperNextgenTest.cpp
+++ b/cider/tests/nextgen/functional/CiderUOperNextgenTest.cpp
@@ -96,6 +96,15 @@ class CiderUOperNextgenTest : public ::testing::Test {
 
     auto output_batch_array = runtime_ctx->getOutputBatch()->getArray();
     EXPECT_EQ(output_batch_array->length, expected_length);
+    auto check_array = [](ArrowArray* array, size_t expect_len) {
+      EXPECT_EQ(array->length, expect_len);
+      int32_t* data_buffer = (int32_t*)array->buffers[1];
+      for (size_t i = 0; i < expect_len; ++i) {
+        std::cout << data_buffer[i] << " ";
+      }
+      std::cout << std::endl;
+    };
+    check_array(output_batch_array->children[0], expected_length);
   }
 };
 

--- a/cider/type/plan/Analyzer.cpp
+++ b/cider/type/plan/Analyzer.cpp
@@ -83,10 +83,6 @@ std::shared_ptr<Analyzer::Expr> Constant::deep_copy() const {
   return makeExpr<Constant>(type_info, is_null, d);
 }
 
-std::shared_ptr<Analyzer::Expr> UOper::deep_copy() const {
-  return makeExpr<UOper>(type_info, contains_agg, optype, operand->deep_copy());
-}
-
 std::shared_ptr<Analyzer::Expr> BinOper::deep_copy() const {
   return makeExpr<BinOper>(type_info,
                            contains_agg,
@@ -1653,25 +1649,6 @@ std::shared_ptr<Analyzer::Expr> Constant::add_cast(const SQLTypeInfo& new_type_i
   return shared_from_this();
 }
 
-std::shared_ptr<Analyzer::Expr> UOper::add_cast(const SQLTypeInfo& new_type_info) {
-  if (optype != kCAST) {
-    return Expr::add_cast(new_type_info);
-  }
-  if (type_info.is_string() && new_type_info.is_string() &&
-      new_type_info.get_compression() == kENCODING_DICT &&
-      type_info.get_compression() == kENCODING_NONE) {
-    const SQLTypeInfo oti = operand->get_type_info();
-    if (oti.is_string() && oti.get_compression() == kENCODING_DICT &&
-        (oti.get_comp_param() == new_type_info.get_comp_param() ||
-         oti.get_comp_param() == TRANSIENT_DICT(new_type_info.get_comp_param()))) {
-      auto result = operand;
-      operand = nullptr;
-      return result;
-    }
-  }
-  return Expr::add_cast(new_type_info);
-}
-
 std::shared_ptr<Analyzer::Expr> CaseExpr::add_cast(const SQLTypeInfo& new_type_info) {
   SQLTypeInfo ti = new_type_info;
   if (new_type_info.is_string() && new_type_info.get_compression() == kENCODING_DICT &&
@@ -1728,11 +1705,6 @@ void Var::check_group_by(
     CIDER_THROW(CiderCompileException,
                 "Internal error: invalid VAR in GROUP BY or HAVING.");
   }
-}
-
-void UOper::check_group_by(
-    const std::list<std::shared_ptr<Analyzer::Expr>>& groupby) const {
-  operand->check_group_by(groupby);
 }
 
 void BinOper::check_group_by(
@@ -1822,20 +1794,6 @@ void ColumnVar::group_predicates(std::list<const Expr*>& scan_predicates,
                                  std::list<const Expr*>& const_predicates) const {
   if (type_info.get_type() == kBOOLEAN) {
     scan_predicates.push_back(this);
-  }
-}
-
-void UOper::group_predicates(std::list<const Expr*>& scan_predicates,
-                             std::list<const Expr*>& join_predicates,
-                             std::list<const Expr*>& const_predicates) const {
-  std::set<int> rte_idx_set;
-  operand->collect_rte_idx(rte_idx_set);
-  if (rte_idx_set.size() > 1) {
-    join_predicates.push_back(this);
-  } else if (rte_idx_set.size() == 1) {
-    scan_predicates.push_back(this);
-  } else {
-    const_predicates.push_back(this);
   }
 }
 
@@ -2484,14 +2442,6 @@ bool Constant::operator==(const Expr& rhs) const {
   return Datum_equal(type_info, constval, rhs_c.get_constval());
 }
 
-bool UOper::operator==(const Expr& rhs) const {
-  if (typeid(rhs) != typeid(UOper)) {
-    return false;
-  }
-  const UOper& rhs_uo = dynamic_cast<const UOper&>(rhs);
-  return optype == rhs_uo.get_optype() && *operand == *rhs_uo.get_operand();
-}
-
 bool BinOper::operator==(const Expr& rhs) const {
   if (typeid(rhs) != typeid(BinOper)) {
     return false;
@@ -2805,37 +2755,6 @@ std::string Constant::toString() const {
   }
   str += ") ";
   return str;
-}
-
-std::string UOper::toString() const {
-  std::string op;
-  switch (optype) {
-    case kNOT:
-      op = "NOT ";
-      break;
-    case kUMINUS:
-      op = "- ";
-      break;
-    case kISNULL:
-      op = "IS NULL ";
-      break;
-    case kEXISTS:
-      op = "EXISTS ";
-      break;
-    case kCAST:
-      op = "CAST " + type_info.get_type_name() + "(" +
-           std::to_string(type_info.get_precision()) + "," +
-           std::to_string(type_info.get_scale()) + ") " +
-           type_info.get_compression_name() + "(" +
-           std::to_string(type_info.get_comp_param()) + ") ";
-      break;
-    case kUNNEST:
-      op = "UNNEST ";
-      break;
-    default:
-      break;
-  }
-  return "(" + op + operand->toString() + ") ";
 }
 
 std::string BinOper::toString() const {
@@ -3186,14 +3105,6 @@ void BinOper::find_expr(bool (*f)(const Expr*), std::list<const Expr*>& expr_lis
   }
   left_operand->find_expr(f, expr_list);
   right_operand->find_expr(f, expr_list);
-}
-
-void UOper::find_expr(bool (*f)(const Expr*), std::list<const Expr*>& expr_list) const {
-  if (f(this)) {
-    add_unique(expr_list);
-    return;
-  }
-  operand->find_expr(f, expr_list);
 }
 
 void InValues::find_expr(bool (*f)(const Expr*),

--- a/cider/type/plan/CMakeLists.txt
+++ b/cider/type/plan/CMakeLists.txt
@@ -18,5 +18,5 @@
 # under the License.
 
 set(cider_type_plan_source_files Analyzer.cpp Expr.cpp BinaryExpr.cpp
-                                 ColumnExpr.cpp ConstantExpr.cpp)
+                                 UnaryExpr.cpp ColumnExpr.cpp ConstantExpr.cpp)
 add_library(cider_type_plan ${cider_type_plan_source_files})

--- a/cider/type/plan/UnaryExpr.cpp
+++ b/cider/type/plan/UnaryExpr.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "UnaryExpr.h"
+#include "exec/template/Execute.h"
+
+namespace Analyzer {
+using namespace cider::jitlib;
+
+JITExprValue& UOper::codegen(JITFunction& func) {
+  if (auto& expr_var = get_expr_value()) {
+    return expr_var;
+  }
+  auto operand = const_cast<Analyzer::Expr*>(get_operand());
+  if (is_unnest(operand) || is_unnest(operand)) {
+    CIDER_THROW(CiderCompileException, "Unnest not supported in UOper");
+  }
+  const auto& operand_ti = operand->get_type_info();
+  if (operand_ti.is_decimal() || operand_ti.is_timeinterval()) {
+    CIDER_THROW(CiderCompileException,
+                "Decimal and TimeInterval are not supported in Uoper codegen now.");
+  }
+  FixSizeJITExprValue operand_val(operand->codegen(func));
+  const auto& ti = get_type_info();
+  const auto type = ti.is_decimal() ? decimal_to_int_type(ti) : ti.get_type();
+  switch (get_optype()) {
+    case kISNULL: {
+      // For ISNULL, the null will always be false
+      auto null_value = operand_val.getNull().get()
+                            ? operand_val.getNull()
+                            : func.createConstant(getJITTag(type), false);
+      return set_expr_value(func.createConstant(getJITTag(type), false), null_value);
+    }
+    case kISNOTNULL: {
+      auto null_value = operand_val.getNull().get()
+                            ? operand_val.getNull()->notOp()
+                            : func.createConstant(getJITTag(type), true);
+      return set_expr_value(func.createConstant(getJITTag(type), false), null_value);
+    }
+    case kNOT: {
+      CHECK(operand_val.getNull().get());
+      return set_expr_value(operand_val.getNull(), operand_val.getValue()->notOp());
+    }
+    default:
+      UNIMPLEMENTED();
+  }
+}
+
+std::shared_ptr<Analyzer::Expr> UOper::deep_copy() const {
+  return makeExpr<UOper>(type_info, contains_agg, optype, operand->deep_copy());
+}
+
+std::shared_ptr<Analyzer::Expr> UOper::add_cast(const SQLTypeInfo& new_type_info) {
+  if (optype != kCAST) {
+    return Expr::add_cast(new_type_info);
+  }
+  if (type_info.is_string() && new_type_info.is_string() &&
+      new_type_info.get_compression() == kENCODING_DICT &&
+      type_info.get_compression() == kENCODING_NONE) {
+    const SQLTypeInfo oti = operand->get_type_info();
+    if (oti.is_string() && oti.get_compression() == kENCODING_DICT &&
+        (oti.get_comp_param() == new_type_info.get_comp_param() ||
+         oti.get_comp_param() == TRANSIENT_DICT(new_type_info.get_comp_param()))) {
+      auto result = operand;
+      operand = nullptr;
+      return result;
+    }
+  }
+  return Expr::add_cast(new_type_info);
+}
+
+void UOper::check_group_by(
+    const std::list<std::shared_ptr<Analyzer::Expr>>& groupby) const {
+  operand->check_group_by(groupby);
+}
+
+void UOper::group_predicates(std::list<const Expr*>& scan_predicates,
+                             std::list<const Expr*>& join_predicates,
+                             std::list<const Expr*>& const_predicates) const {
+  std::set<int> rte_idx_set;
+  operand->collect_rte_idx(rte_idx_set);
+  if (rte_idx_set.size() > 1) {
+    join_predicates.push_back(this);
+  } else if (rte_idx_set.size() == 1) {
+    scan_predicates.push_back(this);
+  } else {
+    const_predicates.push_back(this);
+  }
+}
+
+bool UOper::operator==(const Expr& rhs) const {
+  if (typeid(rhs) != typeid(UOper)) {
+    return false;
+  }
+  const UOper& rhs_uo = dynamic_cast<const UOper&>(rhs);
+  return optype == rhs_uo.get_optype() && *operand == *rhs_uo.get_operand();
+}
+
+std::string UOper::toString() const {
+  std::string op;
+  switch (optype) {
+    case kNOT:
+      op = "NOT ";
+      break;
+    case kUMINUS:
+      op = "- ";
+      break;
+    case kISNULL:
+      op = "IS NULL ";
+      break;
+    case kEXISTS:
+      op = "EXISTS ";
+      break;
+    case kCAST:
+      op = "CAST " + type_info.get_type_name() + "(" +
+           std::to_string(type_info.get_precision()) + "," +
+           std::to_string(type_info.get_scale()) + ") " +
+           type_info.get_compression_name() + "(" +
+           std::to_string(type_info.get_comp_param()) + ") ";
+      break;
+    case kUNNEST:
+      op = "UNNEST ";
+      break;
+    default:
+      break;
+  }
+  return "(" + op + operand->toString() + ") ";
+}
+
+void UOper::find_expr(bool (*f)(const Expr*), std::list<const Expr*>& expr_list) const {
+  if (f(this)) {
+    add_unique(expr_list);
+    return;
+  }
+  operand->find_expr(f, expr_list);
+}
+
+}  // namespace Analyzer

--- a/cider/type/plan/UnaryExpr.h
+++ b/cider/type/plan/UnaryExpr.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ * Copyright (c) OmniSci, Inc. and its affiliates.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef TYPE_PLAN_UNARY_EXPR_H
+#define TYPE_PLAN_UNARY_EXPR_H
+
+#include <list>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "Expr.h"
+#include "exec/nextgen/jitlib/JITLib.h"
+#include "type/data/sqltypes.h"
+#include "util/sqldefs.h"
+
+namespace Analyzer {
+/*
+ * @type UOper
+ * @brief represents unary operator expressions.  operator types include
+ * kUMINUS, kISNULL, kEXISTS, kCAST
+ */
+class UOper : public Expr {
+ public:
+  UOper(const SQLTypeInfo& ti, bool has_agg, SQLOps o, std::shared_ptr<Analyzer::Expr> p)
+      : Expr(ti, has_agg), optype(o), operand(p) {}
+  UOper(SQLTypes t, SQLOps o, std::shared_ptr<Analyzer::Expr> p)
+      : Expr(t, o == kISNULL ? true : p->get_type_info().get_notnull())
+      , optype(o)
+      , operand(p) {}
+  SQLOps get_optype() const { return optype; }
+  const Expr* get_operand() const { return operand.get(); }
+  std::shared_ptr<Analyzer::Expr> get_non_const_own_operand() const { return operand; }
+  const std::shared_ptr<Analyzer::Expr> get_own_operand() const { return operand; }
+  void check_group_by(
+      const std::list<std::shared_ptr<Analyzer::Expr>>& groupby) const override;
+  std::shared_ptr<Analyzer::Expr> deep_copy() const override;
+  void group_predicates(std::list<const Expr*>& scan_predicates,
+                        std::list<const Expr*>& join_predicates,
+                        std::list<const Expr*>& const_predicates) const override;
+  void collect_rte_idx(std::set<int>& rte_idx_set) const override {
+    operand->collect_rte_idx(rte_idx_set);
+  }
+  void collect_column_var(
+      std::set<const ColumnVar*, bool (*)(const ColumnVar*, const ColumnVar*)>&
+          colvar_set,
+      bool include_agg) const override {
+    operand->collect_column_var(colvar_set, include_agg);
+  }
+  std::shared_ptr<Analyzer::Expr> rewrite_with_targetlist(
+      const std::vector<std::shared_ptr<TargetEntry>>& tlist) const override {
+    return makeExpr<UOper>(
+        type_info, contains_agg, optype, operand->rewrite_with_targetlist(tlist));
+  }
+  std::shared_ptr<Analyzer::Expr> rewrite_with_child_targetlist(
+      const std::vector<std::shared_ptr<TargetEntry>>& tlist) const override {
+    return makeExpr<UOper>(
+        type_info, contains_agg, optype, operand->rewrite_with_child_targetlist(tlist));
+  }
+  std::shared_ptr<Analyzer::Expr> rewrite_agg_to_var(
+      const std::vector<std::shared_ptr<TargetEntry>>& tlist) const override {
+    return makeExpr<UOper>(
+        type_info, contains_agg, optype, operand->rewrite_agg_to_var(tlist));
+  }
+  bool operator==(const Expr& rhs) const override;
+  std::string toString() const override;
+  void find_expr(bool (*f)(const Expr*),
+                 std::list<const Expr*>& expr_list) const override;
+  std::shared_ptr<Analyzer::Expr> add_cast(const SQLTypeInfo& new_type_info) override;
+
+ public:
+  ExprPtrRefVector get_children_reference() override { return {&operand}; }
+  JITExprValue& codegen(JITFunction& func) override;
+
+ protected:
+  SQLOps optype;  // operator type, e.g., kUMINUS, kISNULL, kEXISTS
+  std::shared_ptr<Analyzer::Expr> operand;  // operand expression
+};
+}  // namespace Analyzer
+
+#endif


### PR DESCRIPTION
### What changes were proposed in this pull request?
move UOper out of Analyzer.h/Analyzer.cpp and support ISNULL/ISNOTNULL in UOper


### Why are the changes needed?
expr codegen based on nextgen


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT

### Which label does this PR belong to?

