### PR TITLE
[POAE7-2666] Support for calling multiple JITValue methods

### DIFF
--- a/cider/exec/nextgen/jitlib/base/JITFunction.h
+++ b/cider/exec/nextgen/jitlib/base/JITFunction.h
@@ -68,9 +68,9 @@ class JITFunction {
     }
   }
 
-  template <typename T>
-  JITValuePointer packValues(T&& params, uint64_t alignment = 8) {
-    return packJITValues(std::forward<T>(params), alignment);
+  template <uint64_t alignment = 8, typename... T>
+  JITValuePointer packJITValues(T&&... params) {
+    return packJITValuesImpl({std::forward<T>(params)...}, alignment);
   }
 
   template <typename T = int32_t>
@@ -147,8 +147,8 @@ class JITFunction {
                                              const std::string& name,
                                              JITValuePointer& init_val) = 0;
 
-  virtual JITValuePointer packJITValues(const std::vector<JITValuePointer> vals,
-                                        const uint64_t alignment) = 0;
+  virtual JITValuePointer packJITValuesImpl(const std::vector<JITValuePointer>& vals,
+                                            const uint64_t alignment) = 0;
 };
 
 using JITFunctionPointer = std::shared_ptr<JITFunction>;

--- a/cider/exec/nextgen/jitlib/base/JITFunction.h
+++ b/cider/exec/nextgen/jitlib/base/JITFunction.h
@@ -68,6 +68,11 @@ class JITFunction {
     }
   }
 
