### PR TITLE
[POAE7-2725] NextGen segfaults if no column is referenced in input query

### DIFF
--- a/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
+++ b/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
@@ -149,23 +149,12 @@ void ColumnToRowTranslator::codegen(context::CodegenContext& context) {
   // for row loop
   auto index = func->createVariable(JITTypeTag::INT64, "index", 0);
 
-  // input column rows num.
-  JITValuePointer len = nullptr;
-  if (inputs.size()) {
-    len.replace(func->createLocalJITValue([&context, &inputs]() {
-      return context::codegen_utils::getArrowArrayLength(
-          context.getArrowArrayValues(inputs.front()->getLocalIndex()).first);
-    }));
-  } else {
-    // inputs will be empty if no column is referenced in the sql query
-    // e.g. select 123 from test, so we directly get length from the input arrow array
-    // assumes signature be like: query_func(context, array)
-    auto input_array = func->getArgument(1);  // array
-    len.replace(func->createLocalJITValue([&context, &input_array]() {
-      return context::codegen_utils::getArrowArrayLength(input_array);
-    }));
-  }
-
+  // get input row num from input arrow array
+  // assumes signature be like: query_func(context, array)
+  auto input_array = func->getArgument(1);  // array
+  auto len = func->createLocalJITValue([&context, &input_array]() {
+    return context::codegen_utils::getArrowArrayLength(input_array);
+  });
   static_cast<ColumnToRowNode*>(node_.get())->setColumnRowNum(len);
 
   func->createLoopBuilder()

--- a/src/cider/tests/nextgen/compiler/FilterProjectTest.cpp
+++ b/src/cider/tests/nextgen/compiler/FilterProjectTest.cpp
@@ -161,6 +161,14 @@ TEST_F(FilterProjectTest, TestOther) {
                        expected_cols);
 }
 
+TEST_F(FilterProjectTest, TestConstantExpression) {
+  std::vector<std::vector<int32_t>> expected_cols = {{2, 2, 2, 2, 2, 2, 2, 2, 2, 2}};
+  // select 2 from test returns int32_t in substrait
+  executeTest<int32_t>("CREATE TABLE test(a BIGINT, b BIGINT NOT NULL);",
+                       "select 2 from test",
+                       expected_cols);
+}
+
 int main(int argc, char** argv) {
   TestHelpers::init_logger_stderr_only(argc, argv);
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### What changes were proposed in this pull request?

#### Bug Description

If an input query did not reference any column in the input table, e.g. `select 'a-string-literal' from test` or `select 2 from test`, a segmentation fault would occur during ColumnToRow codegen.

This is because, `ColumnToRowNode` gets input from preceding `ArrowSourceNode`. `ArrowSourceNode` keeps all columns that will be used in a vector `input_exprs_`. When inserting `ArrowSourceNode` into the OpNodePipeline, an `InputAnalyzer` will remove any column that is not used in the query (Around L71 in RelAlgEUParser.cpp). In the example queries above, no column is referenced, so all columns are erased from `input_exprs_`. As a result, `input_exprs_` is an *empty vector*.

However, the `ColumnToRowNode` attempts to access the first element in the `input_exprs_` in order to get the row number of the input table (Around L152 in ColumnToRowNode.cpp). Since `input_exprs_` is empty, it results in segmentation fault.

#### Fix

Fixed by adding a special-case handling in `ColumnToRowNode`, if `input_exprs_` is empty, the node tries to get the length directly from the input arrow array (which is available as a parameter passed to the query function).

---

@bigPYJ1151 please help take a review, thanks.

### Why are the changes needed?

Bug fix. Cause of the bug and fixes are detailed in the above section.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT. Added a unit test in FilterProjectTest.

### Which label does this PR belong to?

BUG
