### PR TITLE
[POAE7-2809]try to optimize expression performance

### DIFF
--- a/cpp/src/cider-velox/benchmark/expression/ArithmeticAndComparison.cpp
+++ b/cpp/src/cider-velox/benchmark/expression/ArithmeticAndComparison.cpp
@@ -302,15 +302,11 @@ void mulI8Specialized1(uint8_t* null_input,
     output[i] = input[i] * input[i];
   }
 
-  // null process
-  auto num = n / 8;
+  // null process, ignore extra bit in last uint8
+  auto num = n / 8 + 1;
   for (int i = 0; i < num; ++i) {
     // 8bit packed
     null_output[i] = null_input[i];
-  }
-  int i = num * 8;
-  while (i++ < n) {
-    setBitAt(null_output, i, isBitSet(null_input, i));
   }
 }
 
@@ -390,6 +386,7 @@ BENCHMARK_RELATIVE(specifialize2) {
 BENCHMARK_RELATIVE(specifialize3) {
   benchmark->kernelCompute(mulI8Specialized3);
 }
+BENCHMARK_DRAW_LINE()
 
 #define BENCHMARK_GROUP(name, expr)                                                      \
   BENCHMARK(name##Velox_________Base) { benchmark->veloxCompute(expr); }                 \

--- a/cpp/src/cider/exec/module/CiderOptions.cpp
+++ b/cpp/src/cider/exec/module/CiderOptions.cpp
@@ -57,3 +57,4 @@ DEFINE_bool(codegen_all_opt, false, "codegen all optimization");
 DEFINE_bool(check_bit_vector_clear_opt, false, "use optimized bit clear checker");
 DEFINE_bool(set_null_bit_vector_opt, false, "use optimized set null bit");
 DEFINE_bool(branchless_logic, false, "use branchless logic operation");
+DEFINE_bool(null_separate, false, "separate null operation");

--- a/cpp/src/cider/exec/module/CiderOptions.cpp
+++ b/cpp/src/cider/exec/module/CiderOptions.cpp
@@ -51,3 +51,9 @@ DEFINE_bool(allow_runtime_query_interrupt, false, "allow runtime query interrupt
 DEFINE_double(running_query_interrupt_freq, 0.5, "running query interrupt freq");
 DEFINE_uint64(pending_query_interrupt_freq, 1000, "pending query interrupt freq");
 DEFINE_bool(force_direct_hash, false, "force direct hash");
+
+// Codegen Options
+DEFINE_bool(codegen_all_opt, false, "codegen all optimization");
+DEFINE_bool(check_bit_vector_clear_opt, false, "use optimized bit clear checker");
+DEFINE_bool(set_null_bit_vector_opt, false, "use optimized set null bit");
+DEFINE_bool(branchless_logic, false, "use branchless logic operation");

--- a/cpp/src/cider/exec/module/CiderOptions.cpp
+++ b/cpp/src/cider/exec/module/CiderOptions.cpp
@@ -34,6 +34,7 @@ DEFINE_bool(use_default_col_range, true, "use default col range");
 DEFINE_bool(use_cider_data_format, false, "use cider data format");
 DEFINE_bool(needs_error_check, false, "needs error check");
 DEFINE_bool(use_nextgen_compiler, false, "use nextgen compiler");
+DEFINE_bool(null_separate, false, "separate null operation");
 
 // Execution Options
 DEFINE_bool(output_columnar_hint, false, "output columnar hint");
@@ -51,10 +52,3 @@ DEFINE_bool(allow_runtime_query_interrupt, false, "allow runtime query interrupt
 DEFINE_double(running_query_interrupt_freq, 0.5, "running query interrupt freq");
 DEFINE_uint64(pending_query_interrupt_freq, 1000, "pending query interrupt freq");
 DEFINE_bool(force_direct_hash, false, "force direct hash");
-
-// Codegen Options
-DEFINE_bool(codegen_all_opt, false, "codegen all optimization");
-DEFINE_bool(check_bit_vector_clear_opt, false, "use optimized bit clear checker");
-DEFINE_bool(set_null_bit_vector_opt, false, "use optimized set null bit");
-DEFINE_bool(branchless_logic, false, "use branchless logic operation");
-DEFINE_bool(null_separate, false, "separate null operation");

--- a/cpp/src/cider/exec/nextgen/Nextgen.cpp
+++ b/cpp/src/cider/exec/nextgen/Nextgen.cpp
@@ -23,6 +23,7 @@
 
 #include <memory>
 
+#include "cider/CiderOptions.h"
 #include "jitlib/base/JITFunction.h"
 
 namespace cider::exec::nextgen {
@@ -41,6 +42,10 @@ std::unique_ptr<context::CodegenContext> compile(
     auto pipeline = parsers::toOpPipeline(ra_exe_unit);
     auto translator = transformer::Transformer::toTranslator(pipeline);
     translator->consume(*codegen_ctx);
+    if (FLAGS_null_separate) {
+      // bypass ArrowSourceNode
+      translator->getSuccessor()->consumeNull(*codegen_ctx);
+    }
     auto ret_val = function->createVariable(cider::jitlib::JITTypeTag::INT32, "ret", 0);
     function->createReturn(*ret_val.get());
   };

--- a/cpp/src/cider/exec/nextgen/context/CodegenContext.h
+++ b/cpp/src/cider/exec/nextgen/context/CodegenContext.h
@@ -85,6 +85,10 @@ using AggExprsInfoVector = std::vector<AggExprsInfo>;
 
 struct CodegenOptions {
   bool needs_error_check = false;
+  bool check_bit_vector_clear_opt = false;
+  bool set_null_bit_vector_opt = false;
+  bool branchless_logic = false;
+
   jitlib::CompilationOptions co = jitlib::CompilationOptions{};
 };
 

--- a/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITEngine.cpp
+++ b/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITEngine.cpp
@@ -18,10 +18,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "exec/nextgen/jitlib/llvmjit/LLVMJITEngine.h"
 
 #include <llvm/Analysis/TargetTransformInfo.h>
+#include <llvm/ExecutionEngine/JITEventListener.h>
 
+#include "exec/nextgen/jitlib/llvmjit/LLVMJITEngine.h"
 #include "exec/nextgen/jitlib/llvmjit/LLVMJITModule.h"
 
 namespace cider::jitlib {
@@ -65,6 +66,11 @@ std::unique_ptr<LLVMJITEngine> LLVMJITEngineBuilder::build() {
   engine->engine = eb.create(tm_.release());
   engine->engine->DisableLazyCompilation(false);
   engine->engine->setVerifyModules(false);
+
+  engine->engine->RegisterJITEventListener(
+      llvm::JITEventListener::createPerfJITEventListener());
+  engine->engine->RegisterJITEventListener(
+      llvm::JITEventListener::createIntelJITEventListener());
 
   LOG(INFO) << "Enabled features: "
             << engine->engine->getTargetMachine()->getTargetFeatureString().str();

--- a/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
+++ b/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
@@ -31,6 +31,7 @@
 namespace cider::jitlib {
 JITValue& LLVMJITValue::assign(JITValue& value) {
   if (!is_variable_) {
+    // return *this;
     LOG(FATAL) << "JITValue " << getValueName()
                << "is not a variable in LLVMJITValue::assign.";
   }

--- a/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
+++ b/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
@@ -31,7 +31,6 @@
 namespace cider::jitlib {
 JITValue& LLVMJITValue::assign(JITValue& value) {
   if (!is_variable_) {
-    // return *this;
     LOG(FATAL) << "JITValue " << getValueName()
                << "is not a variable in LLVMJITValue::assign.";
   }
@@ -70,6 +69,9 @@ JITValuePointer LLVMJITValue::orOp(JITValue& rh) {
       ans = getFunctionBuilder(parent_function_).CreateOr(load(), llvm_rh.load());
       break;
     }
+    case JITTypeTag::INT8:
+      ans = getFunctionBuilder(parent_function_).CreateOr(load(), llvm_rh.load());
+      break;
     default:
       LOG(FATAL) << "Invalid JITValue type for or operation. Name=" << getValueName()
                  << ", Type=" << getJITTypeName(getValueTypeTag()) << ".";

--- a/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
@@ -71,15 +71,6 @@ class ColumnReader {
       if (expr_->get_type_info().get_notnull()) {
         expr_->set_expr_null(func.createLiteral(JITTypeTag::BOOL, false));
       } else {
-        // std::string fname = "check_bit_vector_clear";
-        // if (context_.getCodegenOptions().check_bit_vector_clear_opt) {
-        //   fname = "check_bit_vector_clear_opt";
-        // }
-        // auto row_null_data = func.emitRuntimeFunctionCall(
-        //     fname,
-        //     JITFunctionEmitDescriptor{
-        //         .ret_type = JITTypeTag::BOOL,
-        //         .params_vector = {{varsize_values.getNull().get(), index_.get()}}});
         auto row_null_data = varsize_values.getNull()[index_];
         expr_->set_expr_null(row_null_data);
       }
@@ -123,18 +114,6 @@ class ColumnReader {
       if (expr_->get_type_info().get_notnull()) {
         expr_->set_expr_null(func.createLiteral(JITTypeTag::BOOL, false));
       } else {
-        // null buffer decoder
-        // TBD: Null representation, bit-array or bool-array.
-        // std::string fname = "check_bit_vector_clear";
-        // if (context_.getCodegenOptions().check_bit_vector_clear_opt) {
-        //   fname = "check_bit_vector_clear_opt";
-        // }
-        // auto row_null_data = func.emitRuntimeFunctionCall(
-        //     fname,
-        //     JITFunctionEmitDescriptor{
-        //         .ret_type = JITTypeTag::BOOL,
-        //         .params_vector = {{fixsize_values.getNull().get(), index_.get()}}});
-
         auto row_null_data = fixsize_values.getNull()[index_];
         expr_->set_expr_value(row_null_data);
       }

--- a/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
@@ -79,8 +79,12 @@ class ColumnReader {
     } else {
       // null buffer decoder
       // TBD: Null representation, bit-array or bool-array.
+      std::string fname = "check_bit_vector_clear";
+      if (context_.getCodegenOptions().check_bit_vector_clear_opt) {
+        fname = "check_bit_vector_clear_opt";
+      }
       auto row_null_data = func.emitRuntimeFunctionCall(
-          "check_bit_vector_clear",
+          fname,
           JITFunctionEmitDescriptor{
               .ret_type = JITTypeTag::BOOL,
               .params_vector = {{varsize_values.getNull().get(), index_.get()}}});
@@ -99,8 +103,12 @@ class ColumnReader {
     } else {
       // null buffer decoder
       // TBD: Null representation, bit-array or bool-array.
+      std::string fname = "check_bit_vector_clear";
+      if (context_.getCodegenOptions().check_bit_vector_clear_opt) {
+        fname = "check_bit_vector_clear_opt";
+      }
       auto row_null_data = func.emitRuntimeFunctionCall(
-          "check_bit_vector_clear",
+          fname,
           JITFunctionEmitDescriptor{
               .ret_type = JITTypeTag::BOOL,
               .params_vector = {{fixsize_values.getNull().get(), index_.get()}}});

--- a/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
@@ -21,6 +21,7 @@
 
 #include "exec/nextgen/operators/ColumnToRowNode.h"
 
+#include "cider/CiderOptions.h"
 #include "exec/nextgen/context/CodegenContext.h"
 #include "exec/nextgen/operators/OpNode.h"
 #include "exec/nextgen/utils/TypeUtils.h"
@@ -74,7 +75,7 @@ class ColumnReader {
     auto value_pointer = varsize_values.getValue()->castPointerSubType(JITTypeTag::INT8);
     auto row_data = value_pointer + cur_offset;  // still char*
 
-    if (expr_->get_type_info().get_notnull()) {
+    if (FLAGS_null_separate || expr_->get_type_info().get_notnull()) {
       expr_->set_expr_value(func.createLiteral(JITTypeTag::BOOL, false), len, row_data);
     } else {
       // null buffer decoder
@@ -98,7 +99,7 @@ class ColumnReader {
 
     auto& func = batch->getParentJITFunction();
     auto row_data = getFixSizeRowData(func, fixsize_values);
-    if (expr_->get_type_info().get_notnull()) {
+    if (FLAGS_null_separate || expr_->get_type_info().get_notnull()) {
       expr_->set_expr_value(func.createLiteral(JITTypeTag::BOOL, false), row_data);
     } else {
       // null buffer decoder

--- a/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.h
+++ b/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.h
@@ -61,9 +61,10 @@ class ColumnToRowTranslator : public Translator {
   using Translator::Translator;
 
   void consume(context::CodegenContext& context) override;
+  void consumeNull(context::CodegenContext& context) override;
 
  private:
-  void codegen(context::CodegenContext& context);
+  void codegen(context::CodegenContext& context, bool for_null = false);
 };
 
 }  // namespace cider::exec::nextgen::operators

--- a/cpp/src/cider/exec/nextgen/operators/OpNode.h
+++ b/cpp/src/cider/exec/nextgen/operators/OpNode.h
@@ -24,6 +24,7 @@
 
 #include "exec/nextgen/context/CodegenContext.h"
 #include "type/plan/Analyzer.h"
+#include "util/Logger.h"
 
 namespace cider::exec::nextgen::operators {
 using utils::JITExprValueType;
@@ -81,6 +82,7 @@ class Translator {
   virtual ~Translator() = default;
 
   virtual void consume(context::CodegenContext& context) = 0;
+  virtual void consumeNull(context::CodegenContext& context) { UNIMPLEMENTED(); }
 
   OpNodePtr getOpNode() { return node_; }
 

--- a/cpp/src/cider/exec/nextgen/operators/ProjectNode.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/ProjectNode.cpp
@@ -30,12 +30,24 @@ void ProjectTranslator::consume(context::CodegenContext& context) {
   codegen(context);
 }
 
+void ProjectTranslator::consumeNull(context::CodegenContext& context) {
+  codegenNull(context);
+}
+
 void ProjectTranslator::codegen(context::CodegenContext& context) {
   auto&& [output_type, exprs] = node_->getOutputExprs();
   for (auto& expr : exprs) {
     expr->codegen(context);
   }
   successor_->consume(context);
+}
+
+void ProjectTranslator::codegenNull(context::CodegenContext& context) {
+  auto&& [output_type, exprs] = node_->getOutputExprs();
+  for (auto& expr : exprs) {
+    expr->codegenNull(context);
+  }
+  successor_->consumeNull(context);
 }
 
 }  // namespace cider::exec::nextgen::operators

--- a/cpp/src/cider/exec/nextgen/operators/ProjectNode.h
+++ b/cpp/src/cider/exec/nextgen/operators/ProjectNode.h
@@ -41,9 +41,11 @@ class ProjectTranslator : public Translator {
   using Translator::Translator;
 
   void consume(context::CodegenContext& context) override;
+  void consumeNull(context::CodegenContext& context) override;
 
  private:
   void codegen(context::CodegenContext& context);
+  void codegenNull(context::CodegenContext& context);
 };
 }  // namespace cider::exec::nextgen::operators
 #endif  // NEXTGEN_OPERATORS_PROJECTNODE_H

--- a/cpp/src/cider/exec/nextgen/operators/RowToColumnNode.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/RowToColumnNode.cpp
@@ -150,9 +150,6 @@ class ColumnWriter {
 
   JITValuePointer setFixSizeRawData(utils::FixSizeJITExprValue& fixsize_val) {
     if (expr_->get_type_info().get_type() == kBOOLEAN) {
-      // auto tmp_8bit_acc =
-      //     context_.getJITFunction()->createVariable(JITTypeTag::INT8, "tmp_8bit_acc",
-      //     0);
       auto raw_data_buffer = context_.getJITFunction()->createLocalJITValue(
           [this]() { return allocateBitwiseBuffer(1); });
       // leverage existing set_null_vector but need opposite value as input
@@ -168,13 +165,6 @@ class ColumnWriter {
               .params_vector = {{raw_data_buffer.get(),
                                  index_.get(),
                                  (!fixsize_val.getValue()).get()}}});
-      // tmp_8bit_acc = context_.getJITFunction()->emitRuntimeFunctionCall(
-      //     "set_null_vector_bit",
-      //     JITFunctionEmitDescriptor{.ret_type = JITTypeTag::VOID,
-      //                               .params_vector = {{raw_data_buffer.get(),
-      //                                                  index_.get(),
-      //                                                  (!fixsize_val.getValue()).get(),
-      //                                                  tmp_8bit_acc.get()}}});
       return raw_data_buffer;
     } else {
       auto raw_data_buffer = context_.getJITFunction()->createLocalJITValue([this]() {
@@ -194,9 +184,6 @@ class ColumnWriter {
     // or constant false.
     auto null_buffer = JITValuePointer(nullptr);
     if ((!FLAGS_null_separate || for_null) && !expr_->get_type_info().get_notnull()) {
-      // auto tmp_8bit_acc =
-      //     context_.getJITFunction()->createVariable(JITTypeTag::INT8, "tmp_8bit_acc",
-      //     0);
       // TBD: Null representation, bit-array or bool-array.
       null_buffer.replace(context_.getJITFunction()->createLocalJITValue(
           [this]() { return allocateBitwiseBuffer(0); }));
@@ -214,13 +201,6 @@ class ColumnWriter {
           JITFunctionEmitDescriptor{
               .ret_type = JITTypeTag::VOID,
               .params_vector = {{null_buffer.get(), index_.get(), null_val.get()}}});
-      // tmp_8bit_acc = context_.getJITFunction()->emitRuntimeFunctionCall(
-      //     "set_null_vector_bit",
-      //     JITFunctionEmitDescriptor{.ret_type = JITTypeTag::VOID,
-      //                               .params_vector = {{null_buffer.get(),
-      //                                                  index_.get(),
-      //                                                  null_val.get(),
-      //                                                  tmp_8bit_acc.get()}}});
     }
     return null_buffer;
   }

--- a/cpp/src/cider/exec/nextgen/operators/RowToColumnNode.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/RowToColumnNode.cpp
@@ -43,7 +43,7 @@ class ColumnWriter {
       , index_(index)
       , arrow_array_len_(arrow_array_len) {}
 
-  void write() {
+  void write(bool for_null) {
     // TBD: Whether input ColumnVar's ArrowArray could be overwriten.
     // CHECK(0 == expr_->getLocalIndex());
     switch (expr_->get_type_info().get_type()) {
@@ -57,12 +57,12 @@ class ColumnWriter {
       case kDATE:
       case kTIMESTAMP:
       case kTIME:
-        writeFixSizedTypeCol();
+        writeFixSizedTypeCol(for_null);
         break;
       case kVARCHAR:
       case kCHAR:
       case kTEXT:
-        writeVariableSizeTypeCol();
+        writeVariableSizeTypeCol(for_null);
         break;
       default:
         LOG(FATAL) << "Unsupported data type in ColumnWriter: "
@@ -71,9 +71,17 @@ class ColumnWriter {
   }
 
  private:
-  void writeVariableSizeTypeCol() {
+  void writeVariableSizeTypeCol(bool for_null) {
     // Get values need to write
     utils::VarSizeJITExprValue values(expr_->get_expr_value());
+
+    if (for_null) {
+      auto null = setNullBuffer(values.getNull(), for_null);
+      Analyzer::JITExprValueAdaptor(
+          context_.getArrowArrayValues(expr_->getLocalIndex()).second)
+          .setNull(null);
+      return;
+    }
 
     // Allocate buffer
     // offset, need array_len + 1 element.
@@ -110,15 +118,23 @@ class ColumnWriter {
     size_t local_offset = context_.appendArrowArrayValues(
         arrow_array_,
         utils::JITExprValue(JITExprValueType::BATCH,
-                            setNullBuffer(values.getNull()),
+                            setNullBuffer(values.getNull(), for_null),
                             raw_length_buffer,
                             raw_data_buffer));
     expr_->setLocalIndex(local_offset);
   }
 
-  void writeFixSizedTypeCol() {
+  void writeFixSizedTypeCol(bool for_null) {
     // Get values need to write
     utils::FixSizeJITExprValue values(expr_->get_expr_value());
+
+    if (for_null) {
+      auto null = setNullBuffer(values.getNull(), for_null);
+      Analyzer::JITExprValueAdaptor(
+          context_.getArrowArrayValues(expr_->getLocalIndex()).second)
+          .setNull(null);
+      return;
+    }
 
     // Allocate buffer.
     // Write value
@@ -126,8 +142,9 @@ class ColumnWriter {
     // Register Output ArrowArray to CodegenContext
     size_t local_offset = context_.appendArrowArrayValues(
         arrow_array_,
-        utils::JITExprValue(
-            JITExprValueType::BATCH, setNullBuffer(values.getNull()), raw_data_buffer));
+        utils::JITExprValue(JITExprValueType::BATCH,
+                            setNullBuffer(values.getNull(), for_null),
+                            raw_data_buffer));
     expr_->setLocalIndex(local_offset);
   }
 
@@ -171,18 +188,22 @@ class ColumnWriter {
     }
   }
 
-  JITValuePointer setNullBuffer(JITValuePointer& null_val) {
+  JITValuePointer setNullBuffer(JITValuePointer& null_val, bool for_null) {
     // the null_buffer, raw_data_buffer not used anymore.
     // so it doesn't matter whether null_buffer is nullptr
     // or constant false.
     auto null_buffer = JITValuePointer(nullptr);
-    if (!FLAGS_null_separate && !expr_->get_type_info().get_notnull()) {
+    if ((!FLAGS_null_separate || for_null) && !expr_->get_type_info().get_notnull()) {
       // auto tmp_8bit_acc =
       //     context_.getJITFunction()->createVariable(JITTypeTag::INT8, "tmp_8bit_acc",
       //     0);
       // TBD: Null representation, bit-array or bool-array.
       null_buffer.replace(context_.getJITFunction()->createLocalJITValue(
           [this]() { return allocateBitwiseBuffer(0); }));
+      if (for_null) {
+        *null_buffer[index_] = null_val;
+        return null_buffer;
+      }
 
       std::string fname = "set_null_vector_bit";
       if (context_.getCodegenOptions().set_null_bit_vector_opt) {
@@ -235,25 +256,31 @@ void RowToColumnTranslator::consume(context::CodegenContext& context) {
   codegen(context);
 }
 
-void RowToColumnTranslator::codegen(context::CodegenContext& context) {
+void RowToColumnTranslator::consumeNull(context::CodegenContext& context) {
+  codegen(context, true);
+}
+
+void RowToColumnTranslator::codegen(context::CodegenContext& context, bool for_null) {
   auto func = context.getJITFunction();
   auto&& [type, exprs] = node_->getOutputExprs();
   ExprPtrVector& output_exprs = exprs;
 
   // construct output Batch
-  auto output_arrow_array = context.registerBatch(
-      SQLTypeInfo(kSTRUCT,
-                  false,
-                  [&output_exprs]() {
-                    std::vector<SQLTypeInfo> output_types;
-                    output_types.reserve(output_exprs.size());
-                    for (auto& expr : output_exprs) {
-                      output_types.emplace_back(expr->get_type_info());
-                    }
-                    return output_types;
-                  }()),
-      "output",
-      true);
+  if (!for_null) {
+    output_arrow_array_.replace(context.registerBatch(
+        SQLTypeInfo(kSTRUCT,
+                    false,
+                    [&output_exprs]() {
+                      std::vector<SQLTypeInfo> output_types;
+                      output_types.reserve(output_exprs.size());
+                      for (auto& expr : output_exprs) {
+                        output_types.emplace_back(expr->get_type_info());
+                      }
+                      return output_types;
+                    }()),
+        "output",
+        true));
+  }
 
   auto output_index = func->createVariable(JITTypeTag::INT64, "output_index", 0);
 
@@ -264,21 +291,28 @@ void RowToColumnTranslator::codegen(context::CodegenContext& context) {
   for (int64_t i = 0; i < exprs.size(); ++i) {
     ExprPtr& expr = exprs[i];
 
-    auto child_arrow_array = func->createLocalJITValue([&output_arrow_array, &i]() {
-      return codegen_utils::getArrowArrayChild(output_arrow_array, i);
+    auto child_arrow_array = func->createLocalJITValue([&i, this]() {
+      return codegen_utils::getArrowArrayChild(output_arrow_array_, i);
     });
 
     // Write rows
     ColumnWriter writer(context, expr, child_arrow_array, output_index, input_array_len);
-    writer.write();
+    writer.write(for_null);
   }
   // Update index
   output_index = output_index + 1;
 
+  if (for_null) {
+    if (successor_) {
+      successor_->consumeNull(context);
+    }
+    return;
+  }
+
   // Execute length field updating build function after C2R loop finished.
   prev_c2r_node->registerDeferFunc(
-      [output_index, output_arrow_array, &output_exprs, &context]() mutable {
-        codegen_utils::setArrowArrayLength(output_arrow_array, output_index);
+      [output_index, &output_exprs, &context, this]() mutable {
+        codegen_utils::setArrowArrayLength(output_arrow_array_, output_index);
         for (auto& expr : output_exprs) {
           size_t local_offset = expr->getLocalIndex();
           CHECK_NE(local_offset, 0);
@@ -292,4 +326,5 @@ void RowToColumnTranslator::codegen(context::CodegenContext& context) {
     successor_->consume(context);
   }
 }
+
 }  // namespace cider::exec::nextgen::operators

--- a/cpp/src/cider/exec/nextgen/operators/RowToColumnNode.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/RowToColumnNode.cpp
@@ -21,6 +21,7 @@
 
 #include "exec/nextgen/operators/RowToColumnNode.h"
 
+#include "cider/CiderOptions.h"
 #include "exec/nextgen/context/CodegenContext.h"
 #include "exec/nextgen/jitlib/JITLib.h"
 #include "exec/nextgen/utils/JITExprValue.h"
@@ -175,7 +176,7 @@ class ColumnWriter {
     // so it doesn't matter whether null_buffer is nullptr
     // or constant false.
     auto null_buffer = JITValuePointer(nullptr);
-    if (!expr_->get_type_info().get_notnull()) {
+    if (!FLAGS_null_separate && !expr_->get_type_info().get_notnull()) {
       // auto tmp_8bit_acc =
       //     context_.getJITFunction()->createVariable(JITTypeTag::INT8, "tmp_8bit_acc",
       //     0);

--- a/cpp/src/cider/exec/nextgen/operators/RowToColumnNode.h
+++ b/cpp/src/cider/exec/nextgen/operators/RowToColumnNode.h
@@ -48,9 +48,11 @@ class RowToColumnTranslator : public Translator {
   using Translator::Translator;
 
   void consume(context::CodegenContext& context) override;
+  void consumeNull(context::CodegenContext& context) override;
 
  private:
-  void codegen(context::CodegenContext& context);
+  void codegen(context::CodegenContext& context, bool for_null = false);
+  Analyzer::JITValuePointer output_arrow_array_;
 };
 
 }  // namespace cider::exec::nextgen::operators

--- a/cpp/src/cider/exec/nextgen/transformer/Transformer.cpp
+++ b/cpp/src/cider/exec/nextgen/transformer/Transformer.cpp
@@ -19,7 +19,10 @@
  * under the License.
  */
 #include "exec/nextgen/transformer/Transformer.h"
+#include <iterator>
 
+#include "cider/CiderOptions.h"
+#include "exec/nextgen/operators/OpNode.h"
 #include "exec/nextgen/operators/RowToColumnNode.h"
 
 namespace cider::exec::nextgen::transformer {

--- a/cpp/src/cider/exec/nextgen/transformer/Transformer.cpp
+++ b/cpp/src/cider/exec/nextgen/transformer/Transformer.cpp
@@ -20,7 +20,6 @@
  */
 #include "exec/nextgen/transformer/Transformer.h"
 
-#include "cider/CiderOptions.h"
 #include "exec/nextgen/operators/OpNode.h"
 #include "exec/nextgen/operators/RowToColumnNode.h"
 

--- a/cpp/src/cider/exec/nextgen/transformer/Transformer.cpp
+++ b/cpp/src/cider/exec/nextgen/transformer/Transformer.cpp
@@ -19,7 +19,6 @@
  * under the License.
  */
 #include "exec/nextgen/transformer/Transformer.h"
-#include <iterator>
 
 #include "cider/CiderOptions.h"
 #include "exec/nextgen/operators/OpNode.h"

--- a/cpp/src/cider/exec/nextgen/utils/JITExprValue.h
+++ b/cpp/src/cider/exec/nextgen/utils/JITExprValue.h
@@ -50,9 +50,6 @@ class JITExprValue {
   JITExprValue& append(T&&... values) {
     ptrs_.reserve(sizeof...(values));
     (ptrs_.emplace_back(jitlib::JITValuePointer(values)), ...);
-    // if (FLAGS_null_separate) {
-    //   ptrs_[0] = jitlib::JITValuePointer(nullptr);
-    // }
     return *this;
   }
 

--- a/cpp/src/cider/exec/nextgen/utils/JITExprValue.h
+++ b/cpp/src/cider/exec/nextgen/utils/JITExprValue.h
@@ -21,7 +21,6 @@
 #ifndef NEXTGEN_UTILS_JITEXPRVALUE_H
 #define NEXTGEN_UTILS_JITEXPRVALUE_H
 
-#include "cider/CiderOptions.h"
 #include "exec/nextgen/jitlib/base/JITValue.h"
 
 namespace cider::exec::nextgen::utils {

--- a/cpp/src/cider/exec/nextgen/utils/JITExprValue.h
+++ b/cpp/src/cider/exec/nextgen/utils/JITExprValue.h
@@ -21,6 +21,7 @@
 #ifndef NEXTGEN_UTILS_JITEXPRVALUE_H
 #define NEXTGEN_UTILS_JITEXPRVALUE_H
 
+#include "cider/CiderOptions.h"
 #include "exec/nextgen/jitlib/base/JITValue.h"
 
 namespace cider::exec::nextgen::utils {
@@ -49,6 +50,9 @@ class JITExprValue {
   JITExprValue& append(T&&... values) {
     ptrs_.reserve(sizeof...(values));
     (ptrs_.emplace_back(jitlib::JITValuePointer(values)), ...);
+    // if (FLAGS_null_separate) {
+    //   ptrs_[0] = jitlib::JITValuePointer(nullptr);
+    // }
     return *this;
   }
 

--- a/cpp/src/cider/exec/plan/parser/TypeUtils.h
+++ b/cpp/src/cider/exec/plan/parser/TypeUtils.h
@@ -28,13 +28,13 @@
 
 // Public to make substrait type easier
 #define CREATE_SUBSTRAIT_TYPE_FULL(name, nullable) \
-  TypeUtils::createType(substrait::Type::KindCase::k##name, nullable)
+  TypeUtils::createType(::substrait::Type::KindCase::k##name, nullable)
 
 #define CREATE_SUBSTRAIT_TYPE_FULL_PTR(name, nullable) \
-  TypeUtils::createTypePtr(substrait::Type::KindCase::k##name, nullable)
+  TypeUtils::createTypePtr(::substrait::Type::KindCase::k##name, nullable)
 
 #define CREATE_SUBSTRAIT_TYPE(name) \
-  TypeUtils::createType(substrait::Type::KindCase::k##name)
+  TypeUtils::createType(::substrait::Type::KindCase::k##name)
 
 // Internal use this macro
 #define GENERATE_SUBSTRAIT_TYPE(type_name, type_func, nullalbility) \

--- a/cpp/src/cider/exec/processor/DefaultBatchProcessor.cpp
+++ b/cpp/src/cider/exec/processor/DefaultBatchProcessor.cpp
@@ -75,6 +75,7 @@ DefaultBatchProcessor::DefaultBatchProcessor(
   cgo.check_bit_vector_clear_opt =
       FLAGS_codegen_all_opt | FLAGS_check_bit_vector_clear_opt;
   cgo.set_null_bit_vector_opt = FLAGS_codegen_all_opt | FLAGS_set_null_bit_vector_opt;
+  cgo.branchless_logic = FLAGS_codegen_all_opt | FLAGS_branchless_logic;
   codegen_context_ = nextgen::compile(ra_exe_unit, cgo);
   runtime_context_ = codegen_context_->generateRuntimeCTX(allocator);
   query_func_ = reinterpret_cast<nextgen::QueryFunc>(

--- a/cpp/src/cider/exec/processor/DefaultBatchProcessor.cpp
+++ b/cpp/src/cider/exec/processor/DefaultBatchProcessor.cpp
@@ -69,10 +69,9 @@ DefaultBatchProcessor::DefaultBatchProcessor(
   RelAlgExecutionUnit ra_exe_unit = translator->createRelAlgExecutionUnit();
   nextgen::context::CodegenOptions cgo;
   cgo.co.dump_ir = true;
-  // cgo.co.enable_vectorize = true;
-  // cgo.co.enable_avx2 = true;
-  // cgo.co.enable_avx512 = true;
-
+  cgo.co.enable_vectorize = true;
+  cgo.co.enable_avx2 = true;
+  cgo.co.enable_avx512 = true;
   cgo.check_bit_vector_clear_opt =
       FLAGS_codegen_all_opt | FLAGS_check_bit_vector_clear_opt;
   cgo.set_null_bit_vector_opt = FLAGS_codegen_all_opt | FLAGS_set_null_bit_vector_opt;

--- a/cpp/src/cider/exec/processor/DefaultBatchProcessor.cpp
+++ b/cpp/src/cider/exec/processor/DefaultBatchProcessor.cpp
@@ -22,7 +22,6 @@
 #include <memory>
 
 #include "cider/CiderException.h"
-#include "cider/CiderOptions.h"
 #include "exec/nextgen/context/CodegenContext.h"
 #include "exec/plan/parser/SubstraitToRelAlgExecutionUnit.h"
 #include "exec/processor/DefaultBatchProcessor.h"
@@ -67,16 +66,7 @@ DefaultBatchProcessor::DefaultBatchProcessor(
   auto translator =
       std::make_shared<generator::SubstraitToRelAlgExecutionUnit>(plan_->getPlan());
   RelAlgExecutionUnit ra_exe_unit = translator->createRelAlgExecutionUnit();
-  nextgen::context::CodegenOptions cgo;
-  cgo.co.dump_ir = true;
-  cgo.co.enable_vectorize = true;
-  cgo.co.enable_avx2 = true;
-  cgo.co.enable_avx512 = true;
-  cgo.check_bit_vector_clear_opt =
-      FLAGS_codegen_all_opt | FLAGS_check_bit_vector_clear_opt;
-  cgo.set_null_bit_vector_opt = FLAGS_codegen_all_opt | FLAGS_set_null_bit_vector_opt;
-  cgo.branchless_logic = FLAGS_codegen_all_opt | FLAGS_branchless_logic;
-  codegen_context_ = nextgen::compile(ra_exe_unit, cgo);
+  codegen_context_ = nextgen::compile(ra_exe_unit, codegen_options);
   runtime_context_ = codegen_context_->generateRuntimeCTX(allocator);
   query_func_ = reinterpret_cast<nextgen::QueryFunc>(
       codegen_context_->getJITFunction()->getFunctionPointer<void, int8_t*, int8_t*>());

--- a/cpp/src/cider/exec/processor/DefaultBatchProcessor.h
+++ b/cpp/src/cider/exec/processor/DefaultBatchProcessor.h
@@ -34,7 +34,6 @@ class DefaultBatchProcessor : public BatchProcessor {
   DefaultBatchProcessor(
       const plan::SubstraitPlanPtr& plan,
       const BatchProcessorContextPtr& context,
-
       const cider::exec::nextgen::context::CodegenOptions& codegen_options = {});
 
   virtual ~DefaultBatchProcessor() = default;

--- a/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
+++ b/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
@@ -1450,10 +1450,6 @@ extern "C" ALWAYS_INLINE bool check_bit_vector_clear_opt(uint8_t* bit_vector,
                                                          uint64_t index) {
   return CiderBitUtils::isBitClearAt(bit_vector, index);
 }
-// extern "C" ALWAYS_INLINE uint8_t check_8bit_vector_clear(uint8_t* bit_vector,
-//                                                          uint64_t index) {
-//   return CiderBitUtils::isBitClearAt(bit_vector, index);
-// }
 
 extern "C" ALWAYS_INLINE void set_bit_vector(uint8_t* bit_vector, uint64_t index) {
   CiderBitUtils::setBitAt(bit_vector, index);
@@ -1473,7 +1469,7 @@ extern "C" ALWAYS_INLINE void set_null_vector_bit(uint8_t* bit_vector,
 extern "C" ALWAYS_INLINE void set_null_vector_bit_opt(uint8_t* bit_vector,
                                                       uint64_t index,
                                                       bool is_null) {
-  CiderBitUtils::setBitAt1(bit_vector, index, is_null);
+  CiderBitUtils::setBitAtUnified(bit_vector, index, is_null);
 }
 
 extern "C" ALWAYS_INLINE void do_memcpy(int8_t* dst, int8_t* src, int32_t len) {

--- a/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
+++ b/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
@@ -1450,6 +1450,10 @@ extern "C" ALWAYS_INLINE bool check_bit_vector_clear_opt(uint8_t* bit_vector,
                                                          uint64_t index) {
   return CiderBitUtils::isBitClearAt(bit_vector, index);
 }
+// extern "C" ALWAYS_INLINE uint8_t check_8bit_vector_clear(uint8_t* bit_vector,
+//                                                          uint64_t index) {
+//   return CiderBitUtils::isBitClearAt(bit_vector, index);
+// }
 
 extern "C" ALWAYS_INLINE void set_bit_vector(uint8_t* bit_vector, uint64_t index) {
   CiderBitUtils::setBitAt(bit_vector, index);

--- a/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
+++ b/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
@@ -1446,6 +1446,10 @@ extern "C" ALWAYS_INLINE bool check_bit_vector_clear(uint8_t* bit_vector,
   bool ans = !CiderBitUtils::isBitSetAt(bit_vector, index);
   return ans;
 }
+extern "C" ALWAYS_INLINE bool check_bit_vector_clear_opt(uint8_t* bit_vector,
+                                                         uint64_t index) {
+  return CiderBitUtils::isBitClearAt(bit_vector, index);
+}
 
 extern "C" ALWAYS_INLINE void set_bit_vector(uint8_t* bit_vector, uint64_t index) {
   CiderBitUtils::setBitAt(bit_vector, index);
@@ -1461,6 +1465,11 @@ extern "C" ALWAYS_INLINE void set_null_vector_bit(uint8_t* bit_vector,
                                                   bool is_null) {
   is_null ? CiderBitUtils::clearBitAt(bit_vector, index)
           : CiderBitUtils::setBitAt(bit_vector, index);
+}
+extern "C" ALWAYS_INLINE void set_null_vector_bit_opt(uint8_t* bit_vector,
+                                                      uint64_t index,
+                                                      bool is_null) {
+  CiderBitUtils::setBitAt1(bit_vector, index, is_null);
 }
 
 extern "C" ALWAYS_INLINE void do_memcpy(int8_t* dst, int8_t* src, int32_t len) {

--- a/cpp/src/cider/include/cider/CiderOptions.h
+++ b/cpp/src/cider/include/cider/CiderOptions.h
@@ -39,6 +39,7 @@ DECLARE_bool(use_default_col_range);
 DECLARE_bool(use_cider_data_format);
 DECLARE_bool(needs_error_check);
 DECLARE_bool(use_nextgen_compiler);
+DECLARE_bool(null_separate);
 
 DECLARE_bool(output_columnar_hint);
 DECLARE_bool(allow_multifrag);
@@ -55,12 +56,6 @@ DECLARE_bool(allow_runtime_query_interrupt);
 DECLARE_double(running_query_interrupt_freq);
 DECLARE_uint64(pending_query_interrupt_freq);
 DECLARE_bool(force_direct_hash);
-
-DECLARE_bool(codegen_all_opt);
-DECLARE_bool(check_bit_vector_clear_opt);
-DECLARE_bool(set_null_bit_vector_opt);
-DECLARE_bool(branchless_logic);
-DECLARE_bool(null_separate);
 
 // wrapper for Omnisci CompilationOptions
 struct CiderCompilationOption {

--- a/cpp/src/cider/include/cider/CiderOptions.h
+++ b/cpp/src/cider/include/cider/CiderOptions.h
@@ -23,6 +23,7 @@
 #define CIDER_CIDEROPTIONS_H
 
 #include <gflags/gflags.h>
+#include <gflags/gflags_declare.h>
 #include <cstddef>
 #include <cstdint>
 
@@ -59,6 +60,7 @@ DECLARE_bool(codegen_all_opt);
 DECLARE_bool(check_bit_vector_clear_opt);
 DECLARE_bool(set_null_bit_vector_opt);
 DECLARE_bool(branchless_logic);
+DECLARE_bool(null_separate);
 
 // wrapper for Omnisci CompilationOptions
 struct CiderCompilationOption {

--- a/cpp/src/cider/include/cider/CiderOptions.h
+++ b/cpp/src/cider/include/cider/CiderOptions.h
@@ -55,6 +55,11 @@ DECLARE_double(running_query_interrupt_freq);
 DECLARE_uint64(pending_query_interrupt_freq);
 DECLARE_bool(force_direct_hash);
 
+DECLARE_bool(codegen_all_opt);
+DECLARE_bool(check_bit_vector_clear_opt);
+DECLARE_bool(set_null_bit_vector_opt);
+DECLARE_bool(branchless_logic);
+
 // wrapper for Omnisci CompilationOptions
 struct CiderCompilationOption {
   bool hoist_literals;

--- a/cpp/src/cider/type/plan/BinaryExpr.cpp
+++ b/cpp/src/cider/type/plan/BinaryExpr.cpp
@@ -70,7 +70,6 @@ JITExprValue& BinOper::codegen(CodegenContext& context) {
     if (get_optype() == kBW_EQ or get_optype() == kBW_NE) {
       return codegenFixedSizeDistinctFrom(func, lhs_val, rhs_val);
     }
-    // JITValuePointer null = func.createVariable(JITTypeTag::BOOL, "null_val");
     auto null = lhs_val.getNull() || rhs_val.getNull();
 
     const auto optype = get_optype();

--- a/cpp/src/cider/type/plan/BinaryExpr.cpp
+++ b/cpp/src/cider/type/plan/BinaryExpr.cpp
@@ -19,10 +19,10 @@
  * under the License.
  */
 #include "type/plan/BinaryExpr.h"
-#include "cider/CiderOptions.h"
 #include "exec/nextgen/jitlib/base/JITValue.h"
 #include "exec/nextgen/utils/JITExprValue.h"
 #include "exec/template/Execute.h"  // for is_unnest
+#include "util/Logger.h"
 
 namespace Analyzer {
 using namespace cider::jitlib;
@@ -118,51 +118,14 @@ JITExprValue& BinOper::codegenNull(CodegenContext& context) {
   if (lhs_ti.is_string()) {
     // string binops, should only be comparisons
     // const auto optype = get_optype();
-    // if (IS_COMPARISON(optype)) {
-    //   VarSizeJITExprValue lhs_val(lhs->codegen(context));
-    //   VarSizeJITExprValue rhs_val(rhs->codegen(context));
-    //   JITValuePointer null = func.createVariable(JITTypeTag::BOOL, "null_val");
-    //   null = lhs_val.getNull() || rhs_val.getNull();
-    //   return codegenVarcharCmpFun(func, null, lhs_val, rhs_val);
-    // } else {
-    //   CIDER_THROW(CiderUnsupportedException, "string BinOp only supports comparison");
-    // }
+    UNIMPLEMENTED();
   } else {
-    // const auto optype = get_optype();
-    // if (IS_LOGIC(optype)) {
-    //   FixSizeJITExprValue lhs_val(lhs->codegen(context));
-    //   FixSizeJITExprValue rhs_val(rhs->codegen(context));
-
-    //   JITValuePointer null = func.createVariable(JITTypeTag::BOOL, "null_val");
-    //   null = lhs_val.getNull() || rhs_val.getNull();
-
-    //   bool branchless_logic = context.getCodegenOptions().branchless_logic;
-    //   return codegenFixedSizeLogicalFun(func, null, lhs_val, rhs_val,
-    //   branchless_logic);
-    // }
-
     // primitive type binops
     JITExprValueAdaptor lhs_val(lhs->codegenNull(context));
     JITExprValueAdaptor rhs_val(rhs->codegenNull(context));
 
-    // if (get_optype() == kBW_EQ or get_optype() == kBW_NE) {
-    //   return codegenFixedSizeDistinctFrom(func, lhs_val, rhs_val);
-    // }
-
     // FIXME: propagate null, don't support kleene logic operation
     return set_expr_null(lhs_val.getNull() || rhs_val.getNull());
-
-    // if (IS_ARITHMETIC(optype)) {
-    //   bool needs_error_check = context.getCodegenOptions().needs_error_check;
-    //   return codegenFixedSizeColArithFun(
-    //       null, lhs_val.getValue(), rhs_val.getValue(), needs_error_check);
-    // } else if (IS_COMPARISON(optype)) {
-    //   return codegenFixedSizeColCmpFun(null, lhs_val.getValue(), rhs_val.getValue());
-    // } else if (IS_LOGIC(optype)) {
-    //   bool branchless_logic = context.getCodegenOptions().branchless_logic;
-    //   return codegenFixedSizeLogicalFun(func, null, lhs_val, rhs_val,
-    //   branchless_logic);
-    // }
   }
   UNREACHABLE();
   return expr_var_;

--- a/cpp/src/cider/type/plan/BinaryExpr.cpp
+++ b/cpp/src/cider/type/plan/BinaryExpr.cpp
@@ -19,6 +19,7 @@
  * under the License.
  */
 #include "type/plan/BinaryExpr.h"
+#include "cider/CiderOptions.h"
 #include "exec/nextgen/jitlib/base/JITValue.h"
 #include "exec/nextgen/utils/JITExprValue.h"
 #include "exec/template/Execute.h"  // for is_unnest
@@ -70,7 +71,8 @@ JITExprValue& BinOper::codegen(CodegenContext& context) {
     if (get_optype() == kBW_EQ or get_optype() == kBW_NE) {
       return codegenFixedSizeDistinctFrom(func, lhs_val, rhs_val);
     }
-    auto null = lhs_val.getNull() || rhs_val.getNull();
+    JITValuePointer null = func.createVariable(JITTypeTag::BOOL, "null_val");
+    null = lhs_val.getNull() || rhs_val.getNull();
 
     const auto optype = get_optype();
     if (IS_ARITHMETIC(optype)) {
@@ -90,6 +92,8 @@ JITExprValue& BinOper::codegen(CodegenContext& context) {
 JITExprValue& BinOper::codegenNull(CodegenContext& context) {
   // JITFunction& func = *context.getJITFunction();
   // FIXME: how to use cache for not first call
+  // cann't use cache in the first call,
+  // cause codegen() generated null operation need to be updated
   // if (auto& expr_var = get_expr_value()) {
   //   return expr_var;
   // }

--- a/cpp/src/cider/type/plan/BinaryExpr.h
+++ b/cpp/src/cider/type/plan/BinaryExpr.h
@@ -145,7 +145,9 @@ class BinOper : public Expr {
   ExprPtrRefVector get_children_reference() override {
     return {&left_operand, &right_operand};
   }
+
   JITExprValue& codegen(CodegenContext& context) override;
+  JITExprValue& codegenNull(CodegenContext& context) override;
 
   JITExprValue& codegenFixedSizeColArithFun(CodegenContext& context,
                                             JITValuePointer null,

--- a/cpp/src/cider/type/plan/BinaryExpr.h
+++ b/cpp/src/cider/type/plan/BinaryExpr.h
@@ -157,11 +157,10 @@ class BinOper : public Expr {
   JITExprValue& codegenFixedSizeColCmpFun(JITValuePointer& null,
                                           JITValue& lhs,
                                           JITValue& rhs);
-  JITExprValue& codegenFixedSizeLogicalFun(JITFunction& func,
-                                           JITValuePointer& null,
+  JITExprValue& codegenFixedSizeLogicalFun(CodegenContext& context,
+                                           JITFunction& func,
                                            FixSizeJITExprValue& lhs_val,
-                                           FixSizeJITExprValue& rhs_val,
-                                           bool branchless_logic);
+                                           FixSizeJITExprValue& rhs_val);
   JITExprValue& codegenFixedSizeDistinctFrom(JITFunction& func,
                                              FixSizeJITExprValue& lhs,
                                              FixSizeJITExprValue& rhs);

--- a/cpp/src/cider/type/plan/BinaryExpr.h
+++ b/cpp/src/cider/type/plan/BinaryExpr.h
@@ -158,7 +158,8 @@ class BinOper : public Expr {
   JITExprValue& codegenFixedSizeLogicalFun(JITFunction& func,
                                            JITValuePointer& null,
                                            FixSizeJITExprValue& lhs_val,
-                                           FixSizeJITExprValue& rhs_val);
+                                           FixSizeJITExprValue& rhs_val,
+                                           bool branchless_logic);
   JITExprValue& codegenFixedSizeDistinctFrom(JITFunction& func,
                                              FixSizeJITExprValue& lhs,
                                              FixSizeJITExprValue& rhs);

--- a/cpp/src/cider/type/plan/ColumnExpr.cpp
+++ b/cpp/src/cider/type/plan/ColumnExpr.cpp
@@ -26,5 +26,8 @@ using namespace cider::jitlib;
 JITExprValue& ColumnVar::codegen(CodegenContext& context) {
   return get_expr_value();
 }
+JITExprValue& ColumnVar::codegenNull(CodegenContext& context) {
+  return get_expr_value();
+}
 
 }  // namespace Analyzer

--- a/cpp/src/cider/type/plan/ColumnExpr.h
+++ b/cpp/src/cider/type/plan/ColumnExpr.h
@@ -107,6 +107,7 @@ class ColumnVar : public Expr {
 
  public:
   JITExprValue& codegen(CodegenContext& context) override;
+  JITExprValue& codegenNull(CodegenContext& context) override;
 
  protected:
   int rte_idx;  // 0-based range table index, used for table ordering in multi-joins

--- a/cpp/src/cider/type/plan/ConstantExpr.cpp
+++ b/cpp/src/cider/type/plan/ConstantExpr.cpp
@@ -83,4 +83,14 @@ JITExprValue& Constant::codegen(CodegenContext& context) {
   UNREACHABLE();
   return expr_var_;
 }
+
+JITExprValue& Constant::codegenNull(CodegenContext& context) {
+  JITFunction& func = *context.getJITFunction();
+  if (auto& expr_var = get_expr_value()) {
+    return expr_var;
+  }
+
+  auto null = func.createLiteral(JITTypeTag::BOOL, get_is_null());
+  return set_expr_null(null);
+}  // namespace Analyzer
 }  // namespace Analyzer

--- a/cpp/src/cider/type/plan/ConstantExpr.cpp
+++ b/cpp/src/cider/type/plan/ConstantExpr.cpp
@@ -86,9 +86,9 @@ JITExprValue& Constant::codegen(CodegenContext& context) {
 
 JITExprValue& Constant::codegenNull(CodegenContext& context) {
   JITFunction& func = *context.getJITFunction();
-  if (auto& expr_var = get_expr_value()) {
-    return expr_var;
-  }
+  // if (auto& expr_var = get_expr_value()) {
+  //   return expr_var;
+  // }
 
   auto null = func.createLiteral(JITTypeTag::BOOL, get_is_null());
   return set_expr_null(null);

--- a/cpp/src/cider/type/plan/ConstantExpr.cpp
+++ b/cpp/src/cider/type/plan/ConstantExpr.cpp
@@ -21,6 +21,7 @@
 #include "type/plan/ConstantExpr.h"
 #include "cider/CiderOptions.h"
 #include "exec/nextgen/context/CodegenContext.h"
+#include "exec/nextgen/jitlib/base/JITValue.h"
 
 namespace Analyzer {
 
@@ -32,7 +33,7 @@ JITExprValue& Constant::codegen(CodegenContext& context) {
 
   auto null = func.createLiteral(JITTypeTag::BOOL, get_is_null());
   if (FLAGS_null_separate) {
-    null = func.createLiteral(JITTypeTag::BOOL, false);
+    null.replace(func.createLiteral(JITTypeTag::BOOL, false));
   }
 
   const auto& ti = get_type_info();

--- a/cpp/src/cider/type/plan/ConstantExpr.cpp
+++ b/cpp/src/cider/type/plan/ConstantExpr.cpp
@@ -19,6 +19,7 @@
  * under the License.
  */
 #include "type/plan/ConstantExpr.h"
+#include "cider/CiderOptions.h"
 #include "exec/nextgen/context/CodegenContext.h"
 
 namespace Analyzer {
@@ -30,6 +31,9 @@ JITExprValue& Constant::codegen(CodegenContext& context) {
   }
 
   auto null = func.createLiteral(JITTypeTag::BOOL, get_is_null());
+  if (FLAGS_null_separate) {
+    null = func.createLiteral(JITTypeTag::BOOL, false);
+  }
 
   const auto& ti = get_type_info();
   const auto type = ti.is_decimal() ? decimal_to_int_type(ti) : ti.get_type();

--- a/cpp/src/cider/type/plan/ConstantExpr.h
+++ b/cpp/src/cider/type/plan/ConstantExpr.h
@@ -78,6 +78,7 @@ class Constant : public Expr {
   std::string toString() const override;
 
   JITExprValue& codegen(CodegenContext& context) override;
+  JITExprValue& codegenNull(CodegenContext& context) override;
 
   ExprPtrRefVector get_children_reference() override { return {}; }
 

--- a/cpp/src/cider/type/plan/Expr.cpp
+++ b/cpp/src/cider/type/plan/Expr.cpp
@@ -30,6 +30,10 @@ JITExprValue& Expr::codegen(CodegenContext& context) {
   UNREACHABLE();
   return expr_var_;
 }
+JITExprValue& Expr::codegenNull(CodegenContext& context) {
+  UNREACHABLE();
+  return expr_var_;
+}
 }  // namespace Analyzer
 
 std::shared_ptr<Analyzer::Expr> remove_cast(const std::shared_ptr<Analyzer::Expr>& expr) {

--- a/cpp/src/cider/type/plan/Expr.cpp
+++ b/cpp/src/cider/type/plan/Expr.cpp
@@ -30,6 +30,7 @@ JITExprValue& Expr::codegen(CodegenContext& context) {
   UNREACHABLE();
   return expr_var_;
 }
+
 JITExprValue& Expr::codegenNull(CodegenContext& context) {
   UNREACHABLE();
   return expr_var_;

--- a/cpp/src/cider/type/plan/Expr.h
+++ b/cpp/src/cider/type/plan/Expr.h
@@ -29,7 +29,6 @@
 #include <string>
 #include <vector>
 
-#include "cider/CiderOptions.h"
 #include "exec/nextgen/context/CodegenContext.h"
 #include "exec/nextgen/jitlib/JITLib.h"
 #include "exec/nextgen/jitlib/base/JITValue.h"

--- a/cpp/src/cider/type/plan/Expr.h
+++ b/cpp/src/cider/type/plan/Expr.h
@@ -29,8 +29,10 @@
 #include <string>
 #include <vector>
 
+#include "cider/CiderOptions.h"
 #include "exec/nextgen/context/CodegenContext.h"
 #include "exec/nextgen/jitlib/JITLib.h"
+#include "exec/nextgen/jitlib/base/JITValue.h"
 #include "exec/nextgen/utils/JITExprValue.h"
 #include "exec/nextgen/utils/TypeUtils.h"
 #include "type/data/sqltypes.h"
@@ -162,6 +164,7 @@ class Expr : public std::enable_shared_from_this<Expr> {
  public:
   // change this to pure virtual method after all subclasses support codegen.
   virtual JITExprValue& codegen(CodegenContext& context);
+  virtual JITExprValue& codegenNull(CodegenContext& context);
 
   // for {JITValuePointer, ...}
   template <JITExprValueType type = JITExprValueType::ROW, typename... T>
@@ -171,6 +174,13 @@ class Expr : public std::enable_shared_from_this<Expr> {
   }
 
   JITExprValue& get_expr_value() { return expr_var_; }
+
+  // should be called after set_expr_value
+  JITExprValue& set_expr_null(JITValuePointer null) {
+    CHECK_GT(expr_var_.size(), 0);
+    JITExprValueAdaptor(expr_var_).setNull(null);
+    return expr_var_;
+  }
 
   // TODO (bigPYJ1151): to pure virtual.
   virtual ExprPtrRefVector get_children_reference() {

--- a/cpp/src/cider/util/CiderBitUtils.h
+++ b/cpp/src/cider/util/CiderBitUtils.h
@@ -170,6 +170,44 @@ FORCE_INLINE void clearBitAt(uint8_t* bit_vector, size_t index) {
   bit_vector[index >> 3] &= kCiderBitReverseMask[index & 0x7];
 }
 
+FORCE_INLINE bool isBitClearAt(const uint8_t* bit_vector, size_t index) {
+  // return bit_vector[index >> 3] ^ kCiderBitMask[index & 0x7];
+  return bit_vector[index >> 3] ^ (1 << (index & 0x7));
+}
+
+FORCE_INLINE void setBitAt1(uint8_t* bit_vector, size_t index, bool is_null) {
+  // https://stackoverflow.com/questions/24314281/conditionally-set-or-clear-bits
+  // https://graphics.stanford.edu/~seander/bithacks.html#ConditionalSetOrClearBitsWithoutBranching
+  uint8_t idx = index >> 3;
+  uint8_t mask = 1 << (index & 0x7);
+  bit_vector[idx] = (bit_vector[idx] & ~mask) | (-(uint8_t)is_null & mask);
+}
+/*
+FORCE_INLINE uint8_t setBitAt1(uint8_t* bit_vector,
+                               size_t index,
+                               bool is_null,
+                               uint8_t tmp_8bit_acc) {
+  //  uint8_t tmp_8bit_acc,
+  //  uint64_t total_row_num) {
+
+  // https://stackoverflow.com/questions/24314281/conditionally-set-or-clear-bits
+  //
+https://graphics.stanford.edu/~seander/bithacks.html#ConditionalSetOrClearBitsWithoutBranching
+  uint8_t bit = index & 0x7;
+  uint8_t mask = 1 << bit;
+  tmp_8bit_acc = (tmp_8bit_acc & ~mask) | (-(uint8_t)is_null & mask);
+
+  // tmp_8bit_acc |= (kCiderBitReverseMask[bit] | kCiderBitMask[is_null << bit]);
+  // tmp_8bit_acc |= (~(1 << bit)) | (is_null << bit));
+  // if (bit == 0x7 || index + 1 == total_row_num) {
+  if (bit == 0x7) {
+    uint8_t byte_idx = index >> 3;
+    bit_vector[byte_idx] = tmp_8bit_acc;
+    tmp_8bit_acc = 0;
+  }
+  return tmp_8bit_acc;
+}
+*/
 inline size_t countSetBits(const uint8_t* bit_vector, size_t end) {
   size_t i = 0, ans = 0;
   for (; i + 64 <= end; i += 64) {

--- a/cpp/src/cider/util/CiderBitUtils.h
+++ b/cpp/src/cider/util/CiderBitUtils.h
@@ -175,39 +175,14 @@ FORCE_INLINE bool isBitClearAt(const uint8_t* bit_vector, size_t index) {
   return bit_vector[index >> 3] ^ (1 << (index & 0x7));
 }
 
-FORCE_INLINE void setBitAt1(uint8_t* bit_vector, size_t index, bool is_null) {
+FORCE_INLINE void setBitAtUnified(uint8_t* bit_vector, size_t index, bool is_null) {
   // https://stackoverflow.com/questions/24314281/conditionally-set-or-clear-bits
   // https://graphics.stanford.edu/~seander/bithacks.html#ConditionalSetOrClearBitsWithoutBranching
   uint8_t idx = index >> 3;
   uint8_t mask = 1 << (index & 0x7);
   bit_vector[idx] = (bit_vector[idx] & ~mask) | (-(uint8_t)is_null & mask);
 }
-/*
-FORCE_INLINE uint8_t setBitAt1(uint8_t* bit_vector,
-                               size_t index,
-                               bool is_null,
-                               uint8_t tmp_8bit_acc) {
-  //  uint8_t tmp_8bit_acc,
-  //  uint64_t total_row_num) {
 
-  // https://stackoverflow.com/questions/24314281/conditionally-set-or-clear-bits
-  //
-https://graphics.stanford.edu/~seander/bithacks.html#ConditionalSetOrClearBitsWithoutBranching
-  uint8_t bit = index & 0x7;
-  uint8_t mask = 1 << bit;
-  tmp_8bit_acc = (tmp_8bit_acc & ~mask) | (-(uint8_t)is_null & mask);
-
-  // tmp_8bit_acc |= (kCiderBitReverseMask[bit] | kCiderBitMask[is_null << bit]);
-  // tmp_8bit_acc |= (~(1 << bit)) | (is_null << bit));
-  // if (bit == 0x7 || index + 1 == total_row_num) {
-  if (bit == 0x7) {
-    uint8_t byte_idx = index >> 3;
-    bit_vector[byte_idx] = tmp_8bit_acc;
-    tmp_8bit_acc = 0;
-  }
-  return tmp_8bit_acc;
-}
-*/
 inline size_t countSetBits(const uint8_t* bit_vector, size_t end) {
   size_t i = 0, ans = 0;
   for (; i + 64 <= end; i += 64) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
try to optimize expression performance
1) branchless null set and logic operation
2) xor replace not(and) for bit clear check
3) null separated for auto-vectorization
all optimization is under gflags, so nothing changed if all gflags are closed.

**branchless logic gain 15%~35% performance boost for logic operation**

**auto-vectorization will gain 2x performance boost, but null process is hard**
**this pr just enable auto-vectorization with null process splited, which hard to support keleene logic operation**
**so we propagate null, which is one strategy in arrow kernel**

some performance details on haswell:

```bash
============================================================================
/workspace/code/BDTK/src/cider-velox/benchmark/expression/ArithmeticAndComparison.cpprelative  time/iter  iters/s
============================================================================
velox                                                         3.75s  266.78m
nextgen                                           90.84%      4.13s  242.34m
nextgen_opt                                      228.17%      1.64s  608.69m
specifialize1                                   1923.43%   194.89ms     5.13
specifialize2                                   1146.42%   326.97ms     3.06
specifialize3                                    241.53%      1.55s  644.35m
----------------------------------------------------------------------------
mulI8Velox_________Base                                       3.79s  263.63m
mulI8NextGen                                      92.60%      4.10s  244.13m
mulI8NextGen_______Base                                       4.10s  243.78m
mulI8NextgenIsBitClear                            93.25%      4.40s  227.33m
mulI8NextgenBranchlessSetNull                     38.49%     10.66s   93.82m
mulI8NextgenBranchlessLogic                       98.83%      4.15s  240.94m
mulI8NextgenNullSeparate                         292.02%      1.40s  711.91m
mulI8NextgenAllOpt                               296.91%      1.38s  723.81m
mulI8Compile                                                57.50ms    17.39
----------------------------------------------------------------------------
mulI8NestedVelox_________Base                                 6.20s  161.20m
mulI8NestedNextGen                               144.74%      4.29s  233.32m
mulI8NestedNextGen_______Base                                 4.38s  228.28m
mulI8NestedNextgenIsBitClear                      96.13%      4.56s  219.45m
mulI8NestedNextgenBranchlessSetNull               84.12%      5.21s  192.04m
mulI8NestedNextgenBranchlessLogic                101.13%      4.33s  230.85m
mulI8NestedNextgenNullSeparate                   328.52%      1.33s  749.94m
mulI8NestedNextgenAllOpt                         327.48%      1.34s  747.57m
mulI8NestedCompile                                          58.75ms    17.02
----------------------------------------------------------------------------
mulI8NestedDeepVelox_________Base                             8.78s  113.90m
mulI8NestedDeepNextGen                           195.45%      4.49s  222.62m
mulI8NestedDeepNextGen_______Base                             4.44s  224.98m
mulI8NestedDeepNextgenIsBitClear                  97.28%      4.57s  218.86m
mulI8NestedDeepNextgenBranchlessSetNull           78.33%      5.67s  176.23m
mulI8NestedDeepNextgenBranchlessLogic             98.15%      4.53s  220.82m
mulI8NestedDeepNextgenNullSeparate               329.11%      1.35s  740.45m
mulI8NestedDeepNextgenAllOpt                     331.00%      1.34s  744.69m
mulI8NestedDeepCompile                                      57.64ms    17.35
----------------------------------------------------------------------------
mulI16Velox_________Base                                      3.14s  318.00m
mulI16NextGen                                     76.29%      4.12s  242.60m
mulI16NextGen_______Base                                      4.14s  241.65m
mulI16NextgenIsBitClear                           94.24%      4.39s  227.73m
mulI16NextgenBranchlessSetNull                    38.99%     10.61s   94.21m
mulI16NextgenBranchlessLogic                     100.41%      4.12s  242.63m
mulI16NextgenNullSeparate                        282.30%      1.47s  682.16m
mulI16NextgenAllOpt                              281.79%      1.47s  680.93m
mulI16Compile                                               58.10ms    17.21
----------------------------------------------------------------------------
mulI32Velox_________Base                                      3.14s  318.60m
mulI32NextGen                                     72.70%      4.32s  231.63m
mulI32NextGen_______Base                                      4.29s  233.13m
mulI32NextgenIsBitClear                           94.43%      4.54s  220.13m
mulI32NextgenBranchlessSetNull                    40.46%     10.60s   94.32m
mulI32NextgenBranchlessLogic                     101.08%      4.24s  235.64m
mulI32NextgenNullSeparate                        274.58%      1.56s  640.13m
mulI32NextgenAllOpt                              276.19%      1.55s  643.88m
mulI32Compile                                               59.38ms    16.84
----------------------------------------------------------------------------
mulI64Velox_________Base                                      3.04s  328.53m
mulI64NextGen                                     72.30%      4.21s  237.52m
mulI64NextGen_______Base                                      4.34s  230.30m
mulI64NextgenIsBitClear                           90.27%      4.81s  207.90m
mulI64NextgenBranchlessSetNull                    39.94%     10.87s   91.97m
mulI64NextgenBranchlessLogic                      99.67%      4.36s  229.54m
mulI64NextgenNullSeparate                        197.20%      2.20s  454.14m
mulI64NextgenAllOpt                              194.76%      2.23s  448.54m
mulI64Compile                                               59.23ms    16.88
----------------------------------------------------------------------------
mulDoubleVelox_________Base                                   2.97s  337.11m
mulDoubleNextGen                                  59.20%      5.01s  199.58m
mulDoubleNextGen_______Base                                   4.95s  201.94m
mulDoubleNextgenIsBitClear                        83.25%      5.95s  168.11m
mulDoubleNextgenBranchlessSetNull                 56.08%      8.83s  113.26m
mulDoubleNextgenBranchlessLogic                   99.48%      4.98s  200.89m
mulDoubleNextgenNullSeparate                     267.06%      1.85s  539.31m
mulDoubleNextgenAllOpt                           272.94%      1.81s  551.18m
mulDoubleCompile                                            60.50ms    16.53
----------------------------------------------------------------------------
mulDoubleSameColumnVelox_________Base                         3.29s  303.83m
mulDoubleSameColumnNextGen                        77.69%      4.24s  236.05m
mulDoubleSameColumnNextGen_______Base                         4.22s  237.01m
mulDoubleSameColumnNextgenIsBitClear              90.56%      4.66s  214.63m
mulDoubleSameColumnNextgenBranchlessSetNull       81.37%      5.19s  192.86m
mulDoubleSameColumnNextgenBranchlessLogic         97.71%      4.32s  231.58m
mulDoubleSameColumnNextgenNullSeparate           216.80%      1.95s  513.84m
mulDoubleSameColumnNextgenAllOpt                 213.21%      1.98s  505.34m
mulDoubleSameColumnCompile                                  59.88ms    16.70
----------------------------------------------------------------------------
mulDoubleConstantVelox_________Base                           2.99s  334.84m
mulDoubleConstantNextGen                          60.18%      4.96s  201.50m
mulDoubleConstantNextGen_______Base                           4.78s  209.26m
mulDoubleConstantNextgenIsBitClear                80.91%      5.91s  169.32m
mulDoubleConstantNextgenBranchlessSetNull         53.95%      8.86s  112.90m
mulDoubleConstantNextgenBranchlessLogic           97.82%      4.89s  204.69m
mulDoubleConstantNextgenNullSeparate             228.67%      2.09s  478.51m
mulDoubleConstantNextgenAllOpt                   207.58%      2.30s  434.38m
mulDoubleConstantCompile                                    60.90ms    16.42
----------------------------------------------------------------------------
mulDoubleNestedVelox_________Base                             4.48s  223.41m
mulDoubleNestedNextGen                            88.41%      5.06s  197.52m
mulDoubleNestedNextGen_______Base                             5.20s  192.16m
mulDoubleNestedNextgenIsBitClear                  88.63%      5.87s  170.32m
mulDoubleNestedNextgenBranchlessSetNull           79.82%      6.52s  153.37m
mulDoubleNestedNextgenBranchlessLogic            100.86%      5.16s  193.80m
mulDoubleNestedNextgenNullSeparate               229.01%      2.27s  440.07m
mulDoubleNestedNextgenAllOpt                     247.84%      2.10s  476.25m
mulDoubleNestedCompile                                      61.80ms    16.18
----------------------------------------------------------------------------
mulDoubleNestedDeepVelox_________Base                         9.02s  110.83m
mulDoubleNestedDeepNextGen                       182.55%      4.94s  202.31m
mulDoubleNestedDeepNextGen_______Base                         4.96s  201.68m
mulDoubleNestedDeepNextgenIsBitClear              83.17%      5.96s  167.73m
mulDoubleNestedDeepNextgenBranchlessSetNull       69.95%      7.09s  141.08m
mulDoubleNestedDeepNextgenBranchlessLogic         99.47%      4.99s  200.60m
mulDoubleNestedDeepNextgenNullSeparate           233.13%      2.13s  470.17m
mulDoubleNestedDeepNextgenAllOpt                 252.74%      1.96s  509.71m
mulDoubleNestedDeepCompile                                  62.76ms    15.93
----------------------------------------------------------------------------
PlusCheckedVeloxI64                                           3.96s  252.70m
plusI64Velox_________Base                                     3.34s  298.99m
plusI64NextGen                                    75.13%      4.45s  224.64m
plusI64NextGen_______Base                                     4.20s  238.11m
plusI64NextgenIsBitClear                          90.96%      4.62s  216.59m
plusI64NextgenBranchlessSetNull                   38.28%     10.97s   91.15m
plusI64NextgenBranchlessLogic                     98.23%      4.28s  233.90m
plusI64NextgenNullSeparate                       229.01%      1.83s  545.29m
plusI64NextgenAllOpt                             227.79%      1.84s  542.40m
plusI64Compile                                              61.27ms    16.32
----------------------------------------------------------------------------
mulAndAddVelox_________Base                                  16.24s   61.59m
mulAndAddNextGen                                 309.64%      5.24s  190.70m
mulAndAddNextGen_______Base                                   5.12s  195.28m
mulAndAddNextgenIsBitClear                        96.30%      5.32s  188.06m
mulAndAddNextgenBranchlessSetNull                 80.68%      6.35s  157.56m
mulAndAddNextgenBranchlessLogic                   97.58%      5.25s  190.56m
mulAndAddNextgenNullSeparate                     222.06%      2.31s  433.64m
mulAndAddNextgenAllOpt                           235.69%      2.17s  460.26m
mulAndAddCompile                                            59.19ms    16.90
----------------------------------------------------------------------------
eqVelox_________Base                                          3.83s  260.81m
eqNextGen                                         69.54%      5.51s  181.38m
eqNextGen_______Base                                          5.56s  179.81m
eqNextgenIsBitClear                               88.95%      6.25s  159.93m
eqNextgenBranchlessSetNull                        48.03%     11.58s   86.37m
eqNextgenBranchlessLogic                         103.14%      5.39s  185.46m
eqNextgenNullSeparate                            159.73%      3.48s  287.20m
eqNextgenAllOpt                                  115.42%      4.82s  207.53m
eqCompile                                                   62.35ms    16.04
----------------------------------------------------------------------------
eqConstantVelox_________Base                                  3.91s  255.52m
eqConstantNextGen                                 69.55%      5.63s  177.72m
eqConstantNextGen_______Base                                  5.60s  178.51m
eqConstantNextgenIsBitClear                       88.90%      6.30s  158.69m
eqConstantNextgenBranchlessSetNull                46.97%     11.93s   83.84m
eqConstantNextgenBranchlessLogic                  98.33%      5.70s  175.53m
eqConstantNextgenNullSeparate                    159.55%      3.51s  284.81m
eqConstantNextgenAllOpt                          115.50%      4.85s  206.17m
eqConstantCompile                                           60.47ms    16.54
----------------------------------------------------------------------------
eqBoolVelox_________Base                                      4.43s  225.99m
eqBoolNextGen                                     72.80%      6.08s  164.51m
eqBoolNextGen_______Base                                      6.02s  166.03m
eqBoolNextgenIsBitClear                           72.45%      8.31s  120.29m
eqBoolNextgenBranchlessSetNull                    68.81%      8.75s  114.25m
eqBoolNextgenBranchlessLogic                      99.58%      6.05s  165.33m
eqBoolNextgenNullSeparate                        132.70%      4.54s  220.32m
eqBoolNextgenAllOpt                               62.65%      9.61s  104.02m
eqBoolCompile                                               63.49ms    15.75
----------------------------------------------------------------------------
neqVelox_________Base                                         3.83s  261.14m
neqNextGen                                        68.61%      5.58s  179.18m
neqNextGen_______Base                                         5.57s  179.41m
neqNextgenIsBitClear                              82.74%      6.74s  148.44m
neqNextgenBranchlessSetNull                       48.84%     11.41s   87.62m
neqNextgenBranchlessLogic                        100.31%      5.56s  179.98m
neqNextgenNullSeparate                           161.81%      3.44s  290.31m
neqNextgenAllOpt                                 116.75%      4.77s  209.47m
neqCompile                                                  62.09ms    16.10
----------------------------------------------------------------------------
gtVelox_________Base                                          3.92s  255.04m
gtNextGen                                         68.74%      5.70s  175.32m
gtNextGen_______Base                                          5.71s  175.25m
gtNextgenIsBitClear                               82.97%      6.88s  145.41m
gtNextgenBranchlessSetNull                        71.14%      8.02s  124.68m
gtNextgenBranchlessLogic                         100.31%      5.69s  175.80m
gtNextgenNullSeparate                            161.98%      3.52s  283.87m
gtNextgenAllOpt                                  121.43%      4.70s  212.80m
gtCompile                                                   63.86ms    15.66
----------------------------------------------------------------------------
ltVelox_________Base                                          3.66s  273.59m
ltNextGen                                         63.21%      5.78s  172.94m
ltNextGen_______Base                                          5.80s  172.40m
ltNextgenIsBitClear                               84.04%      6.90s  144.89m
ltNextgenBranchlessSetNull                        72.87%      7.96s  125.62m
ltNextgenBranchlessLogic                          98.92%      5.86s  170.54m
ltNextgenNullSeparate                            160.44%      3.62s  276.60m
ltNextgenAllOpt                                  122.67%      4.73s  211.47m
ltCompile                                                   62.81ms    15.92
----------------------------------------------------------------------------
andVelox_________Base                                        33.54s   29.81m
andNextGen                                       372.02%      9.02s  110.91m
andNextGen_______Base                                         9.02s  110.91m
andNextgenIsBitClear                              70.74%     12.75s   78.45m
andNextgenBranchlessSetNull                       82.96%     10.87s   92.01m
andNextgenBranchlessLogic                        116.18%      7.76s  128.85m
andNextgenNullSeparate                           199.97%      4.51s  221.78m
andNextgenAllOpt                                 122.80%      7.34s  136.20m
andCompile                                                  66.94ms    14.94
----------------------------------------------------------------------------
orVelox_________Base                                         35.19s   28.42m
orNextGen                                        438.73%      8.02s  124.67m
orNextGen_______Base                                          8.07s  123.91m
orNextgenIsBitClear                               73.15%     11.03s   90.65m
orNextgenBranchlessSetNull                        78.05%     10.34s   96.71m
orNextgenBranchlessLogic                         114.90%      7.02s  142.38m
orNextgenNullSeparate                            170.23%      4.74s  210.93m
orNextgenAllOpt                                   96.96%      8.32s  120.14m
orCompile                                                   65.04ms    15.37
----------------------------------------------------------------------------
conjunctsNestedVelox_________Base                           2.74min    6.09m
conjunctsNestedNextGen                           713.07%     23.02s   43.44m
conjunctsNestedNextGen_______Base                            22.92s   43.63m
conjunctsNestedNextgenIsBitClear                  89.08%     25.73s   38.87m
conjunctsNestedNextgenBranchlessSetNull           91.30%     25.10s   39.84m
conjunctsNestedNextgenBranchlessLogic            135.07%     16.97s   58.93m
conjunctsNestedNextgenNullSeparate               373.86%      6.13s  163.13m
conjunctsNestedNextgenAllOpt                     301.28%      7.61s  131.46m
conjunctsNestedCompile                                      73.73ms    13.56
----------------------------------------------------------------------------
```

### Why are the changes needed?
try to improve performance 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
benchmark tester

### Which label does this PR belong to?
INFRA
