### PR TITLE
[POAE7-2665] HashJoinTranslator support 

### DIFF
--- a/src/cider/exec/nextgen/CMakeLists.txt
+++ b/src/cider/exec/nextgen/CMakeLists.txt
@@ -35,6 +35,4 @@ add_library(
   nextgen STATIC
   Nextgen.cpp $<TARGET_OBJECTS:cider_operators> $<TARGET_OBJECTS:cider_context>
   $<TARGET_OBJECTS:cider_parsers> $<TARGET_OBJECTS:cider_transformer>)
-# TODO(qiuyang) : folly and ${CMAKE_DL_LIBS} will deleted after hashtable
-# refactoring
-target_link_libraries(nextgen ${NEXTGEN_DEPS} jitlib folly ${CMAKE_DL_LIBS})
+target_link_libraries(nextgen ${NEXTGEN_DEPS} jitlib)

--- a/src/cider/exec/nextgen/Nextgen.cpp
+++ b/src/cider/exec/nextgen/Nextgen.cpp
@@ -28,7 +28,7 @@
 namespace cider::exec::nextgen {
 
 std::unique_ptr<context::CodegenContext> compile(
-    const RelAlgExecutionUnit& ra_exe_unit,
+    RelAlgExecutionUnit& ra_exe_unit,
     const jitlib::CompilationOptions& co,
     const context::CodegenOptions& codegen_options) {
   auto codegen_ctx = std::make_unique<context::CodegenContext>();

--- a/src/cider/exec/nextgen/Nextgen.h
+++ b/src/cider/exec/nextgen/Nextgen.h
@@ -30,7 +30,7 @@ namespace cider::exec::nextgen {
 using QueryFunc = int32_t (*)(int8_t*, int8_t*);
 
 std::unique_ptr<context::CodegenContext> compile(
-    const RelAlgExecutionUnit& eu,
+    RelAlgExecutionUnit& eu,
     const jitlib::CompilationOptions& co = jitlib::CompilationOptions{},
     const context::CodegenOptions& codegen_options = context::CodegenOptions{});
 

--- a/src/cider/exec/nextgen/context/Buffer.h
+++ b/src/cider/exec/nextgen/context/Buffer.h
@@ -42,11 +42,10 @@ class Buffer {
   void allocateBuffer(int32_t size) {
     if (capacity_) {
       buffer_ = allocator_->reallocate(buffer_, capacity_, size);
-      capacity_ = size;
     } else {
       buffer_ = allocator_->allocate(size);
-      capacity_ = size;
     }
+    capacity_ = size;
   }
 
   int8_t* getBuffer() { return buffer_; }

--- a/src/cider/exec/nextgen/context/Buffer.h
+++ b/src/cider/exec/nextgen/context/Buffer.h
@@ -39,6 +39,16 @@ class Buffer {
 
   ~Buffer() { allocator_->deallocate(buffer_, capacity_); }
 
+  void allocateBuffer(int32_t size) {
+    if (capacity_) {
+      buffer_ = allocator_->reallocate(buffer_, capacity_, size);
+      capacity_ = size;
+    } else {
+      buffer_ = allocator_->allocate(size);
+      capacity_ = size;
+    }
+  }
+
   int8_t* getBuffer() { return buffer_; }
 
   int32_t getCapacity() { return capacity_; }

--- a/src/cider/exec/nextgen/context/CodegenContext.cpp
+++ b/src/cider/exec/nextgen/context/CodegenContext.cpp
@@ -282,5 +282,6 @@ void setArrowArrayLength(jitlib::JITValuePointer& arrow_array,
       JITFunctionEmitDescriptor{.ret_type = JITTypeTag::VOID,
                                 .params_vector = {arrow_array.get(), len.get()}});
 }
+
 }  // namespace codegen_utils
 }  // namespace cider::exec::nextgen::context

--- a/src/cider/exec/nextgen/context/CodegenContext.h
+++ b/src/cider/exec/nextgen/context/CodegenContext.h
@@ -21,7 +21,6 @@
 #ifndef NEXTGEN_CONTEXT_CODEGENCONTEXT_H
 #define NEXTGEN_CONTEXT_CODEGENCONTEXT_H
 
-#include "exec/nextgen/context/Batch.h"
 #include "exec/nextgen/context/Buffer.h"
 #include "exec/nextgen/context/CiderSet.h"
 #include "exec/nextgen/jitlib/base/JITModule.h"

--- a/src/cider/exec/nextgen/context/CodegenContext.h
+++ b/src/cider/exec/nextgen/context/CodegenContext.h
@@ -135,7 +135,6 @@ class CodegenContext {
       bool output_raw_buffer = true);
 
   jitlib::JITValuePointer registerHashTable(const std::string& name = "");
-  
   jitlib::JITValuePointer registerCiderSet(const std::string& name,
                                            const SQLTypeInfo& type,
                                            CiderSetPtr c_set);

--- a/src/cider/exec/nextgen/context/CodegenContext.h
+++ b/src/cider/exec/nextgen/context/CodegenContext.h
@@ -21,6 +21,7 @@
 #ifndef NEXTGEN_CONTEXT_CODEGENCONTEXT_H
 #define NEXTGEN_CONTEXT_CODEGENCONTEXT_H
 
+#include "exec/nextgen/context/Batch.h"
 #include "exec/nextgen/context/Buffer.h"
 #include "exec/nextgen/context/CiderSet.h"
 #include "exec/nextgen/jitlib/base/JITModule.h"
@@ -52,6 +53,7 @@ struct murmurHash {
 struct Equal {
   bool operator()(int lhs, int rhs) { return lhs == rhs; }
 };
+
 struct AggExprsInfo {
  public:
   SQLTypeInfo sql_type_info_;
@@ -134,6 +136,7 @@ class CodegenContext {
       bool output_raw_buffer = true);
 
   jitlib::JITValuePointer registerHashTable(const std::string& name = "");
+  
   jitlib::JITValuePointer registerCiderSet(const std::string& name,
                                            const SQLTypeInfo& type,
                                            CiderSetPtr c_set);

--- a/src/cider/exec/nextgen/context/RuntimeContext.cpp
+++ b/src/cider/exec/nextgen/context/RuntimeContext.cpp
@@ -60,6 +60,11 @@ void RuntimeContext::instantiate(const CiderAllocatorPtr& allocator) {
     }
   }
 
+  // Instantiation of hashtable.
+  if (hashtable_holder_ != nullptr) {
+    runtime_ctx_pointers_[hashtable_holder_->ctx_id] = hashtable_holder_->hash_table;
+  }
+
   string_heap_ptr_ = std::make_shared<StringHeap>(allocator);
 
   // Instantiation of hashtable.

--- a/src/cider/exec/nextgen/context/RuntimeContext.cpp
+++ b/src/cider/exec/nextgen/context/RuntimeContext.cpp
@@ -67,11 +67,6 @@ void RuntimeContext::instantiate(const CiderAllocatorPtr& allocator) {
 
   string_heap_ptr_ = std::make_shared<StringHeap>(allocator);
 
-  // Instantiation of hashtable.
-  if (hashtable_holder_ != nullptr) {
-    runtime_ctx_pointers_[hashtable_holder_->ctx_id] = hashtable_holder_->hash_table;
-  }
-
   for (auto& cider_set_desc : cider_set_holder_) {
     if (nullptr == cider_set_desc.second) {
       runtime_ctx_pointers_[cider_set_desc.first->ctx_id] =

--- a/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
+++ b/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
@@ -84,7 +84,7 @@ JITValuePointer LLVMJITValue::notOp() {
     case JITTypeTag::BOOL: {
       if (auto const_bool = llvm::dyn_cast<llvm::ConstantInt>(llvm_value_)) {
         bool literal = const_bool->isOne() ? false : true;
-        return parent_function_.createConstant(JITTypeTag::BOOL, literal);
+        return parent_function_.createLiteral(JITTypeTag::BOOL, literal);
       }
       ans = getFunctionBuilder(parent_function_).CreateNot(load());
       break;

--- a/src/cider/exec/nextgen/operators/CMakeLists.txt
+++ b/src/cider/exec/nextgen/operators/CMakeLists.txt
@@ -27,6 +27,7 @@ add_opnode(ArrowSourceNode)
 add_opnode(ColumnToRowNode)
 add_opnode(AggregationNode)
 add_opnode(RowToColumnNode)
+add_opnode(HashJoinNode)
 
 list(APPEND OPERATORS_SOURCE
      ${CMAKE_CURRENT_LIST_DIR}/extractor/AggExtractorBuilder.cpp)

--- a/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
+++ b/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
@@ -75,7 +75,7 @@ class ColumnReader {
     auto row_data = value_pointer + cur_offset;  // still char*
 
     if (expr_->get_type_info().get_notnull()) {
-      expr_->set_expr_value(func.createConstant(JITTypeTag::BOOL, false), len, row_data);
+      expr_->set_expr_value(func.createLiteral(JITTypeTag::BOOL, false), len, row_data);
     } else {
       // null buffer decoder
       // TBD: Null representation, bit-array or bool-array.
@@ -95,7 +95,7 @@ class ColumnReader {
     auto& func = batch->getParentJITFunction();
     auto row_data = getFixSizeRowData(func, fixsize_values);
     if (expr_->get_type_info().get_notnull()) {
-      expr_->set_expr_value(func.createConstant(JITTypeTag::BOOL, false), row_data);
+      expr_->set_expr_value(func.createLiteral(JITTypeTag::BOOL, false), row_data);
     } else {
       // null buffer decoder
       // TBD: Null representation, bit-array or bool-array.
@@ -152,7 +152,7 @@ void ColumnToRowTranslator::codegen(context::CodegenContext& context) {
   // get input row num from input arrow array
   // assumes signature be like: query_func(context, array)
   auto input_array = func->getArgument(1);  // array
-  auto len = func->createLocalJITValue([&context, &input_array]() {
+  auto len = func->createLocalJITValue([&input_array]() {
     return context::codegen_utils::getArrowArrayLength(input_array);
   });
   static_cast<ColumnToRowNode*>(node_.get())->setColumnRowNum(len);

--- a/src/cider/exec/nextgen/operators/HashJoinNode.cpp
+++ b/src/cider/exec/nextgen/operators/HashJoinNode.cpp
@@ -152,6 +152,7 @@ void traverse(ExprPtr expr,
               std::vector<JITValuePointer>& nulls,
               context::CodegenContext& context) {
   if (Analyzer::ColumnVar* col_var = dynamic_cast<Analyzer::ColumnVar*>(expr.get())) {
+    // FIXME (qiuyang):: 100 is not always used as right table id.
     if (col_var->get_table_id() == 100) {
       utils::FixSizeJITExprValue jit_value(expr->codegen(context));
       keys.emplace_back(jit_value.getValue());

--- a/src/cider/exec/nextgen/operators/HashJoinNode.cpp
+++ b/src/cider/exec/nextgen/operators/HashJoinNode.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "exec/nextgen/operators/HashJoinNode.h"
+
+#include "exec/nextgen/context/CodegenContext.h"
+#include "exec/nextgen/jitlib/JITLib.h"
+#include "exec/nextgen/jitlib/base/ValueTypes.h"
+#include "type/plan/Expr.h"
+
+namespace cider::exec::nextgen::operators {
+using namespace jitlib;
+using namespace context;
+
+class BuildTableReader {
+ public:
+  BuildTableReader(utils::JITExprValue& buffer_values,
+                   ExprPtr& expr,
+                   JITValuePointer& index)
+      : buffer_values_(buffer_values), expr_(expr), index_(index) {}
+
+  void read() {
+    switch (expr_->get_type_info().get_type()) {
+      case kBOOLEAN:
+      case kTINYINT:
+      case kSMALLINT:
+      case kINT:
+      case kBIGINT:
+      case kFLOAT:
+      case kDOUBLE:
+      case kDATE:
+      case kTIME:
+      case kTIMESTAMP:
+        readFixSizedTypeCol();
+        break;
+      case kVARCHAR:
+      case kCHAR:
+      case kTEXT:
+        readVariableSizeTypeCol();
+        break;
+      default:
+        LOG(FATAL) << "Unsupported data type in BuildTableReader: "
+                   << expr_->get_type_info().get_type_name();
+    }
+  }
+
+ private:
+  void readVariableSizeTypeCol() {
+    utils::VarSizeJITExprValue varsize_values(buffer_values_);
+    auto data_buffer = varsize_values.getValue();
+
+    auto& func = data_buffer->getParentJITFunction();
+    // offset buffer
+    auto offset_pointer =
+        varsize_values.getLength()->castPointerSubType(JITTypeTag::INT32);
+    auto len = offset_pointer[index_ + 1] - offset_pointer[index_];
+    auto cur_offset = offset_pointer[index_];
+    // data buffer
+    auto value_pointer = data_buffer->castPointerSubType(JITTypeTag::INT8);
+    auto row_data = value_pointer + cur_offset;  // still char*
+
+    if (expr_->get_type_info().get_notnull()) {
+      expr_->set_expr_value(func.createLiteral(JITTypeTag::BOOL, false), len, row_data);
+    } else {
+      // null buffer decoder
+      // TBD: Null representation, bit-array or bool-array.
+      auto row_null_data = func.emitRuntimeFunctionCall(
+          "check_bit_vector_clear",
+          JITFunctionEmitDescriptor{
+              .ret_type = JITTypeTag::BOOL,
+              .params_vector = {{varsize_values.getNull().get(), index_.get()}}});
+      expr_->set_expr_value(row_null_data, len, row_data);
+    }
+  }
+
+  void readFixSizedTypeCol() {
+    utils::FixSizeJITExprValue fixsize_values(buffer_values_);
+    auto data_buffer = fixsize_values.getValue();
+    auto& func = data_buffer->getParentJITFunction();
+    JITTypeTag tag = utils::getJITTypeTag(expr_->get_type_info().get_type());
+    // data buffer decoder
+    auto actual_raw_data_buffer = data_buffer->castPointerSubType(tag);
+    auto row_data = getFixSizeRowData(func, fixsize_values);
+    if (expr_->get_type_info().get_notnull()) {
+      expr_->set_expr_value(func.createLiteral(JITTypeTag::BOOL, false), row_data);
+    } else {
+      // null buffer decoder
+      // TBD: Null representation, bit-array or bool-array.
+      auto row_null_data = func.emitRuntimeFunctionCall(
+          "check_bit_vector_clear",
+          JITFunctionEmitDescriptor{
+              .ret_type = JITTypeTag::BOOL,
+              .params_vector = {{fixsize_values.getNull().get(), index_.get()}}});
+
+      expr_->set_expr_value(row_null_data, row_data);
+    }
+  }
+
+  JITValuePointer getFixSizeRowData(JITFunction& func,
+                                    utils::FixSizeJITExprValue& fixsize_val) {
+    if (expr_->get_type_info().get_type() == kBOOLEAN) {
+      auto row_data = func.emitRuntimeFunctionCall(
+          "check_bit_vector_set",
+          JITFunctionEmitDescriptor{
+              .ret_type = JITTypeTag::BOOL,
+              .params_vector = {{fixsize_val.getValue().get(), index_.get()}}});
+      return row_data;
+    } else {
+      JITTypeTag tag = utils::getJITTypeTag(expr_->get_type_info().get_type());
+      // data buffer decoder
+      auto data_pointer = fixsize_val.getValue()->castPointerSubType(tag);
+      auto row_data = data_pointer[index_];
+      return row_data;
+    }
+  }
+
+ private:
+  utils::JITExprValue& buffer_values_;
+  ExprPtr& expr_;
+  JITValuePointer& index_;
+};
+
+TranslatorPtr HashJoinNode::toTranslator(const TranslatorPtr& succ) {
+  return createOpTranslator<HashJoinTranslator>(shared_from_this(), succ);
+}
+
+void HashJoinTranslator::consume(context::CodegenContext& context) {
+  codegen(context);
+}
+
+// traverse join_quals expr tree to get join key value
+void traverse(ExprPtr expr,
+              jitlib::JITFunctionPointer func,
+              std::vector<JITValuePointer>& params) {
+  if (Analyzer::ColumnVar* col_var = dynamic_cast<Analyzer::ColumnVar*>(expr.get())) {
+    if (col_var->get_table_id() == 100) {
+      utils::FixSizeJITExprValue jit_value(col_var->codegen(*func));
+      // TODO(qiuyang): null vector handle
+      params.emplace_back(jit_value.getValue());
+    }
+  } else {
+    auto children = expr->get_children_reference();
+    for (auto child : children) {
+      traverse(*child, func, params);
+    }
+  }
+}
+
+void HashJoinTranslator::codegen(context::CodegenContext& context) {
+  auto func = context.getJITFunction();
+  auto join_quals = dynamic_cast<HashJoinNode*>(node_.get())->getJoinQuals();
+
+  std::vector<JITValuePointer> params;
+  for (int i = 0; i < join_quals.size(); ++i) {
+    traverse(join_quals[i], func, params);
+  }
+
+  // open up a section of buffer to reserve the join result
+  auto join_res_buffer = context.registerBuffer(
+      16, "join_res_buffer", [](context::Buffer* buf) {}, false);
+
+  // pack join key values(support only one key now)
+  auto keys = func->packJITValues(params);
+
+  auto hashtable = context.registerHashTable();
+
+  // TODO(qiuyang) : hashtable will be a base class pointer
+  auto join_res_len = func->emitRuntimeFunctionCall(
+      "look_up_value_by_key",
+      JITFunctionEmitDescriptor{
+          .ret_type = JITTypeTag::INT64,
+          .params_vector = {hashtable.get(), keys.get(), join_res_buffer.get()}});
+
+  auto build_tables = dynamic_cast<HashJoinNode*>(node_.get())->getBuildTables();
+  auto row_index = func->createVariable(JITTypeTag::INT64, "row_index", 0l);
+  row_index = func->createLiteral(JITTypeTag::INT64, 0l);
+  func->createLoopBuilder()
+      ->condition([&row_index, &join_res_len]() { return row_index < join_res_len; })
+      ->loop([&] {
+        auto res_array = func->emitRuntimeFunctionCall(
+            "extract_join_res_array",
+            JITFunctionEmitDescriptor{
+                .ret_type = JITTypeTag::POINTER,
+                .ret_sub_type = JITTypeTag::INT8,
+                .params_vector = {join_res_buffer.get(), row_index.get()}});
+
+        auto res_row_id = func->emitRuntimeFunctionCall(
+            "extract_join_row_id",
+            JITFunctionEmitDescriptor{
+                .ret_type = JITTypeTag::INT64,
+                .params_vector = {join_res_buffer.get(), row_index.get()}});
+
+        for (int64_t idx = 0; idx < build_tables.size(); idx++) {
+          ExprPtr& expr = build_tables[idx];
+          auto build_idx = func->createLiteral(JITTypeTag::INT64, idx);
+
+          auto child_arrow_array = func->emitRuntimeFunctionCall(
+              "extract_arrow_array_child",
+              JITFunctionEmitDescriptor{
+                  .ret_type = JITTypeTag::POINTER,
+                  .ret_sub_type = JITTypeTag::VOID,
+                  .params_vector = {res_array.get(), build_idx.get()}});
+
+          int64_t buffer_num = utils::getBufferNum(expr->get_type_info().get_type());
+          utils::JITExprValue buffer_values(buffer_num, JITExprValueType::BATCH);
+          for (int64_t i = 0; i < buffer_num; ++i) {
+            auto buffer_idx = func->createLiteral(JITTypeTag::INT64, i);
+
+            auto arroy_buffer = func->emitRuntimeFunctionCall(
+                "extract_arrow_array_buffer",
+                JITFunctionEmitDescriptor{
+                    .ret_type = JITTypeTag::POINTER,
+                    .ret_sub_type = JITTypeTag::VOID,
+                    .params_vector = {child_arrow_array.get(), buffer_idx.get()}});
+
+            buffer_values.append(arroy_buffer);
+          }
+
+          BuildTableReader reader(buffer_values, expr, res_row_id);
+          reader.read();
+        }
+        successor_->consume(context);
+      })
+      ->update([&row_index]() { row_index = row_index + 1l; })
+      ->build();
+}
+}  // namespace cider::exec::nextgen::operators

--- a/src/cider/exec/nextgen/operators/HashJoinNode.h
+++ b/src/cider/exec/nextgen/operators/HashJoinNode.h
@@ -28,28 +28,28 @@ namespace cider::exec::nextgen::operators {
 class HashJoinNode : public OpNode {
  public:
   HashJoinNode(ExprPtrVector&& output_exprs,
-               ExprPtrVector&& build_tables,
-               ExprPtrVector&& join_quals)
+               ExprPtrVector&& join_quals,
+               std::map<ExprPtr, size_t>&& build_table_map)
       : OpNode("HashJoinNode", std::move(output_exprs), JITExprValueType::ROW)
-      , build_tables_(std::move(build_tables))
-      , join_quals_(std::move(join_quals)) {}
+      , join_quals_(std::move(join_quals))
+      , build_table_map_(std::move(build_table_map)) {}
 
   HashJoinNode(const ExprPtrVector& output_exprs,
-               const ExprPtrVector& build_tables,
-               const ExprPtrVector& join_quals)
+               const ExprPtrVector& join_quals,
+               std::map<ExprPtr, size_t>& build_table_map)
       : OpNode("HashJoinNode", output_exprs, JITExprValueType::ROW)
-      , build_tables_(build_tables)
-      , join_quals_(join_quals) {}
-
-  ExprPtrVector getBuildTables() { return build_tables_; }
+      , join_quals_(join_quals)
+      , build_table_map_(build_table_map) {}
 
   ExprPtrVector getJoinQuals() { return join_quals_; }
+
+  std::map<ExprPtr, size_t>& getBuildTableMap() { return build_table_map_; }
 
   TranslatorPtr toTranslator(const TranslatorPtr& succ = nullptr) override;
 
  private:
-  ExprPtrVector build_tables_;
   ExprPtrVector join_quals_;
+  std::map<ExprPtr, size_t> build_table_map_;
 };
 
 class HashJoinTranslator : public Translator {

--- a/src/cider/exec/nextgen/operators/HashJoinNode.h
+++ b/src/cider/exec/nextgen/operators/HashJoinNode.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef NEXTGEN_OPERATORS_HASHJOINNODE_H
+#define NEXTGEN_OPERATORS_HASHJOINNODE_H
+
+#include "exec/nextgen/operators/OpNode.h"
+
+namespace cider::exec::nextgen::operators {
+class HashJoinNode : public OpNode {
+ public:
+  HashJoinNode(ExprPtrVector&& output_exprs,
+               ExprPtrVector&& build_tables,
+               ExprPtrVector&& join_quals)
+      : OpNode("HashJoinNode", std::move(output_exprs), JITExprValueType::ROW)
+      , build_tables_(std::move(build_tables))
+      , join_quals_(std::move(join_quals)) {}
+
+  HashJoinNode(const ExprPtrVector& output_exprs,
+               const ExprPtrVector& build_tables,
+               const ExprPtrVector& join_quals)
+      : OpNode("HashJoinNode", output_exprs, JITExprValueType::ROW)
+      , build_tables_(build_tables)
+      , join_quals_(join_quals) {}
+
+  ExprPtrVector getBuildTables() { return build_tables_; }
+
+  ExprPtrVector getJoinQuals() { return join_quals_; }
+
+  TranslatorPtr toTranslator(const TranslatorPtr& succ = nullptr) override;
+
+ private:
+  ExprPtrVector build_tables_;
+  ExprPtrVector join_quals_;
+};
+
+class HashJoinTranslator : public Translator {
+ public:
+  using Translator::Translator;
+
+  void consume(context::CodegenContext& context) override;
+
+ private:
+  void codegen(context::CodegenContext& context);
+};
+
+}  // namespace cider::exec::nextgen::operators
+#endif  // NEXTGEN_OPERATORS_HASHJOINNODE_H

--- a/src/cider/exec/nextgen/operators/OperatorRuntimeFunctions.h
+++ b/src/cider/exec/nextgen/operators/OperatorRuntimeFunctions.h
@@ -80,10 +80,10 @@ extern "C" ALWAYS_INLINE void nextgen_cider_agg_count_nullable(int64_t* agg_val_
 }
 
 // HashJoin functions For Nextgen
-extern "C" NEVER_INLINE int64_t look_up_value_by_key(int8_t* hashtable,
-                                                     int8_t* keys,
-                                                     int8_t* nulls,
-                                                     int8_t* buffer) {
+extern "C" ALWAYS_INLINE int64_t look_up_value_by_key(int8_t* hashtable,
+                                                      int8_t* keys,
+                                                      int8_t* nulls,
+                                                      int8_t* buffer) {
   auto LP_hashtable = reinterpret_cast<cider_hashtable::LinearProbeHashTable<
       int,
       std::pair<cider::exec::nextgen::context::Batch*, int64_t>,
@@ -92,10 +92,10 @@ extern "C" NEVER_INLINE int64_t look_up_value_by_key(int8_t* hashtable,
   auto context_buffer = reinterpret_cast<cider::exec::nextgen::context::Buffer*>(buffer);
   // TODO(qiuyang) : now hashtable only support one key
   // hash join probe
-  auto bit_vector = reinterpret_cast<uint8_t*>(nulls);
-  auto key_offset = reinterpret_cast<int64_t*>(keys);
-  if (!CiderBitUtils::isBitSetAt(bit_vector, 0)) {
-    auto join_res = LP_hashtable->find(*key_offset);
+  auto join_key_is_null = reinterpret_cast<bool*>(nulls);
+  auto join_key_val = reinterpret_cast<int64_t*>(keys);
+  if (!*join_key_is_null) {
+    auto join_res = LP_hashtable->findAll(*join_key_val);
     context_buffer->allocateBuffer(join_res.size() * 16);
     auto join_res_buffer =
         reinterpret_cast<std::pair<cider::exec::nextgen::context::Batch*, int64_t>*>(

--- a/src/cider/exec/nextgen/operators/OperatorRuntimeFunctions.h
+++ b/src/cider/exec/nextgen/operators/OperatorRuntimeFunctions.h
@@ -80,9 +80,10 @@ extern "C" ALWAYS_INLINE void nextgen_cider_agg_count_nullable(int64_t* agg_val_
 }
 
 // HashJoin functions For Nextgen
-extern "C" ALWAYS_INLINE int64_t look_up_value_by_key(int8_t* hashtable,
-                                                      int8_t* keys,
-                                                      int8_t* buffer) {
+extern "C" NEVER_INLINE int64_t look_up_value_by_key(int8_t* hashtable,
+                                                     int8_t* keys,
+                                                     int8_t* nulls,
+                                                     int8_t* buffer) {
   auto LP_hashtable = reinterpret_cast<cider_hashtable::LinearProbeHashTable<
       int,
       std::pair<cider::exec::nextgen::context::Batch*, int64_t>,
@@ -91,15 +92,22 @@ extern "C" ALWAYS_INLINE int64_t look_up_value_by_key(int8_t* hashtable,
   auto context_buffer = reinterpret_cast<cider::exec::nextgen::context::Buffer*>(buffer);
   // TODO(qiuyang) : now hashtable only support one key
   // hash join probe
-  auto join_res = LP_hashtable->find(*keys);
-  context_buffer->allocateBuffer(join_res.size() * 16);
-  auto join_res_buffer =
-      reinterpret_cast<std::pair<cider::exec::nextgen::context::Batch*, int64_t>*>(
-          context_buffer->getBuffer());
-  for (int i = 0; i < join_res.size(); ++i) {
-    join_res_buffer[i] = join_res[i];
+  auto bit_vector = reinterpret_cast<uint8_t*>(nulls);
+  auto key_offset = reinterpret_cast<int64_t*>(keys);
+  if (!CiderBitUtils::isBitSetAt(bit_vector, 0)) {
+    auto join_res = LP_hashtable->find(*key_offset);
+    context_buffer->allocateBuffer(join_res.size() * 16);
+    auto join_res_buffer =
+        reinterpret_cast<std::pair<cider::exec::nextgen::context::Batch*, int64_t>*>(
+            context_buffer->getBuffer());
+    for (int i = 0; i < join_res.size(); ++i) {
+      join_res_buffer[i] = join_res[i];
+    }
+    return join_res.size();
+    // if key is null, no result
+  } else {
+    return 0;
   }
-  return join_res.size();
 }
 
 extern "C" ALWAYS_INLINE int8_t* extract_join_res_array(int8_t* buffer, int64_t index) {

--- a/src/cider/exec/nextgen/operators/OperatorRuntimeFunctions.h
+++ b/src/cider/exec/nextgen/operators/OperatorRuntimeFunctions.h
@@ -79,4 +79,43 @@ extern "C" ALWAYS_INLINE void nextgen_cider_agg_count_nullable(int64_t* agg_val_
   }
 }
 
+// HashJoin functions For Nextgen
+extern "C" ALWAYS_INLINE int64_t look_up_value_by_key(int8_t* hashtable,
+                                                      int8_t* keys,
+                                                      int8_t* buffer) {
+  auto LP_hashtable = reinterpret_cast<cider_hashtable::LinearProbeHashTable<
+      int,
+      std::pair<cider::exec::nextgen::context::Batch*, int64_t>,
+      cider::exec::nextgen::context::murmurHash,
+      cider::exec::nextgen::context::Equal>*>(hashtable);
+  auto context_buffer = reinterpret_cast<cider::exec::nextgen::context::Buffer*>(buffer);
+  // TODO(qiuyang) : now hashtable only support one key
+  // hash join probe
+  auto join_res = LP_hashtable->find(*keys);
+  context_buffer->allocateBuffer(join_res.size() * 16);
+  auto join_res_buffer =
+      reinterpret_cast<std::pair<cider::exec::nextgen::context::Batch*, int64_t>*>(
+          context_buffer->getBuffer());
+  for (int i = 0; i < join_res.size(); ++i) {
+    join_res_buffer[i] = join_res[i];
+  }
+  return join_res.size();
+}
+
+extern "C" ALWAYS_INLINE int8_t* extract_join_res_array(int8_t* buffer, int64_t index) {
+  auto join_res_buffer = reinterpret_cast<cider::exec::nextgen::context::Buffer*>(buffer);
+  auto pair =
+      reinterpret_cast<std::pair<cider::exec::nextgen::context::Batch*, int64_t>*>(
+          join_res_buffer->getBuffer());
+  return reinterpret_cast<int8_t*>(pair[index].first->getArray());
+}
+
+extern "C" ALWAYS_INLINE int64_t extract_join_row_id(int8_t* buffer, int64_t index) {
+  auto join_res_buffer = reinterpret_cast<cider::exec::nextgen::context::Buffer*>(buffer);
+  auto pair =
+      reinterpret_cast<std::pair<cider::exec::nextgen::context::Batch*, int64_t>*>(
+          join_res_buffer->getBuffer());
+  return pair[index].second;
+}
+
 #endif  // NEXTEGN_CIDER_FUNCTION_RUNTIME_FUNCTIONS_H

--- a/src/cider/exec/nextgen/parsers/Parser.h
+++ b/src/cider/exec/nextgen/parsers/Parser.h
@@ -29,7 +29,7 @@ namespace cider::exec::nextgen::parsers {
 
 /// \brief A parser convert from the plan fragment to an OpPipeline
 // source--> filter -->sink
-operators::OpPipeline toOpPipeline(const RelAlgExecutionUnit& eu);
+operators::OpPipeline toOpPipeline(RelAlgExecutionUnit& eu);
 
 }  // namespace cider::exec::nextgen::parsers
 

--- a/src/cider/exec/nextgen/parsers/RelAlgEUParser.cpp
+++ b/src/cider/exec/nextgen/parsers/RelAlgEUParser.cpp
@@ -24,6 +24,7 @@
 #include "exec/nextgen/operators/AggregationNode.h"
 #include "exec/nextgen/operators/ArrowSourceNode.h"
 #include "exec/nextgen/operators/FilterNode.h"
+#include "exec/nextgen/operators/HashJoinNode.h"
 #include "exec/nextgen/operators/ProjectNode.h"
 #include "util/Logger.h"
 
@@ -32,10 +33,6 @@ namespace cider::exec::nextgen::parsers {
 using namespace cider::exec::nextgen::operators;
 
 static bool isParseable(const RelAlgExecutionUnit& eu) {
-  if (!eu.join_quals.empty()) {
-    LOG(ERROR) << "JOIN is not supported in RelAlgExecutionUnitParser.";
-    return false;
-  }
   if (eu.groupby_exprs.size() > 1 || *eu.groupby_exprs.begin() != nullptr) {
     LOG(ERROR) << "GroupBy is not supported in RelAlgExecutionUnitParser.";
     return false;
@@ -47,24 +44,39 @@ static bool isParseable(const RelAlgExecutionUnit& eu) {
 // Used for input columnVar collection and combination
 class InputAnalyzer {
  public:
-  InputAnalyzer(const std::vector<InputColDescriptor>& input_desc, OpPipeline& pipeline)
-      : input_desc_(input_desc)
-      , pipeline_(pipeline)
-      , input_exprs_(input_desc.size(), nullptr) {}
+  explicit InputAnalyzer(RelAlgExecutionUnit& eu)
+      : eu_(eu), input_exprs_(eu.input_col_descs.size(), nullptr) {}
 
   void run() {
-    if (pipeline_.empty()) {
-      return;
+    size_t index = 0;
+    for (auto iter = eu_.input_col_descs.begin(); iter != eu_.input_col_descs.end();
+         ++iter) {
+      input_desc_to_index_.insert({**iter, index++});
     }
 
-    for (size_t i = 0; i < input_desc_.size(); ++i) {
-      input_desc_to_index_.insert({input_desc_[i], i});
-    }
-
-    for (auto& op : pipeline_) {
-      auto&& [type, exprs] = op->getOutputExprs();
-      for (auto& expr : exprs) {
+    if (!eu_.simple_quals.empty()) {
+      for (auto& expr : eu_.simple_quals) {
         traverse(&expr);
+      }
+    }
+
+    if (!eu_.quals.empty()) {
+      for (auto& expr : eu_.quals) {
+        traverse(&expr);
+      }
+    }
+
+    if (!eu_.shared_target_exprs.empty()) {
+      for (auto& expr : eu_.shared_target_exprs) {
+        traverse(&expr);
+      }
+    }
+
+    if (!eu_.join_quals.empty()) {
+      for (auto& join_condition : eu_.join_quals) {
+        for (auto join_expr : join_condition.quals) {
+          traverse(&join_expr);
+        }
       }
     }
 
@@ -74,8 +86,23 @@ class InputAnalyzer {
                        [](const ExprPtr& input_expr) { return input_expr == nullptr; }),
         input_exprs_.end());
 
-    pipeline_.insert(pipeline_.begin(), createOpNode<ArrowSourceNode>(input_exprs_));
+    for (auto expr : input_exprs_) {
+      if (expr != nullptr) {
+        auto col_var = dynamic_cast<Analyzer::ColumnVar*>(expr.get());
+        if (col_var->get_table_id() == 100) {
+          left_exprs_.push_back(expr);
+        } else {
+          right_exprs_.push_back(expr);
+        }
+      }
+    }
   }
+
+  ExprPtrVector& getInputExprs() { return input_exprs_; }
+
+  ExprPtrVector& getLeftExprs() { return left_exprs_; }
+
+  ExprPtrVector& getRightExprs() { return right_exprs_; }
 
  private:
   void traverse(ExprPtr* curr) {
@@ -103,32 +130,37 @@ class InputAnalyzer {
     }
   }
 
-  const std::vector<InputColDescriptor>& input_desc_;
-  OpPipeline& pipeline_;
+  RelAlgExecutionUnit& eu_;
   ExprPtrVector input_exprs_;
+  ExprPtrVector left_exprs_;
+  ExprPtrVector right_exprs_;
   std::unordered_map<InputColDescriptor, size_t> input_desc_to_index_;
 };
 
-static void insertSourceNode(const RelAlgExecutionUnit& eu, OpPipeline& pipeline) {
-  std::vector<InputColDescriptor> input_desc;
-  input_desc.reserve(eu.input_col_descs.size());
-  for (auto& desc : eu.input_col_descs) {
-    input_desc.push_back(*desc);
-  }
-
-  InputAnalyzer analyzer(input_desc, pipeline);
-  analyzer.run();
-}
-
-OpPipeline toOpPipeline(const RelAlgExecutionUnit& eu) {
+OpPipeline toOpPipeline(RelAlgExecutionUnit& eu) {
   // TODO (bigPYJ1151): Only support filter and project now.
   // TODO (bigPYJ1151): Only naive expression dispatch now, need to analyze expression
   // trees and dispatch more fine-grained.
   if (!isParseable(eu)) {
     return {};
   }
-
   OpPipeline ops;
+
+  InputAnalyzer analyzer(eu);
+  analyzer.run();
+
+  ops.insert(ops.begin(), createOpNode<ArrowSourceNode>(analyzer.getLeftExprs()));
+
+  ExprPtrVector join_quals;
+  for (auto& join_condition : eu.join_quals) {
+    for (auto& join_expr : join_condition.quals) {
+      join_quals.push_back(join_expr);
+    }
+  }
+  if (join_quals.size() > 0) {
+    ops.emplace_back(createOpNode<HashJoinNode>(
+        analyzer.getLeftExprs(), analyzer.getRightExprs(), join_quals));
+  }
 
   ExprPtrVector filters;
   for (auto& filter_expr : eu.simple_quals) {
@@ -166,7 +198,6 @@ OpPipeline toOpPipeline(const RelAlgExecutionUnit& eu) {
     ops.emplace_back(createOpNode<operators::AggNode>(groupbys, aggs));
   }
 
-  insertSourceNode(eu, ops);
 
   return ops;
 }

--- a/src/cider/function/CMakeLists.txt
+++ b/src/cider/function/CMakeLists.txt
@@ -40,8 +40,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 if(ENABLE_JIT_DEBUG)
   set(RT_OPT_FLAGS -O0 -g)
 else()
-  # TODO(qiuyang) : for test, return to -03 after hashtable refactoring
-  set(RT_OPT_FLAGS -O1)
+  set(RT_OPT_FLAGS -O3)
 endif()
 
 if(NOT PREFER_STATIC_LIBS)

--- a/src/cider/function/CMakeLists.txt
+++ b/src/cider/function/CMakeLists.txt
@@ -40,7 +40,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 if(ENABLE_JIT_DEBUG)
   set(RT_OPT_FLAGS -O0 -g)
 else()
-  set(RT_OPT_FLAGS -O3)
+  # TODO(qiuyang) : for test, return to -03 after hashtable refactoring
+  set(RT_OPT_FLAGS -O1)
 endif()
 
 if(NOT PREFER_STATIC_LIBS)

--- a/src/cider/tests/nextgen/compiler/CMakeLists.txt
+++ b/src/cider/tests/nextgen/compiler/CMakeLists.txt
@@ -38,3 +38,8 @@ add_test(AggTest ${EXECUTABLE_OUTPUT_PATH}/AggTest ${TEST_ARGS})
 add_executable(ContextTest ContextTest.cpp)
 target_link_libraries(ContextTest ${NEXTGEN_COMPILER_TEST_LIBS})
 add_test(ContextTest ${EXECUTABLE_OUTPUT_PATH}/ContextTest ${TEST_ARGS})
+
+add_executable(HashJoinTest HashJoinTest.cpp)
+target_link_libraries(HashJoinTest ${NEXTGEN_COMPILER_TEST_LIBS} ${DEP_LIBS}
+                      ${FOLLY_LIBRARIES})
+add_test(HashJoinTest ${EXECUTABLE_OUTPUT_PATH}/HashJoinTest ${TEST_ARGS})

--- a/src/cider/tests/nextgen/compiler/HashJoinTest.cpp
+++ b/src/cider/tests/nextgen/compiler/HashJoinTest.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <google/protobuf/util/json_util.h>
+#include <gtest/gtest.h>
+
+#include "exec/nextgen/Nextgen.h"
+#include "exec/nextgen/context/Batch.h"
+#include "exec/plan/parser/SubstraitToRelAlgExecutionUnit.h"
+#include "exec/plan/parser/TypeUtils.h"
+#include "tests/TestHelpers.h"
+#include "tests/utils/ArrowArrayBuilder.h"
+#include "tests/utils/Utils.h"
+
+using namespace cider::exec::nextgen;
+
+static const std::shared_ptr<CiderAllocator> allocator =
+    std::make_shared<CiderDefaultAllocator>();
+
+template <typename T>
+void check_arrow_array(ArrowArray* array, const std::vector<T>& expected_res) {
+  EXPECT_EQ(array->length, expected_res.size());
+  T* data_buffer = (T*)array->buffers[1];
+  for (size_t i = 0; i < expected_res.size(); ++i) {
+    EXPECT_EQ(data_buffer[i], expected_res[i]);
+  }
+}
+
+class HashJoinTest : public ::testing::Test {
+ public:
+  void executeTest(const std::string& sql) {
+    // SQL Parsing
+    auto json = RunIsthmus::processSql(sql, create_ddl_ + " " + build_ddl_);
+    ::substrait::Plan plan;
+    google::protobuf::util::JsonStringToMessage(json, &plan);
+
+    generator::SubstraitToRelAlgExecutionUnit substrait2eu(plan);
+    auto eu = substrait2eu.createRelAlgExecutionUnit();
+
+    // Pipeline Building
+    auto pipeline = parsers::toOpPipeline(eu);
+    transformer::Transformer transformer;
+    auto translators = transformer.toTranslator(pipeline);
+
+    // Codegen
+    context::CodegenContext codegen_ctx;
+    cider::jitlib::CompilationOptions co;
+    co.dump_ir = true;
+    auto module = cider::jitlib::LLVMJITModule("test", true, co);
+    cider::jitlib::JITFunctionPointer function =
+        cider::jitlib::JITFunctionBuilder()
+            .registerModule(module)
+            .setFuncName("query_func")
+            .addReturn(cider::jitlib::JITTypeTag::VOID)
+            .addParameter(cider::jitlib::JITTypeTag::POINTER,
+                          "context",
+                          cider::jitlib::JITTypeTag::INT8)
+            .addParameter(cider::jitlib::JITTypeTag::POINTER,
+                          "input",
+                          cider::jitlib::JITTypeTag::INT8)
+            .addProcedureBuilder(
+                [&codegen_ctx, &translators](cider::jitlib::JITFunctionPointer func) {
+                  codegen_ctx.setJITFunction(func);
+                  translators->consume(codegen_ctx);
+                  func->createReturn();
+                })
+            .build();
+    module.finish();
+    auto query_func = function->getFunctionPointer<void, int8_t*, int8_t*>();
+
+    // Execution
+    auto input_builder = ArrowArrayBuilder();
+    auto&& [schema, array] =
+        input_builder.setRowNum(4)
+            .addColumn<int8_t>("l_a", CREATE_SUBSTRAIT_TYPE(I8), {3, 4, 5, 6})
+            .addColumn<int32_t>("l_b", CREATE_SUBSTRAIT_TYPE(I32), {1, 2, 3, 4})
+            .addColumn<int64_t>("l_c", CREATE_SUBSTRAIT_TYPE(I64), {555, 666, 777, 888})
+            .build();
+    auto build_table = ArrowArrayBuilder();
+    auto&& [build_schema, build_array] =
+        build_table.setRowNum(4)
+            .addColumn<int8_t>("r_a", CREATE_SUBSTRAIT_TYPE(I8), {6, 7, 8, 9})
+            .addColumn<int32_t>("r_b", CREATE_SUBSTRAIT_TYPE(I32), {1, 2, 3, 4})
+            .addColumn<int64_t>("r_c", CREATE_SUBSTRAIT_TYPE(I64), {666, 777, 888, 999})
+            .build();
+
+    context::Batch build_batch(*build_schema, *build_array);
+    auto batch = new context::Batch(build_batch);
+
+    cider_hashtable::LinearProbeHashTable<int,
+                                          std::pair<context::Batch*, int64_t>,
+                                          context::murmurHash,
+                                          context::Equal>
+        hm(16, 0);
+    auto join_key = batch->getArray()->children[1];
+    for (int64_t i = 0; i < join_key->length; i++) {
+      int key =
+          *((reinterpret_cast<int32_t*>(const_cast<void*>(join_key->buffers[1]))) + i);
+      hm.insert(key, std::make_pair(batch, i));
+    }
+
+    // TODO(Xinyi) : sethashtable in velox hashjoinbuild
+    codegen_ctx.setHashTable(hm);
+    auto runtime_ctx = codegen_ctx.generateRuntimeCTX(allocator);
+
+    query_func((int8_t*)runtime_ctx.get(), (int8_t*)array);
+
+    // check
+    CHECK(batch->getArray());
+    auto expected_row_len = batch->getArray()->children[0]->length;
+    auto output_batch_array = runtime_ctx->getOutputBatch()->getArray();
+
+    EXPECT_EQ(output_batch_array->length, expected_row_len);
+    check_arrow_array<int8_t>(output_batch_array->children[0], {3, 4, 5, 6});
+    check_arrow_array<int32_t>(output_batch_array->children[1], {1, 2, 3, 4});
+    check_arrow_array<int64_t>(output_batch_array->children[2], {555, 666, 777, 888});
+    check_arrow_array<int8_t>(output_batch_array->children[3], {6, 7, 8, 9});
+    check_arrow_array<int32_t>(output_batch_array->children[4], {1, 2, 3, 4});
+    check_arrow_array<int64_t>(output_batch_array->children[5], {666, 777, 888, 999});
+
+    delete batch;
+  }
+
+ private:
+  std::string create_ddl_ =
+      "CREATE TABLE table_probe(l_a TINYINT NOT NULL, l_b INTEGER NOT NULL, l_c BIGINT "
+      "NOT NULL);";
+  std::string build_ddl_ =
+      "CREATE TABLE table_build(r_a TINYINT NOT NULL, r_b INTEGER NOT NULL, r_c BIGINT "
+      "NOT NULL);";
+};
+
+TEST_F(HashJoinTest, basicTest) {
+  executeTest(
+      "select * from table_probe join table_build on table_probe.l_b = "
+      "table_build.r_b");
+}
+
+int main(int argc, char** argv) {
+  TestHelpers::init_logger_stderr_only(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  int err = RUN_ALL_TESTS();
+  return err;
+}

--- a/src/cider/tests/nextgen/compiler/HashJoinTest.cpp
+++ b/src/cider/tests/nextgen/compiler/HashJoinTest.cpp
@@ -243,7 +243,6 @@ TEST_F(HashJoinTest, basicINT64Test) {
 }
 
 int main(int argc, char** argv) {
-  TestHelpers::init_logger_stderr_only(argc, argv);
   testing::InitGoogleTest(&argc, argv);
   int err = RUN_ALL_TESTS();
   return err;

--- a/src/cider/type/plan/BinaryExpr.cpp
+++ b/src/cider/type/plan/BinaryExpr.cpp
@@ -167,8 +167,8 @@ JITExprValue& BinOper::codegenFixedSizeLogicalFun(JITFunction& func,
             return condition;
           })
           ->ifTrue([&]() {
-            null = func.createConstant(JITTypeTag::BOOL, false);
-            value = func.createConstant(JITTypeTag::BOOL, false);
+            null = func.createLiteral(JITTypeTag::BOOL, false);
+            value = func.createLiteral(JITTypeTag::BOOL, false);
           })
           ->ifFalse([&]() { value = lhs_val.getValue() && rhs_val.getValue(); })
           ->build();
@@ -191,8 +191,8 @@ JITExprValue& BinOper::codegenFixedSizeLogicalFun(JITFunction& func,
             return condition;
           })
           ->ifTrue([&]() {
-            null = func.createConstant(JITTypeTag::BOOL, false);
-            value = func.createConstant(JITTypeTag::BOOL, true);
+            null = func.createLiteral(JITTypeTag::BOOL, false);
+            value = func.createLiteral(JITTypeTag::BOOL, true);
           })
           ->ifFalse([&]() { value = lhs_val.getValue() || rhs_val.getValue(); })
           ->build();
@@ -218,10 +218,10 @@ JITExprValue& BinOper::codegenFixedSizeDistinctFrom(JITFunction& func,
           (lhs_val.getNull() != rhs_val.getNull());
   switch (get_optype()) {
     case kBW_NE: {
-      return set_expr_value(func.createConstant(JITTypeTag::BOOL, false), value);
+      return set_expr_value(func.createLiteral(JITTypeTag::BOOL, false), value);
     }
     case kBW_EQ: {
-      return set_expr_value(func.createConstant(JITTypeTag::BOOL, false), !value);
+      return set_expr_value(func.createLiteral(JITTypeTag::BOOL, false), !value);
     }
     default:
       UNREACHABLE();


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add HashJoinNode and Translator (inner hashjoin) and related RuntimeFuncitons, modify the parser to create HashJoinNode and add it to transform pipeline
- Add HashJoinTest, Construct a basic hash join sql to run the workflow to prove correctness
- Add null vector handling
- Refactor EU parser
- Change the createConstant using to createLiteral in some places
- Remove folly dependency
- Rebase hashtable  .h and .cpp file separation #304 

### Why are the changes needed?
For HashJoin codegen in Next Gen FW design

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UTs

### Which label does this PR belong to?
INFRA