### PR TITLE
[POAE7-2561] String Scalar Function support: regexp_replace

### DIFF
--- a/cider/exec/plan/parser/SubstraitToAnalyzerExpr.cpp
+++ b/cider/exec/plan/parser/SubstraitToAnalyzerExpr.cpp
@@ -47,7 +47,8 @@ bool isStringFunction(const std::string& function_name) {
                                                "concat",
                                                "||",
                                                "length",
-                                               "char_length"};
+                                               "char_length",
+                                               "regexp_replace"};
   return funcs.find(function_name) != funcs.end();
 }
 
@@ -842,8 +843,8 @@ std::shared_ptr<Analyzer::Expr> Substrait2AnalyzerExprConverter::buildStrExpr(
       //      return makeExpr<Analyzer::ReplaceStringOper>(args);
       //    case SqlStringOpKind::SPLIT_PART:
       //      return makeExpr<Analyzer::SplitPartStringOper>(args);
-      //    case SqlStringOpKind::REGEXP_REPLACE:
-      //      return makeExpr<Analyzer::RegexpReplaceStringOper>(args);
+    case SqlStringOpKind::REGEXP_REPLACE:
+      return makeExpr<Analyzer::RegexpReplaceStringOper>(args);
       //    case SqlStringOpKind::REGEXP_SUBSTR:
       //      return makeExpr<Analyzer::RegexpSubstrStringOper>(args);
       //    case SqlStringOpKind::JSON_VALUE:

--- a/cider/tests/functionality/CiderStringTest.cpp
+++ b/cider/tests/functionality/CiderStringTest.cpp
@@ -789,6 +789,32 @@ TEST_F(CiderRegexpTestArrow, RegexpReplaceBasicTest) {
             .build());
     assertQueryArrow("stringop_regexp_replace_position.json", replace_expected);
   }
