### PR TITLE
[POAE7-2679] CodegenContext Register Hashtable

### DIFF
--- a/src/cider/exec/nextgen/CMakeLists.txt
+++ b/src/cider/exec/nextgen/CMakeLists.txt
@@ -35,4 +35,5 @@ add_library(
   nextgen STATIC
   Nextgen.cpp $<TARGET_OBJECTS:cider_operators> $<TARGET_OBJECTS:cider_context>
   $<TARGET_OBJECTS:cider_parsers> $<TARGET_OBJECTS:cider_transformer>)
-target_link_libraries(nextgen ${NEXTGEN_DEPS} jitlib)
+# TODO(qiuyang) : folly will deleted after hashtable refactoring
+target_link_libraries(nextgen ${NEXTGEN_DEPS} jitlib folly)

--- a/src/cider/exec/nextgen/context/CodegenContext.cpp
+++ b/src/cider/exec/nextgen/context/CodegenContext.cpp
@@ -109,6 +109,27 @@ JITValuePointer CodegenContext::registerBuffer(const int32_t capacity,
   return ret;
 }
 
+JITValuePointer CodegenContext::registerHashTable(const std::string& name) {
+  int64_t id = acquireContextID();
+  auto index = this->jit_func_->createLiteral(JITTypeTag::INT64, id);
+  JITValuePointer ret = jit_func_->createLocalJITValue([this, id]() {
+    auto index = this->jit_func_->createLiteral(JITTypeTag::INT64, id);
+    auto pointer = this->jit_func_->emitRuntimeFunctionCall(
+        "get_query_context_item_ptr",
+        JITFunctionEmitDescriptor{
+            .ret_type = JITTypeTag::POINTER,
+            .ret_sub_type = JITTypeTag::INT8,
+            .params_vector = {this->jit_func_->getArgument(0).get(), index.get()}});
+
+    return pointer;
+  });
+  ret->setName(name);
+
+  hashtable_descriptor_.first = std::make_shared<HashTableDescriptor>(id, name);
+  hashtable_descriptor_.second.replace(ret);
+  return ret;
+}
+
 RuntimeCtxPtr CodegenContext::generateRuntimeCTX(
     const CiderAllocatorPtr& allocator) const {
   auto runtime_ctx = std::make_unique<RuntimeContext>(getNextContextID());
@@ -120,6 +141,8 @@ RuntimeCtxPtr CodegenContext::generateRuntimeCTX(
   for (auto& buffer_desc : buffer_descriptors_) {
     runtime_ctx->addBuffer(buffer_desc.first);
   }
+
+  runtime_ctx->addHashTable(hashtable_descriptor_.first);
 
   runtime_ctx->instantiate(allocator);
   return runtime_ctx;

--- a/src/cider/exec/nextgen/context/RuntimeContext.cpp
+++ b/src/cider/exec/nextgen/context/RuntimeContext.cpp
@@ -32,6 +32,11 @@ void RuntimeContext::addBuffer(const CodegenContext::BufferDescriptorPtr& descri
   buffer_holder_.emplace_back(descriptor, nullptr);
 }
 
+void RuntimeContext::addHashTable(
+    const CodegenContext::HashTableDescriptorPtr& descriptor) {
+  hashtable_holder_ = descriptor;
+}
+
 void RuntimeContext::instantiate(const CiderAllocatorPtr& allocator) {
   // Instantiation of batches.
   for (auto& batch_desc : batch_holder_) {
@@ -51,6 +56,11 @@ void RuntimeContext::instantiate(const CiderAllocatorPtr& allocator) {
   }
 
   string_heap_ptr_ = std::make_shared<StringHeap>(allocator);
+
+  // Instantiation of hashtable.
+  if (hashtable_holder_ != nullptr) {
+    runtime_ctx_pointers_[hashtable_holder_->ctx_id] = hashtable_holder_->hash_table;
+  }
 }
 
 void allocateBatchMem(ArrowArray* array,

--- a/src/cider/exec/nextgen/context/RuntimeContext.h
+++ b/src/cider/exec/nextgen/context/RuntimeContext.h
@@ -43,6 +43,8 @@ class RuntimeContext {
 
   void addBuffer(const CodegenContext::BufferDescriptorPtr& descriptor);
 
+  void addHashTable(const CodegenContext::HashTableDescriptorPtr& descriptor);
+
   void instantiate(const CiderAllocatorPtr& allocator);
 
   // TBD: Currently, last batch would be output batch under all known scenarios.
@@ -80,6 +82,7 @@ class RuntimeContext {
   std::vector<std::pair<CodegenContext::BatchDescriptorPtr, BatchPtr>> batch_holder_;
   std::vector<std::pair<CodegenContext::BufferDescriptorPtr, BufferPtr>> buffer_holder_;
   std::shared_ptr<StringHeap> string_heap_ptr_;
+  CodegenContext::HashTableDescriptorPtr hashtable_holder_;
 };
 
 using RuntimeCtxPtr = std::unique_ptr<RuntimeContext>;


### PR DESCRIPTION
### What changes were proposed in this pull request?

- provide registerHashTable related function in codegenContext and setHashTable in RuntimeContext
- add related test file
- **(Since the design of the template class used by hashtable is not applicable this time, a hard-coded template class is now used, and the default template class will be provided later, and corresponding modifications will be made here)**

### Why are the changes needed?
for NextGen FW and HashJoinTranslator development

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UTs

### Which label does this PR belong to?
INFRA
