### PR TITLE
[POAE7-2648] support null in filter and expr

### DIFF
--- a/cider/exec/nextgen/jitlib/base/JITValue.h
+++ b/cider/exec/nextgen/jitlib/base/JITValue.h
@@ -151,11 +151,6 @@ class JITValuePointer {
   // JITValuePointer, please use replace() method or use lh = rh.get().
   JITValuePointer& operator=(const JITValuePointer&) = delete;
 
-  JITValuePointer& operator=(JITValue* rh) {
-    replace(rh);
-    return *this;
-  }
-
   JITValuePointer& operator=(JITValuePointer&& rh) noexcept;
 
   JITValuePointer& operator=(JITValue& rh) noexcept;

--- a/cider/exec/nextgen/jitlib/base/JITValueOperations.h
+++ b/cider/exec/nextgen/jitlib/base/JITValueOperations.h
@@ -69,7 +69,9 @@ inline JITValuePointer operator&&(JITValue& lh, JITValue& rh) {
   return lh.andOp(rh);
 }
 
-inline JITValuePointer operator&&(JITValue& lh, bool rh) {
+// disable pointer to bool implicit cast
+template <class T, std::enable_if_t<std::is_same_v<T, bool>, bool> = true>
+inline JITValuePointer operator&&(JITValue& lh, T rh) {
   auto& parent_func = lh.getParentJITFunction();
   auto type = lh.getValueTypeTag();
   JITValuePointer rh_pointer =
@@ -77,7 +79,9 @@ inline JITValuePointer operator&&(JITValue& lh, bool rh) {
   return lh && *rh_pointer;
 }
 
-inline JITValuePointer operator&&(bool lh, JITValue& rh) {
+// disable pointer to bool implicit cast
+template <class T, std::enable_if_t<std::is_same_v<T, bool>, bool> = true>
+inline JITValuePointer operator&&(T lh, JITValue& rh) {
   return rh && lh;
 }
 
@@ -85,7 +89,9 @@ inline JITValuePointer operator||(JITValue& lh, JITValue& rh) {
   return lh.orOp(rh);
 }
 
-inline JITValuePointer operator||(JITValue& lh, bool rh) {
+// disable pointer to bool implicit cast
+template <class T, std::enable_if_t<std::is_same_v<T, bool>, bool> = true>
+inline JITValuePointer operator||(JITValue& lh, T rh) {
   auto& parent_func = lh.getParentJITFunction();
   auto type = lh.getValueTypeTag();
   JITValuePointer rh_pointer =
@@ -93,7 +99,9 @@ inline JITValuePointer operator||(JITValue& lh, bool rh) {
   return lh || *rh_pointer;
 }
 
-inline JITValuePointer operator||(bool lh, JITValue& rh) {
+// disable pointer to bool implicit cast
+template <class T, std::enable_if_t<std::is_same_v<T, bool>, bool> = true>
+inline JITValuePointer operator||(T lh, JITValue& rh) {
   return rh || lh;
 }
 

--- a/cider/exec/nextgen/operators/FilterNode.cpp
+++ b/cider/exec/nextgen/operators/FilterNode.cpp
@@ -43,7 +43,9 @@ void FilterTranslator::codegen(context::CodegenContext& context) {
         for (const auto& expr : exprs) {
           utils::FixSizeJITExprValue cond(expr->codegen(*func));
           bool_init = bool_init && cond.getValue();
-          TODO("MaJian", "support null in condition");
+          if (cond.isNullable()) {
+            bool_init = bool_init && !cond.getNull();
+          }
         }
         return bool_init;
       })

--- a/cider/exec/nextgen/utils/JITExprValue.h
+++ b/cider/exec/nextgen/utils/JITExprValue.h
@@ -75,6 +75,8 @@ class JITExprValueAdaptor {
 
   void setNull(jitlib::JITValuePointer& rh) { values_[0].replace(rh); }
 
+  bool isNullable() { return values_[0].get() != nullptr; }
+
  protected:
   JITExprValue& values_;
 };

--- a/cider/tests/nextgen/compiler/CMakeLists.txt
+++ b/cider/tests/nextgen/compiler/CMakeLists.txt
@@ -20,7 +20,12 @@
 set(NEXTGEN_TEST_DEPS nextgen test_utils cider_plan_parser)
 
 add_executable(NextgenCompilerTest NextgenCompilerTest.cpp)
+add_executable(FilterProjectTest FilterProjectTest.cpp)
 target_link_libraries(NextgenCompilerTest ${EXECUTE_TEST_LIBS}
                       ${NEXTGEN_TEST_DEPS})
+target_link_libraries(FilterProjectTest ${EXECUTE_TEST_LIBS}
+                      ${NEXTGEN_TEST_DEPS})
 add_test(NextgenCompilerTest ${EXECUTABLE_OUTPUT_PATH}/NextgenCompilerTest
+         ${TEST_ARGS})
+add_test(FilterProjectTest ${EXECUTABLE_OUTPUT_PATH}/FilterProjectTest
          ${TEST_ARGS})

--- a/cider/tests/nextgen/compiler/FilterProjectTest.cpp
+++ b/cider/tests/nextgen/compiler/FilterProjectTest.cpp
@@ -104,6 +104,8 @@ class FilterProjectTest : public ::testing::Test {
 
     check_array(output_batch_array->children[0], 4);
     check_array(output_batch_array->children[1], 4);
+    check_array(output_batch_array->children[2], 4);
+    check_array(output_batch_array->children[3], 4);
   }
 
  private:
@@ -111,7 +113,8 @@ class FilterProjectTest : public ::testing::Test {
 };
 
 TEST_F(FilterProjectTest, FrameworkTest) {
-  executeTest("select a + b, a - b from test where a < b");
+  // nullable + not null, not null + nullable, nullable + nullable, not null + not null
+  executeTest("select a + b, b + a, a + a, b + b from test where a < b");
 }
 
 int main(int argc, char** argv) {

--- a/cider/tests/nextgen/compiler/FilterProjectTest.cpp
+++ b/cider/tests/nextgen/compiler/FilterProjectTest.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <google/protobuf/util/json_util.h>
+#include <gtest/gtest.h>
+
+#include "exec/nextgen/Nextgen.h"
+#include "exec/plan/parser/SubstraitToRelAlgExecutionUnit.h"
+#include "exec/plan/parser/TypeUtils.h"
+#include "tests/TestHelpers.h"
+#include "tests/utils/ArrowArrayBuilder.h"
+#include "tests/utils/Utils.h"
+
+using namespace cider::exec::nextgen;
+
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
+
+class FilterProjectTest : public ::testing::Test {
+ public:
+  void executeTest(const std::string& sql) {
+    // SQL Parsing
+    auto json = RunIsthmus::processSql(sql, create_ddl_);
+    ::substrait::Plan plan;
+    google::protobuf::util::JsonStringToMessage(json, &plan);
+
+    generator::SubstraitToRelAlgExecutionUnit substrait2eu(plan);
+    auto eu = substrait2eu.createRelAlgExecutionUnit();
+
+    // Pipeline Building
+    auto pipeline = parsers::toOpPipeline(eu);
+    transformer::Transformer transformer;
+    auto translators = transformer.toTranslator(pipeline);
+
+    // Codegen
+    context::CodegenContext codegen_ctx;
+    auto module = cider::jitlib::LLVMJITModule("test", true);
+    cider::jitlib::JITFunctionPointer function =
+        cider::jitlib::JITFunctionBuilder()
+            .registerModule(module)
+            .setFuncName("query_func")
+            .addReturn(cider::jitlib::JITTypeTag::VOID)
+            .addParameter(cider::jitlib::JITTypeTag::POINTER,
+                          "context",
+                          cider::jitlib::JITTypeTag::INT8)
+            .addParameter(cider::jitlib::JITTypeTag::POINTER,
+                          "input",
+                          cider::jitlib::JITTypeTag::INT8)
+            .addProcedureBuilder(
+                [&codegen_ctx, &translators](cider::jitlib::JITFunction* func) {
+                  codegen_ctx.setJITFunction(func);
+                  translators->consume(codegen_ctx);
+                  func->createReturn();
+                })
+            .build();
+    module.finish();
+    auto query_func = function->getFunctionPointer<void, int8_t*, int8_t*>();
+
+    // Execution
+    auto runtime_ctx = codegen_ctx.generateRuntimeCTX(allocator);
+    auto input_builder = ArrowArrayBuilder();
+    auto&& [schema, array] =
+        input_builder.setRowNum(10)
+            .addColumn<int64_t>(
+                "a",
+                CREATE_SUBSTRAIT_TYPE(I64),
+                {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+                {true, false, false, false, false, true, false, false, false, false})
+            .addColumn<int64_t>(
+                "b", CREATE_SUBSTRAIT_TYPE(I64), {1, 2, 3, 4, 5, 1, 2, 3, 4, 5})
+            .build();
+
+    query_func((int8_t*)runtime_ctx.get(), (int8_t*)array);
+
+    auto output_batch_array = runtime_ctx->getOutputBatch()->getArray();
+    EXPECT_EQ(output_batch_array->length, 4);
+
+    auto check_array = [](ArrowArray* array, size_t expect_len) {
+      EXPECT_EQ(array->length, expect_len);
+      int64_t* data_buffer = (int64_t*)array->buffers[1];
+      for (size_t i = 0; i < expect_len; ++i) {
+        std::cout << data_buffer[i] << " ";
+      }
+      std::cout << std::endl;
+    };
+
+    check_array(output_batch_array->children[0], 4);
+    check_array(output_batch_array->children[1], 4);
+  }
+
+ private:
+  std::string create_ddl_ = "CREATE TABLE test(a BIGINT, b BIGINT NOT NULL);";
+};
+
+TEST_F(FilterProjectTest, FrameworkTest) {
+  executeTest("select a + b, a - b from test where a < b");
+}
+
+int main(int argc, char** argv) {
+  TestHelpers::init_logger_stderr_only(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  int err = RUN_ALL_TESTS();
+  return err;
+}

--- a/cider/type/plan/BinaryExpr.cpp
+++ b/cider/type/plan/BinaryExpr.cpp
@@ -49,12 +49,12 @@ JITExprValue& BinOper::codegen(JITFunction& func) {
   FixSizeJITExprValue rhs_val(rhs->codegen(func));
 
   JITValuePointer null(nullptr);
-  auto lhs_null = lhs_val.getNull().get();
-  auto rhs_null = rhs_val.getNull().get();
-  if (lhs_null && rhs_null) {
-    null = *lhs_null || *rhs_null;
-  } else if (lhs_null || rhs_null) {
-    null = lhs_null ? lhs_null : rhs_null;
+  bool lhs_nullable = lhs_val.isNullable();
+  bool rhs_nullable = rhs_val.isNullable();
+  if (lhs_nullable && rhs_nullable) {
+    null.replace(lhs_val.getNull() || rhs_val.getNull());
+  } else if (lhs_nullable || rhs_nullable) {
+    null.replace(lhs_nullable ? lhs_val.getNull() : rhs_val.getNull());
   }
 
   switch (lhs_ti.get_type()) {

--- a/cider/type/plan/BinaryExpr.cpp
+++ b/cider/type/plan/BinaryExpr.cpp
@@ -19,6 +19,7 @@
  * under the License.
  */
 #include "BinaryExpr.h"
+#include "exec/nextgen/jitlib/base/JITValue.h"
 #include "exec/template/Execute.h"  // for is_unnest
 
 namespace Analyzer {
@@ -47,22 +48,14 @@ JITExprValue& BinOper::codegen(JITFunction& func) {
   FixSizeJITExprValue lhs_val(lhs->codegen(func));
   FixSizeJITExprValue rhs_val(rhs->codegen(func));
 
-  // auto null = func_->createVariable(getJITTag(lhs), "null");
-  TODO("MaJian", "merge null");
-  // auto lhs_nullable = dynamic_cast<NullableColValues*>(lhs_lv.get());
-  // auto rhs_nullable = dynamic_cast<NullableColValues*>(rhs_lv.get());
-  // if (lhs_nullable && rhs_nullable) {
-  //   if (lhs_nullable->getNull() && rhs_nullable->getNull()) {
-  //     // null = cgen_state_->ir_builder_.CreateOr(lhs_nullable->getNull(),
-  //     //                                          rhs_nullable->getNull());
-  //     null = lhs->getNull() || rhs_nullable->getNull();
-  //   } else {
-  //     null = lhs_nullable->getNull() ? lhs_nullable->getNull() :
-  //     rhs_nullable->getNull();
-  //   }
-  // } else if (lhs_nullable || rhs_nullable) {
-  //   null = lhs_nullable ? lhs_nullable->getNull() : rhs_nullable->getNull();
-  // }
+  JITValuePointer null(nullptr);
+  auto lhs_null = lhs_val.getNull().get();
+  auto rhs_null = rhs_val.getNull().get();
+  if (lhs_null && rhs_null) {
+    null = *lhs_null || *rhs_null;
+  } else if (lhs_null || rhs_null) {
+    null = lhs_null ? lhs_null : rhs_null;
+  }
 
   switch (lhs_ti.get_type()) {
     case kVARCHAR:
@@ -73,10 +66,10 @@ JITExprValue& BinOper::codegen(JITFunction& func) {
     default:
       const auto optype = get_optype();
       if (IS_ARITHMETIC(optype)) {
-        return codegenFixedSizeColArithFun(lhs_val.getValue(), rhs_val.getValue());
+        return codegenFixedSizeColArithFun(null, lhs_val.getValue(), rhs_val.getValue());
       } else if (IS_COMPARISON(optype)) {
         // return codegenCmpFun(bin_oper);
-        return codegenFixedSizeColCmpFun(lhs_val.getValue(), rhs_val.getValue());
+        return codegenFixedSizeColCmpFun(null, lhs_val.getValue(), rhs_val.getValue());
       } else if (IS_LOGIC(optype)) {
         // return codegenLogicalFun(bin_oper, co);
         UNIMPLEMENTED();
@@ -86,19 +79,21 @@ JITExprValue& BinOper::codegen(JITFunction& func) {
   return expr_var_;
 }
 
-JITExprValue& BinOper::codegenFixedSizeColArithFun(JITValue& lhs, JITValue& rhs) {
+JITExprValue& BinOper::codegenFixedSizeColArithFun(JITValuePointer& null,
+                                                   JITValue& lhs,
+                                                   JITValue& rhs) {
   // TODO: Null Process
   switch (get_optype()) {
     case kMINUS:
-      return set_expr_value(nullptr, lhs - rhs);
+      return set_expr_value(null, lhs - rhs);
     case kPLUS:
-      return set_expr_value(nullptr, lhs + rhs);
+      return set_expr_value(null, lhs + rhs);
     case kMULTIPLY:
-      return set_expr_value(nullptr, lhs * rhs);
+      return set_expr_value(null, lhs * rhs);
     case kDIVIDE:
-      return set_expr_value(nullptr, lhs / rhs);
+      return set_expr_value(null, lhs / rhs);
     case kMODULO:
-      return set_expr_value(nullptr, lhs % rhs);
+      return set_expr_value(null, lhs % rhs);
     default:
       UNREACHABLE();
   }
@@ -106,21 +101,23 @@ JITExprValue& BinOper::codegenFixedSizeColArithFun(JITValue& lhs, JITValue& rhs)
   return expr_var_;
 }
 
-JITExprValue& BinOper::codegenFixedSizeColCmpFun(JITValue& lhs, JITValue& rhs) {
+JITExprValue& BinOper::codegenFixedSizeColCmpFun(JITValuePointer& null,
+                                                 JITValue& lhs,
+                                                 JITValue& rhs) {
   // TODO: Null Process
   switch (get_optype()) {
     case kEQ:
-      return set_expr_value(nullptr, lhs == rhs);
+      return set_expr_value(null, lhs == rhs);
     case kNE:
-      return set_expr_value(nullptr, lhs != rhs);
+      return set_expr_value(null, lhs != rhs);
     case kLT:
-      return set_expr_value(nullptr, lhs < rhs);
+      return set_expr_value(null, lhs < rhs);
     case kGT:
-      return set_expr_value(nullptr, lhs > rhs);
+      return set_expr_value(null, lhs > rhs);
     case kLE:
-      return set_expr_value(nullptr, lhs <= rhs);
+      return set_expr_value(null, lhs <= rhs);
     case kGE:
-      return set_expr_value(nullptr, lhs >= rhs);
+      return set_expr_value(null, lhs >= rhs);
     default:
       UNREACHABLE();
   }

--- a/cider/type/plan/BinaryExpr.h
+++ b/cider/type/plan/BinaryExpr.h
@@ -30,6 +30,7 @@
 
 #include "Expr.h"
 #include "exec/nextgen/jitlib/JITLib.h"
+#include "exec/nextgen/jitlib/base/JITValue.h"
 #include "type/data/sqltypes.h"
 #include "util/sqldefs.h"
 
@@ -143,8 +144,12 @@ class BinOper : public Expr {
     return {&left_operand, &right_operand};
   }
   JITExprValue& codegen(JITFunction& func) override;
-  JITExprValue& codegenFixedSizeColArithFun(JITValue& lhs, JITValue& rhs);
-  JITExprValue& codegenFixedSizeColCmpFun(JITValue& lhs, JITValue& rhs);
+  JITExprValue& codegenFixedSizeColArithFun(JITValuePointer& null,
+                                            JITValue& lhs,
+                                            JITValue& rhs);
+  JITExprValue& codegenFixedSizeColCmpFun(JITValuePointer& null,
+                                          JITValue& lhs,
+                                          JITValue& rhs);
 
  private:
   SQLOps optype;           // operator type, e.g., kLT, kAND, kPLUS, etc.

--- a/cider/type/plan/ConstantExpr.cpp
+++ b/cider/type/plan/ConstantExpr.cpp
@@ -34,7 +34,8 @@ JITExprValue& Constant::codegen(JITFunction& func) {
       CIDER_THROW(CiderCompileException,
                   "NULL type literals are not currently supported in this context.");
     case kBOOLEAN:
-      return set_expr_value(func.createConstant(getJITTag(type), get_constval().boolval));
+      return set_expr_value(nullptr,
+                            func.createConstant(getJITTag(type), get_constval().boolval));
     case kTINYINT:
     case kSMALLINT:
     case kINT:
@@ -44,13 +45,14 @@ JITExprValue& Constant::codegen(JITFunction& func) {
     case kDATE:
     case kINTERVAL_DAY_TIME:
     case kINTERVAL_YEAR_MONTH:
-      return set_expr_value(func.createConstant(getJITTag(type), get_constval().intval));
+      return set_expr_value(nullptr,
+                            func.createConstant(getJITTag(type), get_constval().intval));
     case kFLOAT:
       return set_expr_value(
-          func.createConstant(getJITTag(type), get_constval().floatval));
+          nullptr, func.createConstant(getJITTag(type), get_constval().floatval));
     case kDOUBLE:
       return set_expr_value(
-          func.createConstant(getJITTag(type), get_constval().doubleval));
+          nullptr, func.createConstant(getJITTag(type), get_constval().doubleval));
     case kVARCHAR:
     case kCHAR:
     case kTEXT: {


### PR DESCRIPTION
### What changes were proposed in this pull request?
support null in filter and expr
disable implicit cast for bool for some operator overload.

### Why are the changes needed?
next-gen compiler


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT

### Which label does this PR belong to?
INFRA
