### PR TITLE
[POAE7-2652]bool specialization in expr

### DIFF
--- a/cider/exec/nextgen/jitlib/base/JITValueOperations.h
+++ b/cider/exec/nextgen/jitlib/base/JITValueOperations.h
@@ -24,6 +24,7 @@
 #include <type_traits>
 
 #include "exec/nextgen/jitlib/base/JITValue.h"
+#include "exec/nextgen/jitlib/base/ValueTypes.h"
 #include "exec/nextgen/jitlib/llvmjit/LLVMJITFunction.h"
 
 namespace cider::jitlib {
@@ -72,11 +73,11 @@ inline JITValuePointer operator&&(JITValue& lh, JITValue& rh) {
 // disable pointer to bool implicit cast
 template <class T, std::enable_if_t<std::is_same_v<T, bool>, bool> = true>
 inline JITValuePointer operator&&(JITValue& lh, T rh) {
-  auto& parent_func = lh.getParentJITFunction();
-  auto type = lh.getValueTypeTag();
-  JITValuePointer rh_pointer =
-      parent_func.createConstant(type, op_utils::castConstant(type, rh));
-  return lh && *rh_pointer;
+  if (rh) {
+    return &lh;
+  }
+  auto& func = lh.getParentJITFunction();
+  return func.createConstant(JITTypeTag::BOOL, false);
 }
 
 // disable pointer to bool implicit cast
@@ -92,11 +93,11 @@ inline JITValuePointer operator||(JITValue& lh, JITValue& rh) {
 // disable pointer to bool implicit cast
 template <class T, std::enable_if_t<std::is_same_v<T, bool>, bool> = true>
 inline JITValuePointer operator||(JITValue& lh, T rh) {
-  auto& parent_func = lh.getParentJITFunction();
-  auto type = lh.getValueTypeTag();
-  JITValuePointer rh_pointer =
-      parent_func.createConstant(type, op_utils::castConstant(type, rh));
-  return lh || *rh_pointer;
+  if (!rh) {
+    return &lh;
+  }
+  auto& func = lh.getParentJITFunction();
+  return func.createConstant(JITTypeTag::BOOL, true);
 }
 
 // disable pointer to bool implicit cast

--- a/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
+++ b/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
@@ -66,7 +66,7 @@ JITValuePointer LLVMJITValue::orOp(JITValue& rh) {
       if (auto const_bool = llvm::dyn_cast<llvm::ConstantInt>(llvm_rh.llvm_value_)) {
         return const_bool->isOne() ? &rh : this;
       }
-      ans = getFunctionBuilder(parent_function_).CreateAnd(load(), llvm_rh.load());
+      ans = getFunctionBuilder(parent_function_).CreateOr(load(), llvm_rh.load());
       break;
     }
     default:

--- a/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
+++ b/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
@@ -23,6 +23,7 @@
 
 #include <llvm/IR/Value.h>
 
+#include "exec/nextgen/jitlib/base/JITValue.h"
 #include "exec/nextgen/jitlib/base/ValueTypes.h"
 #include "util/Logger.h"
 
@@ -41,9 +42,13 @@ JITValuePointer LLVMJITValue::andOp(JITValue& rh) {
   LLVMJITValue& llvm_rh = static_cast<LLVMJITValue&>(rh);
   llvm::Value* ans = nullptr;
   switch (getValueTypeTag()) {
-    case JITTypeTag::BOOL:
+    case JITTypeTag::BOOL: {
+      if (auto const_bool = llvm::dyn_cast<llvm::ConstantInt>(llvm_rh.llvm_value_)) {
+        return const_bool->isOne() ? this : &rh;
+      }
       ans = getFunctionBuilder(parent_function_).CreateAnd(load(), llvm_rh.load());
       break;
+    }
     default:
       LOG(FATAL) << "Invalid JITValue type for and operation. Name=" << getValueName()
                  << ", Type=" << getJITTypeName(getValueTypeTag()) << ".";
@@ -57,9 +62,13 @@ JITValuePointer LLVMJITValue::orOp(JITValue& rh) {
   LLVMJITValue& llvm_rh = static_cast<LLVMJITValue&>(rh);
   llvm::Value* ans = nullptr;
   switch (getValueTypeTag()) {
-    case JITTypeTag::BOOL:
-      ans = getFunctionBuilder(parent_function_).CreateOr(load(), llvm_rh.load());
+    case JITTypeTag::BOOL: {
+      if (auto const_bool = llvm::dyn_cast<llvm::ConstantInt>(llvm_rh.llvm_value_)) {
+        return const_bool->isOne() ? &rh : this;
+      }
+      ans = getFunctionBuilder(parent_function_).CreateAnd(load(), llvm_rh.load());
       break;
+    }
     default:
       LOG(FATAL) << "Invalid JITValue type for or operation. Name=" << getValueName()
                  << ", Type=" << getJITTypeName(getValueTypeTag()) << ".";
@@ -72,9 +81,14 @@ JITValuePointer LLVMJITValue::orOp(JITValue& rh) {
 JITValuePointer LLVMJITValue::notOp() {
   llvm::Value* ans = nullptr;
   switch (getValueTypeTag()) {
-    case JITTypeTag::BOOL:
+    case JITTypeTag::BOOL: {
+      if (auto const_bool = llvm::dyn_cast<llvm::ConstantInt>(llvm_value_)) {
+        bool literal = const_bool->isOne() ? false : true;
+        return parent_function_.createConstant(JITTypeTag::BOOL, literal);
+      }
       ans = getFunctionBuilder(parent_function_).CreateNot(load());
       break;
+    }
     default:
       LOG(FATAL) << "Invalid JITValue type for not operation. Name=" << getValueName()
                  << ", Type=" << getJITTypeName(getValueTypeTag()) << ".";

--- a/cider/exec/nextgen/operators/ArrowSourceNode.cpp
+++ b/cider/exec/nextgen/operators/ArrowSourceNode.cpp
@@ -40,8 +40,8 @@ void ArrowSourceTranslator::codegen(context::CodegenContext& context) {
   auto func = context.getJITFunction();
   auto&& [output_type, exprs] = op_node_->getOutputExprs();
 
-  // get input ArrowArray pointer, generated query function signature likes void
-  // query_func(RuntimeContext* ctx, ArrowArray* input).
+  // get input ArrowArray pointer, generated query function signature likes
+  // void query_func(RuntimeContext* ctx, ArrowArray* input).
   auto arrow_pointer = func->getArgument(1);
 
   for (int64_t index = 0; index < exprs.size(); ++index) {

--- a/cider/exec/nextgen/operators/ColumnToRowNode.cpp
+++ b/cider/exec/nextgen/operators/ColumnToRowNode.cpp
@@ -60,7 +60,7 @@ class ColumnReader {
     auto row_data = data_pointer[index_];
 
     if (expr_->get_type_info().get_notnull()) {
-      expr_->set_expr_value<JITExprValueType::ROW>(nullptr, row_data);
+      expr_->set_expr_value(func.createConstant(JITTypeTag::BOOL, false), row_data);
     } else {
       // null buffer decoder
       // TBD: Null representation, bit-array or bool-array.
@@ -70,7 +70,7 @@ class ColumnReader {
               .ret_type = JITTypeTag::BOOL,
               .params_vector = {{fixsize_values.getNull().get(), index_.get()}}});
 
-      expr_->set_expr_value<JITExprValueType::ROW>(row_null_data, row_data);
+      expr_->set_expr_value(row_null_data, row_data);
     }
   }
 
@@ -94,8 +94,6 @@ void ColumnToRowTranslator::codegen(context::CodegenContext& context) {
   ExprPtrVector& inputs = exprs;
 
   // for row loop
-  // prototype:void func(CodegenContext* context, ArrowArray* in, ArrowArray* out);
-  auto arrow_pointer = func->getArgument(1);
   auto index = func->createVariable(JITTypeTag::INT64, "index");
   index = func->createConstant(JITTypeTag::INT64, 0l);
 

--- a/cider/exec/nextgen/operators/FilterNode.cpp
+++ b/cider/exec/nextgen/operators/FilterNode.cpp
@@ -42,10 +42,7 @@ void FilterTranslator::codegen(context::CodegenContext& context) {
         auto&& [expr_type, exprs] = op_node_->getOutputExprs();
         for (const auto& expr : exprs) {
           utils::FixSizeJITExprValue cond(expr->codegen(*func));
-          bool_init = bool_init && cond.getValue();
-          if (cond.isNullable()) {
-            bool_init = bool_init && !cond.getNull();
-          }
+          bool_init = bool_init && cond.getValue() && !cond.getNull();
         }
         return bool_init;
       })

--- a/cider/exec/nextgen/operators/RowToColumnNode.cpp
+++ b/cider/exec/nextgen/operators/RowToColumnNode.cpp
@@ -65,6 +65,9 @@ class ColumnWriter {
     // Allocate buffer.
     auto raw_data_buffer = context_.getJITFunction()->createLocalJITValue(
         [this]() { return allocateRawDataBuffer(1, expr_->get_type_info().get_type()); });
+    // the null_buffer, raw_data_buffer not used anymore.
+    // so it doesn't matter whether null_buffer is nullptr
+    // or constant false.
     auto null_buffer = JITValuePointer(nullptr);
 
     // Write value

--- a/cider/exec/nextgen/utils/JITExprValue.h
+++ b/cider/exec/nextgen/utils/JITExprValue.h
@@ -75,8 +75,6 @@ class JITExprValueAdaptor {
 
   void setNull(jitlib::JITValuePointer& rh) { values_[0].replace(rh); }
 
-  bool isNullable() { return values_[0].get() != nullptr; }
-
  protected:
   JITExprValue& values_;
 };

--- a/cider/tests/nextgen/compiler/FilterProjectTest.cpp
+++ b/cider/tests/nextgen/compiler/FilterProjectTest.cpp
@@ -93,19 +93,29 @@ class FilterProjectTest : public ::testing::Test {
     auto output_batch_array = runtime_ctx->getOutputBatch()->getArray();
     EXPECT_EQ(output_batch_array->length, 4);
 
-    auto check_array = [](ArrowArray* array, size_t expect_len) {
-      EXPECT_EQ(array->length, expect_len);
-      int64_t* data_buffer = (int64_t*)array->buffers[1];
-      for (size_t i = 0; i < expect_len; ++i) {
-        std::cout << data_buffer[i] << " ";
-      }
-      std::cout << std::endl;
-    };
+    auto check_array =
+        [](ArrowArray* array, size_t expect_len, std::vector<int64_t>& expect_res) {
+          EXPECT_EQ(array->length, expect_len);
+          int64_t* data_buffer = (int64_t*)array->buffers[1];
+          for (size_t i = 0; i < expect_len; ++i) {
+            EXPECT_EQ(data_buffer[i], expect_res[i]);
+          }
+        };
 
-    check_array(output_batch_array->children[0], 4);
-    check_array(output_batch_array->children[1], 4);
-    check_array(output_batch_array->children[2], 4);
-    check_array(output_batch_array->children[3], 4);
+    // a   1 2 3 4
+    // b   2 3 4 5
+    // a+b 3 5 7 9
+    // b+a 3 5 7 9
+    // a+a 2 4 6 8
+    // b+b 4 6 8 10
+    std::vector<int64_t> expect_res = {3, 5, 7, 9};
+    check_array(output_batch_array->children[0], 4, expect_res);
+    expect_res = {3, 5, 7, 9};
+    check_array(output_batch_array->children[1], 4, expect_res);
+    expect_res = {2, 4, 6, 8};
+    check_array(output_batch_array->children[2], 4, expect_res);
+    expect_res = {4, 6, 8, 10};
+    check_array(output_batch_array->children[3], 4, expect_res);
   }
 
  private:

--- a/cider/type/plan/BinaryExpr.cpp
+++ b/cider/type/plan/BinaryExpr.cpp
@@ -48,14 +48,7 @@ JITExprValue& BinOper::codegen(JITFunction& func) {
   FixSizeJITExprValue lhs_val(lhs->codegen(func));
   FixSizeJITExprValue rhs_val(rhs->codegen(func));
 
-  JITValuePointer null(nullptr);
-  bool lhs_nullable = lhs_val.isNullable();
-  bool rhs_nullable = rhs_val.isNullable();
-  if (lhs_nullable && rhs_nullable) {
-    null.replace(lhs_val.getNull() || rhs_val.getNull());
-  } else if (lhs_nullable || rhs_nullable) {
-    null.replace(lhs_nullable ? lhs_val.getNull() : rhs_val.getNull());
-  }
+  auto null = lhs_val.getNull() || rhs_val.getNull();
 
   switch (lhs_ti.get_type()) {
     case kVARCHAR:

--- a/cider/type/plan/ConstantExpr.cpp
+++ b/cider/type/plan/ConstantExpr.cpp
@@ -27,6 +27,8 @@ JITExprValue& Constant::codegen(JITFunction& func) {
     return expr_var;
   }
 
+  auto null = func.createConstant(JITTypeTag::BOOL, false);
+
   const auto& ti = get_type_info();
   const auto type = ti.is_decimal() ? decimal_to_int_type(ti) : ti.get_type();
   switch (type) {
@@ -34,7 +36,7 @@ JITExprValue& Constant::codegen(JITFunction& func) {
       CIDER_THROW(CiderCompileException,
                   "NULL type literals are not currently supported in this context.");
     case kBOOLEAN:
-      return set_expr_value(nullptr,
+      return set_expr_value(null,
                             func.createConstant(getJITTag(type), get_constval().boolval));
     case kTINYINT:
     case kSMALLINT:
@@ -45,14 +47,14 @@ JITExprValue& Constant::codegen(JITFunction& func) {
     case kDATE:
     case kINTERVAL_DAY_TIME:
     case kINTERVAL_YEAR_MONTH:
-      return set_expr_value(nullptr,
+      return set_expr_value(null,
                             func.createConstant(getJITTag(type), get_constval().intval));
     case kFLOAT:
       return set_expr_value(
-          nullptr, func.createConstant(getJITTag(type), get_constval().floatval));
+          null, func.createConstant(getJITTag(type), get_constval().floatval));
     case kDOUBLE:
       return set_expr_value(
-          nullptr, func.createConstant(getJITTag(type), get_constval().doubleval));
+          null, func.createConstant(getJITTag(type), get_constval().doubleval));
     case kVARCHAR:
     case kCHAR:
     case kTEXT: {


### PR DESCRIPTION
### What changes were proposed in this pull request?
constant bool specialization in expr codegen.  
we should always fill null(false for not null, ) in expr, please don't use nullptr, and then we can pipeline all conditions without checking `isNullable`.
we check the const bool value inner and generate optimized IR with less calculation.


### Why are the changes needed?
better user API and performance.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT

### Which label does this PR belong to?
INFRA
