### PR TITLE
[POAE7-2815] Add namespace and resolve redefinition with other modules for HashTable

### DIFF
--- a/src/cider/common/CMakeLists.txt
+++ b/src/cider/common/CMakeLists.txt
@@ -18,3 +18,5 @@
 # specific language governing permissions and limitations
 # under the License.
 add_subdirectory(contrib)
+
+add_library(cider_hashtable interpreters/AggregationHashTable.cpp)

--- a/src/cider/common/hashtable/FixedHashMap.h
+++ b/src/cider/common/hashtable/FixedHashMap.h
@@ -25,6 +25,7 @@
 #include <common/hashtable/FixedHashTable.h>
 #include <common/hashtable/HashMap.h>
 
+namespace cider::hashtable {
 template <typename Key, typename TMapped, typename TState = HashTableNoState>
 struct FixedHashMapCell {
   using Mapped = TMapped;
@@ -189,3 +190,5 @@ using FixedImplicitZeroHashMapWithCalculatedSize =
                  FixedHashMapImplicitZeroCell<Key, Mapped>,
                  FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<Key, Mapped>>,
                  Allocator>;
+
+}  // namespace cider::hashtable

--- a/src/cider/common/hashtable/FixedHashTable.h
+++ b/src/cider/common/hashtable/FixedHashTable.h
@@ -28,7 +28,6 @@ namespace cider::hashtable {
 namespace ErrorCodes {
 extern const int NO_AVAILABLE_DATA;
 }
-}  // namespace cider::hashtable
 
 template <typename Key, typename TState = HashTableNoState>
 struct FixedHashTableCell {
@@ -510,3 +509,5 @@ class FixedHashTable : private boost::noncopyable,
   size_t getCollisions() const { return 0; }
 #endif
 };
+
+}  // namespace cider::hashtable

--- a/src/cider/common/hashtable/HashMap.h
+++ b/src/cider/common/hashtable/HashMap.h
@@ -26,6 +26,7 @@
 #include <common/hashtable/HashTable.h>
 #include <common/hashtable/HashTableAllocator.h>
 #include <common/hashtable/Prefetching.h>