+  template <typename T>
+  JITValuePointer packValues(T&& params, uint64_t alignment = 8) {
+    return packJITValues(std::forward<T>(params), alignment);
+  }
+
   template <typename T = int32_t>
   JITValuePointer createVariable(JITTypeTag type_tag,
                                  const std::string& name = "var",
@@ -141,6 +146,9 @@ class JITFunction {
   virtual JITValuePointer createVariableImpl(JITTypeTag type_tag,
                                              const std::string& name,
                                              JITValuePointer& init_val) = 0;
+
+  virtual JITValuePointer packJITValues(const std::vector<JITValuePointer> vals,
+                                        const uint64_t alignment) = 0;
 };
 
 using JITFunctionPointer = std::shared_ptr<JITFunction>;

--- a/cider/exec/nextgen/jitlib/base/JITValue.h
+++ b/cider/exec/nextgen/jitlib/base/JITValue.h
@@ -128,7 +128,7 @@ class JITValuePointer {
 
   JITValuePointer(JITValuePointer&& rh) noexcept : ptr_(rh.ptr_) { rh.ptr_ = nullptr; }
 
-  JITValue* get() { return ptr_; }
+  JITValue* get() const { return ptr_; }
 
   size_t getRefNum() { return ptr_->getRefNum(); }
 
@@ -155,13 +155,13 @@ class JITValuePointer {
 
   JITValuePointer& operator=(JITValue& rh) noexcept;
 
-  JITValue& operator*() { return *ptr_; }
+  JITValue& operator*() const { return *ptr_; }
 
-  JITValue* operator->() { return ptr_; }
+  JITValue* operator->() const { return ptr_; }
 
-  operator JITValue&() { return *ptr_; }
+  operator JITValue&() const { return *ptr_; }
 
-  JITValuePointer operator[](JITValue& index);
+  JITValuePointer operator[](JITValue& index) const;
 
  private:
   void release() {
@@ -190,7 +190,7 @@ inline JITValuePointer& JITValuePointer::operator=(JITValue& rh) noexcept {
   return *this;
 }
 
-inline JITValuePointer JITValuePointer::operator[](JITValue& index) {
+inline JITValuePointer JITValuePointer::operator[](JITValue& index) const {
   return (*ptr_)[index];
 }
 };  // namespace cider::jitlib

--- a/cider/exec/nextgen/jitlib/llvmjit/LLVMJITFunction.h
+++ b/cider/exec/nextgen/jitlib/llvmjit/LLVMJITFunction.h
@@ -78,8 +78,8 @@ class LLVMJITFunction final : public JITFunction {
 
   void cloneFunctionRecursive(llvm::Function* fn);
 
-  JITValuePointer packJITValues(const std::vector<JITValuePointer> vals,
-                                const uint64_t alignment) override;
+  JITValuePointer packJITValuesImpl(const std::vector<JITValuePointer>& vals,
+                                    const uint64_t alignment) override;
 
   LLVMJITModule& module_;
   llvm::Function& func_;

--- a/cider/exec/nextgen/jitlib/llvmjit/LLVMJITFunction.h
+++ b/cider/exec/nextgen/jitlib/llvmjit/LLVMJITFunction.h
@@ -78,6 +78,9 @@ class LLVMJITFunction final : public JITFunction {
 
   void cloneFunctionRecursive(llvm::Function* fn);
 
+  JITValuePointer packJITValues(const std::vector<JITValuePointer> vals,
+                                const uint64_t alignment) override;
+
   LLVMJITModule& module_;
   llvm::Function& func_;
   mutable std::unique_ptr<llvm::IRBuilder<>> ir_builder_;

--- a/cider/tests/nextgen/jitlib/JITLibTest.cpp
+++ b/cider/tests/nextgen/jitlib/JITLibTest.cpp
@@ -623,34 +623,30 @@ TEST_F(JITLibTests, PackJITValueTest) {
   LLVMJITModule module("TestModule");
   JITFunctionPointer func =
       JITFunctionBuilder()
-          .setFuncName("test_pack_jitvalue")
+          .setFuncName("test_packjitvalues")
           .registerModule(module)
           .addReturn(JITTypeTag::BOOL)
-          .addProcedureBuilder([](JITFunction* function) {
+          .addProcedureBuilder([](JITFunctionPointer function) {
             JITValuePointer param1 =
-                function->createVariable(JITTypeTag::INT32, "param1");
-            param1 = function->createConstant(JITTypeTag::INT32, 1);
+                function->createVariable(JITTypeTag::INT32, "param1", 1);
             JITValuePointer param2 =
-                function->createVariable(JITTypeTag::INT64, "param2");
-            param2 = function->createConstant(JITTypeTag::INT64, 2l);
+                function->createVariable(JITTypeTag::INT64, "param2", 2l);
             JITValuePointer param3 =
-                function->createVariable(JITTypeTag::DOUBLE, "param3");
-            param3 = function->createConstant(JITTypeTag::DOUBLE, 3.0);
+                function->createVariable(JITTypeTag::DOUBLE, "param3", 3.0);
             uint64_t alignment = 16;
             std::vector<JITValuePointer> vals = {param1, param2, param3};
-            auto start_address = function->packValues(vals, alignment);
+            auto start_address = function->packJITValues<16>(param1, param2, param3);
             int64_t memory_count = 0;
             std::vector<int64_t> memory_index;
             for (auto val : vals) {
               memory_index.push_back(memory_count);
-              memory_count += getJITTypeSize(val->getTypeTag());
-              memory_count = (memory_count + alignment) & ~(alignment - 1);
+              memory_count += getJITTypeSize(val->getValueTypeTag());
+              memory_count = (memory_count + alignment - 1) & ~(alignment - 1);
             }
-            auto isTrue = function->createVariable(JITTypeTag::BOOL, "isTrue");
-            isTrue = function->createConstant(JITTypeTag::BOOL, true);
+            auto isTrue = function->createVariable(JITTypeTag::BOOL, "isTrue", true);
 
             for (int i = 0; i < vals.size(); ++i) {
-              auto offset = function->createConstant(JITTypeTag::INT64, memory_index[i]);
+              auto offset = function->createLiteral(JITTypeTag::INT64, memory_index[i]);
               auto jit_value = (start_address + offset)
                                    ->castPointerSubType(vals[i]->getValueTypeTag());
               auto res = (**jit_value == vals[i]);

--- a/cider/tests/nextgen/jitlib/JITLibTest.cpp
+++ b/cider/tests/nextgen/jitlib/JITLibTest.cpp
@@ -619,6 +619,53 @@ TEST_F(JITLibTests, ReadAndWriteJITPointerTest) {
   }
 }
 
+TEST_F(JITLibTests, PackJITValueTest) {
+  LLVMJITModule module("TestModule");
+  JITFunctionPointer func =
+      JITFunctionBuilder()
+          .setFuncName("test_pack_jitvalue")
+          .registerModule(module)
+          .addReturn(JITTypeTag::BOOL)
+          .addProcedureBuilder([](JITFunction* function) {
+            JITValuePointer param1 =
+                function->createVariable(JITTypeTag::INT32, "param1");
+            param1 = function->createConstant(JITTypeTag::INT32, 1);
+            JITValuePointer param2 =
+                function->createVariable(JITTypeTag::INT64, "param2");
+            param2 = function->createConstant(JITTypeTag::INT64, 2l);
+            JITValuePointer param3 =
+                function->createVariable(JITTypeTag::DOUBLE, "param3");
+            param3 = function->createConstant(JITTypeTag::DOUBLE, 3.0);
+            uint64_t alignment = 16;
+            std::vector<JITValuePointer> vals = {param1, param2, param3};
+            auto start_address = function->packValues(vals, alignment);
+            int64_t memory_count = 0;
+            std::vector<int64_t> memory_index;
+            for (auto val : vals) {
+              memory_index.push_back(memory_count);
+              memory_count += getJITTypeSize(val->getTypeTag());
+              memory_count = (memory_count + alignment) & ~(alignment - 1);
+            }
+            auto isTrue = function->createVariable(JITTypeTag::BOOL, "isTrue");
+            isTrue = function->createConstant(JITTypeTag::BOOL, true);
+
+            for (int i = 0; i < vals.size(); ++i) {
+              auto offset = function->createConstant(JITTypeTag::INT64, memory_index[i]);
+              auto jit_value = (start_address + offset)
+                                   ->castPointerSubType(vals[i]->getValueTypeTag());
+              auto res = (**jit_value == vals[i]);
+              isTrue = res && isTrue;
+            }
+            function->createReturn(isTrue);
+          })
+          .build();
+
+  module.finish();
+  auto func_ptr = func->getFunctionPointer<bool>();
+  bool result = func_ptr();
+  EXPECT_EQ(result, true);
+}
+
 int main(int argc, char** argv) {
   TestHelpers::init_logger_stderr_only(argc, argv);
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### What changes were proposed in this pull request?

- add JITFunction ```packJITValue(const std::string& name,  const uint64_t alignment, const std::vector<JITValuePointer>& vals)```. To generate IR code. Pass in multiple JITValuePointers, allocate a buffer and store JITValuePointers,  alignment is used as memory alignment here, finally return the buffer head address.
- add related unit test in JITLibTest

### Why are the changes needed?
For Next Gen Framework translator development
For example : we need to pass mutiple exprs as hash join keys in HashJoinTranslator

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UTs

### Which label does this PR belong to?
INFRA