+  {
+    // replace with capturing groups
+    // substrait specification states that the replacement can refer to capturing groups
+    // the n-th capturing group can be refererenced by $n in the replacement
+    // REGEXP_REPLACE(col, '(h)([a-z])', 'Ha$2', occurrence=0)
+    auto replaced = std::vector<std::string>{"Haello",
+                                             "Haello",
+                                             "HaelloworldHaello",
+                                             "HaelloworldHaello",
+                                             "pqrsttsrqp",
+                                             "pqrsttsrqp",
+                                             "112@mail123.com",
+                                             "112@mail123.com",
+                                             "123qwerty123",
+                                             "123qwerty123",
+                                             "",
+                                             ""};
+    const auto [replaced_data, replaced_offsets] =
+        ArrowBuilderUtils::createDataAndOffsetFromStrVector(replaced);
+    auto replace_expected = ArrowBuilderUtils::createCiderBatchFromArrowBuilder(
+        ArrowArrayBuilder()
+            .addUTF8Column("col_2", replaced_data, replaced_offsets)
+            .addUTF8Column("col_3", replaced_data, replaced_offsets, is_null)
+            .build());
+    assertQueryArrow("stringop_regexp_replace_capture.json", replace_expected);
+  }
 }
 
 TEST_F(CiderRegexpTestArrow, RegexpReplaceExtendedTest) {

--- a/cider/tests/substrait_plan_files/stringop_regexp_replace_all.json
+++ b/cider/tests/substrait_plan_files/stringop_regexp_replace_all.json
@@ -1,0 +1,261 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "regexp_replace:opt_opt_opt_vchar_vchar_vchar_i64_i64"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[wert]",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "yo",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 0,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[wert]",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "yo",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 0,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0",
+          "EXPR$1"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_regexp_replace_capture.json
+++ b/cider/tests/substrait_plan_files/stringop_regexp_replace_capture.json
@@ -1,0 +1,261 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "regexp_replace:opt_opt_opt_vchar_vchar_vchar_i64_i64"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "(h)([a-z])",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "Ha$2",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 0,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "(h)([a-z])",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "Ha$2",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 0,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0",
+          "EXPR$1"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_regexp_replace_first.json
+++ b/cider/tests/substrait_plan_files/stringop_regexp_replace_first.json
@@ -1,0 +1,261 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "regexp_replace:opt_opt_opt_vchar_vchar_vchar_i64_i64"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[wert]",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "yo",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[wert]",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "yo",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0",
+          "EXPR$1"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_regexp_replace_neg_occ.json
+++ b/cider/tests/substrait_plan_files/stringop_regexp_replace_neg_occ.json
@@ -1,0 +1,261 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "regexp_replace:opt_opt_opt_vchar_vchar_vchar_i64_i64"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[0-9]+",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "<digits>",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": -2,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[0-9]+",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "<digits>",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": -2,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0",
+          "EXPR$1"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_regexp_replace_neg_pos.json
+++ b/cider/tests/substrait_plan_files/stringop_regexp_replace_neg_pos.json
@@ -1,0 +1,261 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "regexp_replace:opt_opt_opt_vchar_vchar_vchar_i64_i64"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[l]{2}",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "<two-l>",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": -5,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 0,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[l]{2}",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "<two-l>",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": -5,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 0,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0",
+          "EXPR$1"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_regexp_replace_position.json
+++ b/cider/tests/substrait_plan_files/stringop_regexp_replace_position.json
@@ -1,0 +1,261 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "regexp_replace:opt_opt_opt_vchar_vchar_vchar_i64_i64"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[l]{2}",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "<two-l>",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 10,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 0,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[l]{2}",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "<two-l>",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 10,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 0,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0",
+          "EXPR$1"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/substrait_plan_files/stringop_regexp_replace_second.json
+++ b/cider/tests/substrait_plan_files/stringop_regexp_replace_second.json
@@ -1,0 +1,261 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "regexp_replace:opt_opt_opt_vchar_vchar_vchar_i64_i64"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  3,
+                  4
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "COL_1",
+                    "COL_2",
+                    "COL_3"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "varchar": {
+                          "length": 15,
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "TEST"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[0-9]+",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "<digits>",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 2,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "varchar": {
+                      "length": 15,
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "[0-9]+",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "cast": {
+                          "type": {
+                            "varchar": {
+                              "length": 15,
+                              "typeVariationReference": 0,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "input": {
+                            "literal": {
+                              "fixedChar": "<digits>",
+                              "nullable": false,
+                              "typeVariationReference": 0
+                            }
+                          },
+                          "failureBehavior": "FAILURE_BEHAVIOR_UNSPECIFIED"
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 1,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i64": 2,
+                          "nullable": false,
+                          "typeVariationReference": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0",
+          "EXPR$1"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}

--- a/cider/tests/utils/Utils.h
+++ b/cider/tests/utils/Utils.h
@@ -143,6 +143,10 @@ class SchemaUtils {
 
 class ArrowBuilderUtils {
  public:
+  /**
+   * Helper method for creating CiderBatch instances.
+   * Builds a CiderBatch from the array and schema returned by ArrowArrayBuilder::build()
+   */
   static std::shared_ptr<CiderBatch> createCiderBatchFromArrowBuilder(
       std::tuple<ArrowSchema*&, ArrowArray*&> array_with_schema) {
     ArrowSchema* schema = nullptr;
@@ -153,6 +157,12 @@ class ArrowBuilderUtils {
         schema, array, std::make_shared<CiderDefaultAllocator>());
   }
 
+  /**
+   * Helper method for generating inputs for ArrowArrayBuilder::addUTF8Column()
+   * It accepts a vector of strings (i.e., rows of a VarChar/String column)
+   * and returns a buffer for strings and a vector for offsets
+   * which can then be passed to ArrowArrayBuilder::addUtf8Column()
+   */
   static std::tuple<std::string, std::vector<int32_t>> createDataAndOffsetFromStrVector(
       const std::vector<std::string>& input) {
     std::vector<int32_t> offsets{0};

--- a/cider/type/plan/Analyzer.cpp
+++ b/cider/type/plan/Analyzer.cpp
@@ -431,6 +431,25 @@ std::shared_ptr<Analyzer::Expr> ConcatStringOper::deep_copy() const {
       std::dynamic_pointer_cast<Analyzer::StringOper>(StringOper::deep_copy()));
 }
 
+std::shared_ptr<Analyzer::Expr> RegexpReplaceStringOper::deep_copy() const {
+  return makeExpr<Analyzer::RegexpReplaceStringOper>(
+      std::dynamic_pointer_cast<Analyzer::StringOper>(StringOper::deep_copy()));
+}
+
+std::vector<std::shared_ptr<Analyzer::Expr>> RegexpReplaceStringOper::foldLiteralStrCasts(
+    const std::vector<std::shared_ptr<Analyzer::Expr>>& operands,
+    int start_idx) {
+  std::vector<std::shared_ptr<Analyzer::Expr>> folded_operands;
+  for (int i = 0; i < operands.size(); ++i) {
+    if (i < start_idx) {
+      folded_operands.push_back(operands[i]);
+    } else {
+      folded_operands.push_back(remove_cast(operands[i].get())->deep_copy());
+    }
+  }
+  return folded_operands;
+}
+
 bool ConcatStringOper::isLiteralOrCastLiteral(const Analyzer::Expr* operand) {
   // literals may exist in a CAST op (casted from fixedchar to varchar)
   auto literal_arg = dynamic_cast<const Analyzer::Constant*>(remove_cast(operand));

--- a/cider/type/plan/Analyzer.cpp
+++ b/cider/type/plan/Analyzer.cpp
@@ -440,6 +440,7 @@ std::vector<std::shared_ptr<Analyzer::Expr>> StringOper::foldLiteralStrCasts(
     const std::vector<std::shared_ptr<Analyzer::Expr>>& operands,
     int start_idx) {
   std::vector<std::shared_ptr<Analyzer::Expr>> folded_operands;
+  folded_operands.reserve(operands.size());
   for (int i = 0; i < operands.size(); ++i) {
     if (i < start_idx) {
       folded_operands.push_back(operands[i]);

--- a/cider/type/plan/Analyzer.cpp
+++ b/cider/type/plan/Analyzer.cpp
@@ -436,7 +436,7 @@ std::shared_ptr<Analyzer::Expr> RegexpReplaceStringOper::deep_copy() const {
       std::dynamic_pointer_cast<Analyzer::StringOper>(StringOper::deep_copy()));
 }
 
-std::vector<std::shared_ptr<Analyzer::Expr>> RegexpReplaceStringOper::foldLiteralStrCasts(
+std::vector<std::shared_ptr<Analyzer::Expr>> StringOper::foldLiteralStrCasts(
     const std::vector<std::shared_ptr<Analyzer::Expr>>& operands,
     int start_idx) {
   std::vector<std::shared_ptr<Analyzer::Expr>> folded_operands;
@@ -444,7 +444,14 @@ std::vector<std::shared_ptr<Analyzer::Expr>> RegexpReplaceStringOper::foldLitera
     if (i < start_idx) {
       folded_operands.push_back(operands[i]);
     } else {
-      folded_operands.push_back(remove_cast(operands[i].get())->deep_copy());
+      auto literal_arg =
+          dynamic_cast<const Analyzer::Constant*>(remove_cast(operands[i].get()));
+      if (literal_arg && literal_arg->get_type_info().is_string()) {
+        // only fold str casts
+        folded_operands.push_back(literal_arg->deep_copy());
+      } else {
+        folded_operands.push_back(operands[i]);
+      }
     }
   }
   return folded_operands;

--- a/cider/type/plan/Analyzer.h
+++ b/cider/type/plan/Analyzer.h
@@ -1563,6 +1563,53 @@ class ConcatStringOper : public StringOper {
       const std::vector<std::shared_ptr<Analyzer::Expr>>& operands);
 };
 
+class RegexpReplaceStringOper : public StringOper {
+ public:
+  RegexpReplaceStringOper(const std::vector<std::shared_ptr<Analyzer::Expr>>& operands)
+      : StringOper(SqlStringOpKind::REGEXP_REPLACE,
+                   foldLiteralStrCasts(operands),
+                   getMinArgs(),
+                   getExpectedTypeFamilies(),
+                   getArgNames()) {}
+
+  RegexpReplaceStringOper(const std::shared_ptr<Analyzer::Expr>& input,
+                          const std::shared_ptr<Analyzer::Expr>& pattern,
+                          const std::shared_ptr<Analyzer::Expr>& replacement,
+                          const std::shared_ptr<Analyzer::Expr>& position,
+                          const std::shared_ptr<Analyzer::Expr>& occurrence)
+      : StringOper(SqlStringOpKind::REGEXP_REPLACE,
+                   {input, pattern, replacement, position, occurrence},
+                   getMinArgs(),
+                   getExpectedTypeFamilies(),
+                   getArgNames()) {}
+
+  RegexpReplaceStringOper(const std::shared_ptr<Analyzer::StringOper>& string_oper)
+      : StringOper(string_oper) {}
+
+  std::shared_ptr<Analyzer::Expr> deep_copy() const override;
+
+  size_t getMinArgs() const override { return 5UL; }
+
+  std::vector<OperandTypeFamily> getExpectedTypeFamilies() const override {
+    return {OperandTypeFamily::STRING_FAMILY,
+            OperandTypeFamily::STRING_FAMILY,
+            OperandTypeFamily::STRING_FAMILY,
+            OperandTypeFamily::INT_FAMILY,
+            OperandTypeFamily::INT_FAMILY};
+  }
+
+  const std::vector<std::string>& getArgNames() const override {
+    static std::vector<std::string> names{
+        "input", "pattern", "replacement", "position", "occurrence"};
+    return names;
+  }
+
+ private:
+  std::vector<std::shared_ptr<Analyzer::Expr>> foldLiteralStrCasts(
+      const std::vector<std::shared_ptr<Analyzer::Expr>>& operands,
+      int start_idx = 1);
+};
+
 class TryStringCastOper : public StringOper {
  public:
   TryStringCastOper(const SQLTypeInfo& ti, const std::shared_ptr<Analyzer::Expr>& operand)

--- a/cider/type/plan/Analyzer.h
+++ b/cider/type/plan/Analyzer.h
@@ -1316,6 +1316,11 @@ class StringOper : public Expr {
     return {};
   }
 
+ protected:
+  std::vector<std::shared_ptr<Analyzer::Expr>> foldLiteralStrCasts(
+      const std::vector<std::shared_ptr<Analyzer::Expr>>& operands,
+      int start_idx = 1);
+
  private:
   static SQLTypeInfo get_return_type(
       const SqlStringOpKind kind,
@@ -1603,11 +1608,6 @@ class RegexpReplaceStringOper : public StringOper {
         "input", "pattern", "replacement", "position", "occurrence"};
     return names;
   }
-
- private:
-  std::vector<std::shared_ptr<Analyzer::Expr>> foldLiteralStrCasts(
-      const std::vector<std::shared_ptr<Analyzer::Expr>>& operands,
-      int start_idx = 1);
 };
 
 class TryStringCastOper : public StringOper {

--- a/cider/type/plan/Analyzer.h
+++ b/cider/type/plan/Analyzer.h
@@ -1582,11 +1582,12 @@ class RegexpReplaceStringOper : public StringOper {
                           const std::shared_ptr<Analyzer::Expr>& replacement,
                           const std::shared_ptr<Analyzer::Expr>& position,
                           const std::shared_ptr<Analyzer::Expr>& occurrence)
-      : StringOper(SqlStringOpKind::REGEXP_REPLACE,
-                   {input, pattern, replacement, position, occurrence},
-                   getMinArgs(),
-                   getExpectedTypeFamilies(),
-                   getArgNames()) {}
+      : StringOper(
+            SqlStringOpKind::REGEXP_REPLACE,
+            foldLiteralStrCasts({input, pattern, replacement, position, occurrence}),
+            getMinArgs(),
+            getExpectedTypeFamilies(),
+            getArgNames()) {}
 
   RegexpReplaceStringOper(const std::shared_ptr<Analyzer::StringOper>& string_oper)
       : StringOper(string_oper) {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added support for regular expression function `REGEXP_REPLACE(input, pattern, replacement, position, occurrence)`, which replaces one or more substrings that match `pattern` in `input` with `replacement`.

The implementation is based on substrait specification on `regexp_replace`, which should generally be the same as the `regexp_replace` implemented in PrestoDb (but with additional features to specify `position` and `occurrence`)

- Enabled existing `regexp_replace` code in code base.
- Added unit tests that cover basic features specified by substrait.
- There are 3 optional arguments that controls case sensitivity, multi-line replacement and dot character (`'.'`) matching respectively. These 3 arguments are NOT supported for now for lack of support to parse optional arguments.

### Why are the changes needed?

String op feature support.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UTs. All query plans are currently manually crafted, because Isthmus does not support `regexp_replace`. Some of the test cases use hand-crafted reference outputs because some features are not supported in DuckDb.

### Which label does this PR belong to?