+#include <iostream>
 
 /** NOTE HashMap could only be used for memmoveable (position independent) types.
  * Example: std::string is not position independent in libstdc++ with C++11 ABI or in
@@ -37,7 +38,6 @@ namespace cider::hashtable {
 namespace ErrorCodes {
 extern const int LOGICAL_ERROR;
 }
-}  // namespace cider::hashtable
 
 struct NoInitTag {};
 
@@ -174,23 +174,26 @@ struct HashMapCell {
       return std::move(value.second);
   }
 };
+}  // namespace cider::hashtable
 
 namespace std {
 
 template <typename Key, typename TMapped, typename Hash, typename TState>
-struct tuple_size<HashMapCell<Key, TMapped, Hash, TState>>
+struct tuple_size<cider::hashtable::HashMapCell<Key, TMapped, Hash, TState>>
     : std::integral_constant<size_t, 2> {};
 
 template <typename Key, typename TMapped, typename Hash, typename TState>
-struct tuple_element<0, HashMapCell<Key, TMapped, Hash, TState>> {
+struct tuple_element<0, cider::hashtable::HashMapCell<Key, TMapped, Hash, TState>> {
   using type = Key;
 };
 
 template <typename Key, typename TMapped, typename Hash, typename TState>
-struct tuple_element<1, HashMapCell<Key, TMapped, Hash, TState>> {
+struct tuple_element<1, cider::hashtable::HashMapCell<Key, TMapped, Hash, TState>> {
   using type = TMapped;
 };
 }  // namespace std
+
+namespace cider::hashtable {
 
 template <typename Key,
           typename TMapped,
@@ -343,24 +346,30 @@ class HashMapTable : public HashTable<Key, Cell, Hash, Grower, Allocator> {
     return it;
   }
 };
+}  // namespace cider::hashtable
 
 namespace std {
 
 template <typename Key, typename TMapped, typename Hash, typename TState>
-struct tuple_size<HashMapCellWithSavedHash<Key, TMapped, Hash, TState>>
+struct tuple_size<cider::hashtable::HashMapCellWithSavedHash<Key, TMapped, Hash, TState>>
     : std::integral_constant<size_t, 2> {};
 
 template <typename Key, typename TMapped, typename Hash, typename TState>
-struct tuple_element<0, HashMapCellWithSavedHash<Key, TMapped, Hash, TState>> {
+struct tuple_element<
+    0,
+    cider::hashtable::HashMapCellWithSavedHash<Key, TMapped, Hash, TState>> {
   using type = Key;
 };
 
 template <typename Key, typename TMapped, typename Hash, typename TState>
-struct tuple_element<1, HashMapCellWithSavedHash<Key, TMapped, Hash, TState>> {
+struct tuple_element<
+    1,
+    cider::hashtable::HashMapCellWithSavedHash<Key, TMapped, Hash, TState>> {
   using type = TMapped;
 };
 }  // namespace std
 
+namespace cider::hashtable {
 template <typename Key,
           typename Mapped,
           typename Hash = DefaultHash<Key>,
@@ -391,3 +400,5 @@ using HashMapWithSavedHash = HashMapTable<Key,
 //     HashTableAllocatorWithStackMemory<
 //         (1ULL << initial_size_degree)
 //         * sizeof(HashMapCellWithSavedHash<Key, Mapped, Hash>)>>;
+
+}  // namespace cider::hashtable

--- a/src/cider/common/hashtable/HashSet.h
+++ b/src/cider/common/hashtable/HashSet.h
@@ -30,7 +30,6 @@ namespace cider::hashtable {
 namespace ErrorCodes {
 extern const int LOGICAL_ERROR;
 }
-}  // namespace cider::hashtable
 
 /** NOTE HashSet could only be used for memmoveable (position independent) types.
  * Example: std::string is not position independent in libstdc++ with C++11 ABI or in
@@ -190,3 +189,5 @@ using HashSetWithSavedHash =
 //     HashTableAllocatorWithStackMemory<
 //         (1ULL << initial_size_degree)
 //         * sizeof(HashSetCellWithSavedHash<Key, Hash>)>>;
+
+}  // namespace cider::hashtable

--- a/src/cider/common/hashtable/HashTable.h
+++ b/src/cider/common/hashtable/HashTable.h
@@ -33,6 +33,8 @@
 
 #include <common/hashtable/HashTableAllocator.h>
 #include <common/hashtable/HashTableKeyHolder.h>
+#include "type/data/funcannotations.h"
+#include "util/Logger.h"
 
 #ifdef DBMS_HASH_MAP_DEBUG_RESIZES
 #include <Common/Stopwatch.h>
@@ -51,7 +53,6 @@ namespace ErrorCodes {
 extern const int LOGICAL_ERROR;
 extern const int NO_AVAILABLE_DATA;
 }  // namespace ErrorCodes
-}  // namespace cider::hashtable
 
 /** The state of the hash table that affects the properties of its cells.
  * Used as a template parameter.
@@ -1339,3 +1340,5 @@ class HashTable : private boost::noncopyable,
   size_t getCollisions() const { return collisions; }
 #endif
 };
+
+}  // namespace cider::hashtable

--- a/src/cider/common/hashtable/HashTableKeyHolder.h
+++ b/src/cider/common/hashtable/HashTableKeyHolder.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <common/Arena.h>
+#include "type/data/funcannotations.h"
 
 /**
  * In some aggregation scenarios, when adding a key to the hash table, we

--- a/src/cider/common/interpreters/AggregationHashTable.cpp
+++ b/src/cider/common/interpreters/AggregationHashTable.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ * Copyright (c) 2016-2022 ClickHouse, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "common/interpreters/AggregationHashTable.h"
+
+namespace cider::hashtable {
+
+HashTableAllocator allocator;
+
+// key_types: all key types
+// init_addr: initial value addr
+// init_len: initial value length
+// `init_addr` and `init_len` describe the init value of a value in HashTable.
+// The memory layout can of any kind and should be designed by users.
+AggregationHashTable::AggregationHashTable(std::vector<SQLTypes> key_types,
+                                           int8_t* addr,
+                                           uint32_t len)
+    : key_types_(key_types), init_val_(addr), init_len_(len) {
+  // TODO: use agg_method to construct the specific HashTable instead of all
+  agg_method_ = chooseAggregationMethod();
+}
+
+// raw_key: Layout of keys should be aligned to 16 like below:
+// |<-- key1_isNUll -->|<-- pad_1 -->|<-- key1_values -->|<-- key2_isNull -->| .....
+// |<- 8bit ->|<- 8bit ->|<-- key1_values -->|<-- key2_isNull -->| .....
+// `keyn_values` will be like:
+// |<-- v1_int8 -->|<-- pad -->| or |<-- v1_int32 -->| or |<-- v1_bool -->|<-- pad -->|
+// |<- 8bit ->|<- 8bit ->| or |<--- 32bit  --->| or |<- 8bit ->|<- 8bit ->|
+// return: start position of value
+AggregateDataPtr AggregationHashTable::get(int8_t* raw_key) {
+  // Transfer all keys to one AggKey
+  AggKey key = transferToAggKey(raw_key);
+  // key_set_.emplace(key);
+
+  for (int i = 0; i < key_types_.size(); i++) {
+    if (SQLTypes::kTINYINT == key_types_[i]) {
+      uint8_t key_v = (reinterpret_cast<uint8_t*>(key.getAddr()))[0];
+      if (agg_ht_uint8_[key_v] == nullptr) {
+        // Allocate memory of values here since value type like non-fixed length address
+        // cannot be new in hash table. This case should be manually handled and it's
+        // better to use an Arena for better memory efficiency.
+        agg_ht_uint8_[key_v] = allocator.allocate(init_len_);
+        std::memcpy(agg_ht_uint8_[key_v], init_val_, init_len_);
+      }
+      return agg_ht_uint8_[key_v];
+    } else if (SQLTypes::kSMALLINT == key_types_[i]) {
+      uint16_t key_v = (reinterpret_cast<uint16_t*>(key.getAddr()))[0];
+      if (agg_ht_uint16_[key_v] == nullptr) {
+        // Allocate memory of values here since value type like non-fixed length address
+        // cannot be new in hash table. This case should be manually handled and it's
+        // better to use an Arena for better memory efficiency.
+        agg_ht_uint16_[key_v] = allocator.allocate(init_len_);
+        std::memcpy(agg_ht_uint16_[key_v], init_val_, init_len_);
+      }
+      return agg_ht_uint16_[key_v];
+    } else if (SQLTypes::kINT == key_types_[i]) {
+      uint32_t key_v = (reinterpret_cast<uint32_t*>(key.getAddr()))[0];
+      if (agg_ht_uint32_[key_v] == nullptr) {
+        agg_ht_uint32_[key_v] = allocator.allocate(init_len_);
+        std::memcpy(agg_ht_uint32_[key_v], init_val_, init_len_);
+      }
+      return agg_ht_uint32_[key_v];
+    } else if (SQLTypes::kBIGINT == key_types_[i]) {
+      uint64_t key_v = (reinterpret_cast<uint64_t*>(key.getAddr()))[0];
+      if (agg_ht_uint64_[key_v] == nullptr) {
+        agg_ht_uint64_[key_v] = allocator.allocate(init_len_);
+        std::memcpy(agg_ht_uint64_[key_v], init_val_, init_len_);
+      }
+      return agg_ht_uint64_[key_v];
+    }
+  }
+  CIDER_THROW(CiderRuntimeException, "Unsupported key type");
+}
+
+AggregateDataPtr AggregationHashTable::get(std::vector<AggKey> agg_keys) {
+  CIDER_THROW(CiderRuntimeException, "Unsupported key type");
+}
+
+// key_addr: Same as `key_addr` in get
+// return: AggKey stored in HashTable
+// This function is to transfer keys formatted in codegen to AggKey in HashTable.
+// It will try to merge keys to a primitive type in multiple key cases.
+// If failed, serialize all keys to one key in Type::SERIALIZED.
+AggKey AggregationHashTable::transferToAggKey(int8_t* key_addr) {
+  // Single key
+  if (1 == key_types_.size()) {
+    if (SQLTypes::kTINYINT == key_types_[0]) {
+      bool is_null = (reinterpret_cast<bool*>(key_addr))[0];
+      AggKey key(is_null, key_addr + 2, 1);
+      return key;
+    }
+    if (SQLTypes::kSMALLINT == key_types_[0]) {
+      bool is_null = (reinterpret_cast<bool*>(key_addr))[0];
+      AggKey key(is_null, key_addr + 2, 2);
+      return key;
+    }
+    if (SQLTypes::kINT == key_types_[0]) {
+      bool is_null = (reinterpret_cast<bool*>(key_addr))[0];
+      AggKey key(is_null, key_addr + 2, 4);
+      return key;
+    }
+    if (SQLTypes::kBIGINT == key_types_[0]) {
+      bool is_null = (reinterpret_cast<bool*>(key_addr))[0];
+      AggKey key(is_null, key_addr + 2, 8);
+      return key;
+    }
+    // TODO: Support more types.
+  }
+  CIDER_THROW(CiderRuntimeException, "Unsupported Aggregation key");
+  // TODO: Multiple keys, find out if keys can be arranged to primitive types like
+  // int32/int64... If not, serialize the key and set the key type to Type::serialized.
+}
+
+// Dump all value of the HashTable.
+// TODO: Here need to be discussed, what to return?
+// std::vector<AggregateDataPtr> dump() {
+//   std::vector<AggregateDataPtr> res(key_set_.size());
+//   for (auto key : key_set_) {
+//     if (SQLTypes::kTINYINT == key_types_[0]) {
+//       int8_t key_v = (reinterpret_cast<int8_t*>(key.addr))[0];
+//       ;
+//       res.emplace(agg_ht_uint8_[key_v]);
+//     } else if (SQLTypes::kSMALLINT == key_types_[0]) {
+//       int16_t key_v = (reinterpret_cast<int16_t*>(key.addr))[0];
+//       ;
+//       res.emplace(agg_ht_uint16_[key_v]);
+//     }
+//   }
+//   return res;
+// }
+
+// Select the aggregation method based on the number and types of keys.
+AggregationMethod::Type AggregationHashTable::chooseAggregationMethod() {
+  // Single key
+  if (1 == key_types_.size()) {
+    if (SQLTypes::kTINYINT == key_types_[0]) {
+      return AggregationMethod::Type::INT8;
+    } else if (SQLTypes::kSMALLINT == key_types_[0]) {
+      return AggregationMethod::Type::INT16;
+    } else if (SQLTypes::kINT == key_types_[0]) {
+      return AggregationMethod::Type::INT32;
+    } else if (SQLTypes::kBIGINT == key_types_[0]) {
+      return AggregationMethod::Type::INT64;
+    }
+    // TODO: Support more types.
+  }
+  // TODO: Support multiple keys.
+  return AggregationMethod::Type::EMPTY;
+}
+}  // namespace cider::hashtable

--- a/src/cider/common/interpreters/AggregationHashTable.h
+++ b/src/cider/common/interpreters/AggregationHashTable.h
@@ -84,7 +84,6 @@ using AggregatedHashTableWithNullableUInt16Key =
     AggregatedHashTableWithNullKey<AggregatedHashTableWithUInt16Key>;
 
 class AggregationHashTable;
-HashTableAllocator allocator;
 
 struct AggregationMethod : private boost::noncopyable {
   enum class Type {
@@ -135,13 +134,7 @@ class AggregationHashTable final {
   // init_len: initial value length
   // `init_addr` and `init_len` describe the init value of a value in HashTable.
   // The memory layout can of any kind and should be designed by users.
-  explicit AggregationHashTable(std::vector<SQLTypes> key_types,
-                                int8_t* addr,
-                                uint32_t len)
-      : key_types_(key_types), init_val_(addr), init_len_(len) {
-    // TODO: use agg_method to construct the specific HashTable instead of all
-    agg_method_ = chooseAggregationMethod();
-  }
+  AggregationHashTable(std::vector<SQLTypes> key_types, int8_t* addr, uint32_t len);
 
   // raw_key: Layout of keys should be aligned to 16 like below:
   // |<-- key1_isNUll -->|<-- pad_1 -->|<-- key1_values -->|<-- key2_isNull -->| .....
@@ -150,89 +143,16 @@ class AggregationHashTable final {
   // |<-- v1_int8 -->|<-- pad -->| or |<-- v1_int32 -->| or |<-- v1_bool -->|<-- pad -->|
   // |<- 8bit ->|<- 8bit ->| or |<--- 32bit  --->| or |<- 8bit ->|<- 8bit ->|
   // return: start position of value
-  AggregateDataPtr get(int8_t* raw_key) {
-    // Transfer all keys to one AggKey
-    AggKey key = transferToAggKey(raw_key);
-    // key_set_.emplace(key);
+  AggregateDataPtr get(int8_t* raw_key);
 
-    for (int i = 0; i < key_types_.size(); i++) {
-      if (SQLTypes::kTINYINT == key_types_[i]) {
-        uint8_t key_v = (reinterpret_cast<uint8_t*>(key.getAddr()))[0];
-        if (agg_ht_uint8_[key_v] == nullptr) {
-          // Allocate memory of values here since value type like non-fixed length address
-          // cannot be new in hash table. This case should be manually handled and it's
-          // better to use an Arena for better memory efficiency.
-          agg_ht_uint8_[key_v] = allocator.allocate(init_len_);
-          std::memcpy(agg_ht_uint8_[key_v], init_val_, init_len_);
-        }
-        return agg_ht_uint8_[key_v];
-      } else if (SQLTypes::kSMALLINT == key_types_[i]) {
-        uint16_t key_v = (reinterpret_cast<uint16_t*>(key.getAddr()))[0];
-        if (agg_ht_uint16_[key_v] == nullptr) {
-          // Allocate memory of values here since value type like non-fixed length address
-          // cannot be new in hash table. This case should be manually handled and it's
-          // better to use an Arena for better memory efficiency.
-          agg_ht_uint16_[key_v] = allocator.allocate(init_len_);
-          std::memcpy(agg_ht_uint16_[key_v], init_val_, init_len_);
-        }
-        return agg_ht_uint16_[key_v];
-      } else if (SQLTypes::kINT == key_types_[i]) {
-        uint32_t key_v = (reinterpret_cast<uint32_t*>(key.getAddr()))[0];
-        if (agg_ht_uint32_[key_v] == nullptr) {
-          agg_ht_uint32_[key_v] = allocator.allocate(init_len_);
-          std::memcpy(agg_ht_uint32_[key_v], init_val_, init_len_);
-        }
-        return agg_ht_uint32_[key_v];
-      } else if (SQLTypes::kBIGINT == key_types_[i]) {
-        uint64_t key_v = (reinterpret_cast<uint64_t*>(key.getAddr()))[0];
-        if (agg_ht_uint64_[key_v] == nullptr) {
-          agg_ht_uint64_[key_v] = allocator.allocate(init_len_);
-          std::memcpy(agg_ht_uint64_[key_v], init_val_, init_len_);
-        }
-        return agg_ht_uint64_[key_v];
-      }
-    }
-    CIDER_THROW(CiderRuntimeException, "Unsupported key type");
-  }
-
-  AggregateDataPtr get(std::vector<AggKey> agg_keys) {
-    CIDER_THROW(CiderRuntimeException, "Unsupported key type");
-  }
+  AggregateDataPtr get(std::vector<AggKey> agg_keys);
 
   // key_addr: Same as `key_addr` in get
   // return: AggKey stored in HashTable
   // This function is to transfer keys formatted in codegen to AggKey in HashTable.
   // It will try to merge keys to a primitive type in multiple key cases.
   // If failed, serialize all keys to one key in Type::SERIALIZED.
-  AggKey transferToAggKey(int8_t* key_addr) {
-    // Single key
-    if (1 == key_types_.size()) {
-      if (SQLTypes::kTINYINT == key_types_[0]) {
-        bool is_null = (reinterpret_cast<bool*>(key_addr))[0];
-        AggKey key(is_null, key_addr + 2, 1);
-        return key;
-      }
-      if (SQLTypes::kSMALLINT == key_types_[0]) {
-        bool is_null = (reinterpret_cast<bool*>(key_addr))[0];
-        AggKey key(is_null, key_addr + 2, 2);
-        return key;
-      }
-      if (SQLTypes::kINT == key_types_[0]) {
-        bool is_null = (reinterpret_cast<bool*>(key_addr))[0];
-        AggKey key(is_null, key_addr + 2, 4);
-        return key;
-      }
-      if (SQLTypes::kBIGINT == key_types_[0]) {
-        bool is_null = (reinterpret_cast<bool*>(key_addr))[0];
-        AggKey key(is_null, key_addr + 2, 8);
-        return key;
-      }
-      // TODO: Support more types.
-    }
-    CIDER_THROW(CiderRuntimeException, "Unsupported Aggregation key");
-    // TODO: Multiple keys, find out if keys can be arranged to primitive types like
-    // int32/int64... If not, serialize the key and set the key type to Type::serialized.
-  }
+  AggKey transferToAggKey(int8_t* key_addr);
 
   // Dump all value of the HashTable.
   // TODO: Here need to be discussed, what to return?
@@ -264,22 +184,6 @@ class AggregationHashTable final {
   AggregatedHashTableWithUInt64Key agg_ht_uint64_;
 
   // Select the aggregation method based on the number and types of keys.
-  AggregationMethod::Type chooseAggregationMethod() {
-    // Single key
-    if (1 == key_types_.size()) {
-      if (SQLTypes::kTINYINT == key_types_[0]) {
-        return AggregationMethod::Type::INT8;
-      } else if (SQLTypes::kSMALLINT == key_types_[0]) {
-        return AggregationMethod::Type::INT16;
-      } else if (SQLTypes::kINT == key_types_[0]) {
-        return AggregationMethod::Type::INT32;
-      } else if (SQLTypes::kBIGINT == key_types_[0]) {
-        return AggregationMethod::Type::INT64;
-      }
-      // TODO: Support more types.
-    }
-    // TODO: Support multiple keys.
-    return AggregationMethod::Type::EMPTY;
-  }
+  AggregationMethod::Type chooseAggregationMethod();
 };
 }  // namespace cider::hashtable

--- a/src/cider/exec/nextgen/context/CodegenContext.h
+++ b/src/cider/exec/nextgen/context/CodegenContext.h
@@ -21,6 +21,7 @@
 #ifndef NEXTGEN_CONTEXT_CODEGENCONTEXT_H
 #define NEXTGEN_CONTEXT_CODEGENCONTEXT_H
 
+#include "common/interpreters/AggregationHashTable.h"
 #include "exec/nextgen/context/Buffer.h"
 #include "exec/nextgen/context/CiderSet.h"
 #include "exec/nextgen/jitlib/base/JITModule.h"

--- a/src/cider/tests/CMakeLists.txt
+++ b/src/cider/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(StringHeapTest StringHeapTest.cpp)
 
 set(EXECUTE_TEST_LIBS
     cider
+    cider_hashtable
     gtest
     test_utils
     fmt::fmt

--- a/src/cider/tests/CiderNewAggHashTableTest.cpp
+++ b/src/cider/tests/CiderNewAggHashTableTest.cpp
@@ -26,10 +26,11 @@
 #include "common/interpreters/AggregationHashTable.h"
 
 using namespace TestHelpers;
+using namespace cider::hashtable;
 
 class CiderNewAggHashTableTest : public ::testing::Test {};
 
-static const std::shared_ptr<CiderAllocator> allocator =
+static const std::shared_ptr<CiderAllocator> default_allocator =
     std::make_shared<CiderDefaultAllocator>();
 
 TEST_F(CiderNewAggHashTableTest, aggUInt8Test) {
@@ -60,7 +61,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt8Test) {
   // value of HT: SUM(int8)-int64 + COUNT(int8)-int32 + MIN(int8)-int8 +
   // MAX(int8)-int8
   uint32_t init_value_len = 14;
-  int8_t* init_value_ptr = allocator->allocate(init_value_len);
+  int8_t* init_value_ptr = default_allocator->allocate(init_value_len);
   int64_t sum_init_val = 0;
   int32_t cnt_init_val = 0;
   int8_t min_init_val = std::numeric_limits<int8_t>::max();
@@ -70,12 +71,11 @@ TEST_F(CiderNewAggHashTableTest, aggUInt8Test) {
   *reinterpret_cast<int8_t*>(init_value_ptr + offset_vec[2]) = min_init_val;
   *reinterpret_cast<int8_t*>(init_value_ptr + offset_vec[3]) = max_init_val;
 
-  cider::hashtable::AggregationHashTable agg_ht(
-      key_types, init_value_ptr, init_value_len);
+  AggregationHashTable agg_ht(key_types, init_value_ptr, init_value_len);
 
   // Row0:
   // Generate a key = 1
-  int8_t* key1_ptr = allocator->allocate(key_len);
+  int8_t* key1_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key1_ptr) = key_null;
   *reinterpret_cast<uint8_t*>(key1_ptr + offset_vec[0]) = key1;
   // Use get api and return value address
@@ -96,7 +96,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt8Test) {
       std::max(reinterpret_cast<int8_t*>(value1_ptr + offset_vec[3])[0], val1);
 
   // Row1:
-  int8_t* key2_ptr = allocator->allocate(key_len);
+  int8_t* key2_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key2_ptr) = key_null;
   *reinterpret_cast<uint8_t*>(key2_ptr + offset_vec[0]) = key2;
   // Use get api and return value address
@@ -117,7 +117,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt8Test) {
       std::max(reinterpret_cast<int8_t*>(value2_ptr + offset_vec[3])[0], val2);
 
   // Row2:
-  int8_t* key3_ptr = allocator->allocate(key_len);
+  int8_t* key3_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key3_ptr) = key_null;
   *reinterpret_cast<uint16_t*>(key3_ptr + offset_vec[0]) = key3;
   // Use get api and return value address
@@ -133,7 +133,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt8Test) {
 
   // Final check
   // Check key = 1
-  int8_t* key1_check_ptr = allocator->allocate(key_len);
+  int8_t* key1_check_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key1_check_ptr) = key_null;
   *reinterpret_cast<uint8_t*>(key1_check_ptr + offset_vec[0]) = key1;
   // Use get api and return value address
@@ -146,7 +146,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt8Test) {
   CHECK_EQ(reinterpret_cast<int8_t*>(value1_check_ptr + offset_vec[3])[0], 30);
 
   // Check key = 2
-  int8_t* key2_check_ptr = allocator->allocate(key_len);
+  int8_t* key2_check_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key2_check_ptr) = key_null;
   *reinterpret_cast<uint8_t*>(key2_check_ptr + offset_vec[0]) = key2;
   // Use get api and return value address
@@ -187,7 +187,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt16Test) {
   // value of HT: SUM(int16)-int64 + COUNT(int16)-int32 + MIN(int16)-int16 +
   // MAX(int16)-int16
   uint32_t init_value_len = 16;
-  int8_t* init_value_ptr = allocator->allocate(init_value_len);
+  int8_t* init_value_ptr = default_allocator->allocate(init_value_len);
   int64_t sum_init_val = 0;
   int32_t cnt_init_val = 0;
   int16_t min_init_val = std::numeric_limits<int16_t>::max();
@@ -197,11 +197,11 @@ TEST_F(CiderNewAggHashTableTest, aggUInt16Test) {
   *reinterpret_cast<int16_t*>(init_value_ptr + offset_vec[2]) = min_init_val;
   *reinterpret_cast<int16_t*>(init_value_ptr + offset_vec[3]) = max_init_val;
 
-  cider::hashtable::AggregationHashTable agg_ht(keys, init_value_ptr, init_value_len);
+  AggregationHashTable agg_ht(keys, init_value_ptr, init_value_len);
 
   // Row0:
   // Generate a key = 1
-  int8_t* key1_ptr = allocator->allocate(key_len);
+  int8_t* key1_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key1_ptr) = key_null;
   *reinterpret_cast<uint16_t*>(key1_ptr + offset_vec[0]) = key1;
   // Use get api and return value address
@@ -222,7 +222,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt16Test) {
       std::max(reinterpret_cast<int16_t*>(value1_ptr + offset_vec[3])[0], val1);
 
   // Row1:
-  int8_t* key2_ptr = allocator->allocate(key_len);
+  int8_t* key2_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key2_ptr) = key_null;
   *reinterpret_cast<uint16_t*>(key2_ptr + offset_vec[0]) = key2;
   // Use get api and return value address
@@ -243,7 +243,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt16Test) {
       std::max(reinterpret_cast<int16_t*>(value2_ptr + offset_vec[3])[0], val2);
 
   // Row2:
-  int8_t* key3_ptr = allocator->allocate(key_len);
+  int8_t* key3_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key3_ptr) = key_null;
   *reinterpret_cast<uint16_t*>(key3_ptr + offset_vec[0]) = key3;
   // Use get api and return value address
@@ -259,7 +259,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt16Test) {
 
   // Final check
   // Check key = 1
-  int8_t* key1_check_ptr = allocator->allocate(key_len);
+  int8_t* key1_check_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key1_check_ptr) = key_null;
   *reinterpret_cast<uint16_t*>(key1_check_ptr + offset_vec[0]) = key1;
   // Use get api and return value address
@@ -272,7 +272,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt16Test) {
   CHECK_EQ(reinterpret_cast<int16_t*>(value1_check_ptr + offset_vec[3])[0], 30);
 
   // Check key = 2
-  int8_t* key2_check_ptr = allocator->allocate(key_len);
+  int8_t* key2_check_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key2_check_ptr) = key_null;
   *reinterpret_cast<uint16_t*>(key2_check_ptr + offset_vec[0]) = key2;
   // Use get api and return value address
@@ -313,7 +313,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt32Test) {
   // value of HT: SUM(int32)-int64 + COUNT(int32)-int32 + MIN(int32)-int32 +
   // MAX(int32)-int32
   uint32_t init_value_len = 20;
-  int8_t* init_value_ptr = allocator->allocate(init_value_len);
+  int8_t* init_value_ptr = default_allocator->allocate(init_value_len);
   int64_t sum_init_val = 0;
   int32_t cnt_init_val = 0;
   int32_t min_init_val = std::numeric_limits<int32_t>::max();
@@ -323,11 +323,11 @@ TEST_F(CiderNewAggHashTableTest, aggUInt32Test) {
   *reinterpret_cast<int32_t*>(init_value_ptr + offset_vec[2]) = min_init_val;
   *reinterpret_cast<int32_t*>(init_value_ptr + offset_vec[3]) = max_init_val;
 
-  cider::hashtable::AggregationHashTable agg_ht(keys, init_value_ptr, init_value_len);
+  AggregationHashTable agg_ht(keys, init_value_ptr, init_value_len);
 
   // Row0:
   // Generate a key = 1
-  int8_t* key1_ptr = allocator->allocate(key_len);
+  int8_t* key1_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key1_ptr) = key_null;
   *reinterpret_cast<uint32_t*>(key1_ptr + offset_vec[0]) = key1;
   // Use get api and return value address
@@ -348,7 +348,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt32Test) {
       std::max(reinterpret_cast<int32_t*>(value1_ptr + 16)[0], val1);
 
   // Row1:
-  int8_t* key2_ptr = allocator->allocate(key_len);
+  int8_t* key2_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key2_ptr) = key_null;
   *reinterpret_cast<uint32_t*>(key2_ptr + offset_vec[0]) = key2;
   // Use get api and return value address
@@ -369,7 +369,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt32Test) {
       std::max(reinterpret_cast<int32_t*>(value2_ptr + offset_vec[3])[0], val2);
 
   // Row2:
-  int8_t* key3_ptr = allocator->allocate(key_len);
+  int8_t* key3_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key3_ptr) = key_null;
   *reinterpret_cast<uint32_t*>(key3_ptr + offset_vec[0]) = key3;
   // Use get api and return value address
@@ -385,7 +385,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt32Test) {
 
   // Final check
   // Check key = 1
-  int8_t* key1_check_ptr = allocator->allocate(key_len);
+  int8_t* key1_check_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key1_check_ptr) = key_null;
   *reinterpret_cast<uint32_t*>(key1_check_ptr + offset_vec[0]) = key1;
   // Use get api and return value address
@@ -398,7 +398,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt32Test) {
   CHECK_EQ(reinterpret_cast<int32_t*>(value1_check_ptr + offset_vec[3])[0], 30);
 
   // Check key = 2
-  int8_t* key2_check_ptr = allocator->allocate(key_len);
+  int8_t* key2_check_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key2_check_ptr) = key_null;
   *reinterpret_cast<uint32_t*>(key2_check_ptr + offset_vec[0]) = key2;
   // Use get api and return value address
@@ -439,7 +439,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt64Test) {
   // value of HT: SUM(int64)-int64 + COUNT(int64)-int32 + MIN(int64)-int64 +
   // MAX(int64)-int64
   uint32_t init_value_len = 28;
-  int8_t* init_value_ptr = allocator->allocate(init_value_len);
+  int8_t* init_value_ptr = default_allocator->allocate(init_value_len);
   int64_t sum_init_val = 0;
   int32_t cnt_init_val = 0;
   int64_t min_init_val = std::numeric_limits<int64_t>::max();
@@ -449,11 +449,11 @@ TEST_F(CiderNewAggHashTableTest, aggUInt64Test) {
   *reinterpret_cast<int64_t*>(init_value_ptr + offset_vec[2]) = min_init_val;
   *reinterpret_cast<int64_t*>(init_value_ptr + offset_vec[3]) = max_init_val;
 
-  cider::hashtable::AggregationHashTable agg_ht(keys, init_value_ptr, init_value_len);
+  AggregationHashTable agg_ht(keys, init_value_ptr, init_value_len);
 
   // Row0:
   // Generate a key = 1
-  int8_t* key1_ptr = allocator->allocate(key_len);
+  int8_t* key1_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key1_ptr) = key_null;
   *reinterpret_cast<uint64_t*>(key1_ptr + offset_vec[0]) = key1;
   // Use get api and return value address
@@ -474,7 +474,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt64Test) {
       std::max(reinterpret_cast<int64_t*>(value1_ptr + offset_vec[3])[0], val1);
 
   // Row1:
-  int8_t* key2_ptr = allocator->allocate(key_len);
+  int8_t* key2_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key2_ptr) = key_null;
   *reinterpret_cast<uint64_t*>(key2_ptr + offset_vec[0]) = key2;
   // Use get api and return value address
@@ -495,7 +495,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt64Test) {
       std::max(reinterpret_cast<int64_t*>(value2_ptr + offset_vec[3])[0], val2);
 
   // Row2:
-  int8_t* key3_ptr = allocator->allocate(key_len);
+  int8_t* key3_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key3_ptr) = key_null;
   *reinterpret_cast<uint64_t*>(key3_ptr + offset_vec[0]) = key3;
   // Use get api and return value address
@@ -511,7 +511,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt64Test) {
 
   // Final check
   // Check key = 1
-  int8_t* key1_check_ptr = allocator->allocate(key_len);
+  int8_t* key1_check_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key1_check_ptr) = key_null;
   *reinterpret_cast<uint64_t*>(key1_check_ptr + offset_vec[0]) = key1;
   // Use get api and return value address
@@ -524,7 +524,7 @@ TEST_F(CiderNewAggHashTableTest, aggUInt64Test) {
   CHECK_EQ(reinterpret_cast<int64_t*>(value1_check_ptr + offset_vec[3])[0], 30);
 
   // Check key = 2
-  int8_t* key2_check_ptr = allocator->allocate(key_len);
+  int8_t* key2_check_ptr = default_allocator->allocate(key_len);
   *reinterpret_cast<bool*>(key2_check_ptr) = key_null;
   *reinterpret_cast<uint64_t*>(key2_check_ptr + offset_vec[0]) = key2;
   // Use get api and return value address

--- a/src/cider/tests/CiderNewHashTableTest.cpp
+++ b/src/cider/tests/CiderNewHashTableTest.cpp
@@ -25,6 +25,7 @@
 #include "common/hashtable/FixedHashMap.h"
 
 using namespace TestHelpers;
+using namespace cider::hashtable;
 
 class CiderNewHashTableTest : public ::testing::Test {};
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add namespace `cider::hashtable` to all HashTable related classes.
2. Seperate all implementation parts of `AggregationHashTable.h` into `AggregationHashTable.cpp`. It can reduce compilation time and prevent redefinition errors.
3. Include `AggregationHashTable.h` in `CodegenContext.h` to expose compilation problems and prove it can be well used.


### Why are the changes needed?
Improvement and integration.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.

### Which label does this PR belong to?

