### PR TITLE
[POAE7-2821] Fix uts and prevent conflict between hash_table and other libraries

### DIFF
--- a/cpp/src/cider/common/Arena.h
+++ b/cpp/src/cider/common/Arena.h
@@ -57,7 +57,7 @@ class Arena : private boost::noncopyable {
   /// Get piece of memory with alignment
   char* alignedAlloc(size_t size, size_t alignment) { return nullptr; }
 
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   template <typename T>
   T* alloc() {
     return nullptr;
@@ -85,17 +85,17 @@ class Arena : private boost::noncopyable {
   char* allocContinue(size_t additional_bytes,
                       char const*& range_start,
                       size_t start_alignment = 0) {
-    // TODO: Implement and enable later
+    // TODO(Deegue): Implement and enable later
     return nullptr;
   }
 
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   /// NOTE Old memory region is wasted.
   char* realloc(const char* old_data, size_t old_size, size_t new_size) {
     return nullptr;
   }
 
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   char* alignedRealloc(const char* old_data,
                        size_t old_size,
                        size_t new_size,

--- a/cpp/src/cider/common/base/unaligned.h
+++ b/cpp/src/cider/common/base/unaligned.h
@@ -42,7 +42,7 @@ inline void reverseMemcpy(void* dst, const void* src, size_t size) {
 template <typename T>
 inline T unalignedLoadLE(const void* address) {
   T res{};
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   // if constexpr (std::endian::native == std::endian::little)
   //     memcpy(&res, address, sizeof(res));
   // else
@@ -54,7 +54,7 @@ template <typename T>
 inline void unalignedStoreLE(void* address,
                              const typename std::enable_if<true, T>::type& src) {
   static_assert(std::is_trivially_copyable_v<T>);
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   // if constexpr (std::endian::native == std::endian::little)
   //     memcpy(address, &src, sizeof(src));
   // else

--- a/cpp/src/cider/common/hashtable/FixedHashSet.h
+++ b/cpp/src/cider/common/hashtable/FixedHashSet.h
@@ -41,7 +41,7 @@ class FixedHashSet
         new (&Base::buf[i]) Cell(rhs.buf[i]);
   }
 
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   /// NOTE: Currently this method isn't used. When it does, the ReadBuffer should
   ///  contain the Key explicitly.
   // void readAndMerge(DB::ReadBuffer & rb)

--- a/cpp/src/cider/common/hashtable/FixedHashTable.h
+++ b/cpp/src/cider/common/hashtable/FixedHashTable.h
@@ -248,7 +248,7 @@ class FixedHashTable : private boost::noncopyable,
     return *this;
   }
 
-  // TODO: refactor and enable later
+  // TODO(Deegue): refactor and enable later
   // class Reader final : private Cell::State
   // {
   // public:
@@ -389,7 +389,7 @@ class FixedHashTable : private boost::noncopyable,
     return !buf[hash_value].isZero(*this);
   }
 
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   // void write(DB::WriteBuffer & wb) const
   // {
   //     Cell::State::write(wb);

--- a/cpp/src/cider/common/hashtable/Hash.h
+++ b/cpp/src/cider/common/hashtable/Hash.h
@@ -299,6 +299,6 @@ struct IntHash32 {
   }
 };
 
-// TODO: Implement and enable later
+// TODO(Deegue): Implement and enable later
 // template <>
 // struct DefaultHash<StringRef> : public StringRefHash {};

--- a/cpp/src/cider/common/hashtable/HashMap.h
+++ b/cpp/src/cider/common/hashtable/HashMap.h
@@ -22,11 +22,12 @@
 
 #pragma once
 
+#include "cider/CiderException.h"
+
 #include <common/hashtable/Hash.h>
 #include <common/hashtable/HashTable.h>
 #include <common/hashtable/HashTableAllocator.h>
 #include <common/hashtable/Prefetching.h>
-#include <iostream>
 
 /** NOTE HashMap could only be used for memmoveable (position independent) types.
  * Example: std::string is not position independent in libstdc++ with C++11 ABI or in
@@ -117,7 +118,7 @@ struct HashMapCell {
 
   void setMapped(const value_type& value_) { value.second = value_.second; }
 
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   // /// Serialization, in binary and text form.
   // void write(DB::WriteBuffer & wb) const
   // {
@@ -330,9 +331,7 @@ class HashMapTable : public HashTable<Key, Cell, Hash, Grower, Allocator> {
   const typename Cell::Mapped& ALWAYS_INLINE at(const Key& x) const {
     if (auto it = this->find(x); it != this->end())
       return it->getMapped();
-    // throw DB::Exception("Cannot find element in HashMap::at method",
-    // DB::ErrorCodes::LOGICAL_ERROR);
-    std::cout << "Cannot find element in HashMap::at method" << std::endl;
+    CIDER_THROW(CiderRuntimeException, "Cannot find element in HashMap::at method");
     return nullptr;
   }
 
@@ -389,7 +388,7 @@ using HashMapWithSavedHash = HashMapTable<Key,
                                           Grower,
                                           Allocator>;
 
-// TODO: Implement and enable later
+// TODO(Deegue): Implement and enable later
 // template <typename Key, typename Mapped, typename Hash,
 //     size_t initial_size_degree>
 // using HashMapWithStackMemory = HashMapTable<

--- a/cpp/src/cider/common/hashtable/HashSet.h
+++ b/cpp/src/cider/common/hashtable/HashSet.h
@@ -60,7 +60,7 @@ class HashSetTable : public HashTable<Key, TCell, Hash, Grower, Allocator> {
         this->insert(rhs.buf[i].getValue());
   }
 
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   // void readAndMerge(DB::ReadBuffer & rb)
   // {
   //     Cell::State::read(rb);
@@ -79,7 +79,7 @@ class HashSetTable : public HashTable<Key, TCell, Hash, Grower, Allocator> {
   // }
 };
 
-// TODO: Implement and enable later
+// TODO(Deegue): Implement and enable later
 // template <typename Key,
 //           typename TCell,  /// Supposed to have no state (HashTableNoState)
 //           typename Hash = DefaultHash<Key>,
@@ -157,7 +157,7 @@ template <typename Key,
           typename Allocator = HashTableAllocator>
 using HashSet = HashSetTable<Key, HashTableCell<Key, Hash>, Hash, Grower, Allocator>;
 
-// TODO: Implement and enable later
+// TODO(Deegue): Implement and enable later
 // template <typename Key,
 //           typename Hash = DefaultHash<Key>,
 //           typename Grower = TwoLevelHashTableGrower<>,

--- a/cpp/src/cider/common/hashtable/HashTable.h
+++ b/cpp/src/cider/common/hashtable/HashTable.h
@@ -577,7 +577,7 @@ class HashTable : private boost::noncopyable,
              reinterpret_cast<const void*>(old_buffer.get()),
              old_buffer_size);
     } else {
-      // TODO: Use realloc after new allocator is implemented.
+      // TODO(Deegue): Use realloc after new allocator is implemented.
       // buf = reinterpret_cast<Cell*>(
       // Allocator::realloc(buf, old_buffer_size, new_grower.bufSize() * sizeof(Cell)));
 
@@ -781,7 +781,7 @@ class HashTable : private boost::noncopyable,
     return *this;
   }
 
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   // class Reader final : private Cell::State
   // {
   // public:
@@ -1211,7 +1211,7 @@ class HashTable : private boost::noncopyable,
     return !buf[place_value].isZero(*this);
   }
 
-  // TODO: Implement and enable later
+  // TODO(Deegue): Implement and enable later
   // void write(DB::WriteBuffer & wb) const
   // {
   //     Cell::State::write(wb);

--- a/cpp/src/cider/common/hashtable/HashTableAllocator.h
+++ b/cpp/src/cider/common/hashtable/HashTableAllocator.h
@@ -31,7 +31,7 @@
  */
 using HashTableAllocator = CiderDefaultAllocator;
 
-// TODO: will implement more allocator later
+// TODO(Deegue): will implement more allocator later
 // template <size_t initial_bytes = 64>
 // using HashTableAllocatorWithStackMemory = AllocatorWithStackMemory<HashTableAllocator,
 // initial_bytes>;

--- a/cpp/src/cider/common/interpreters/AggregationHashTable.cpp
+++ b/cpp/src/cider/common/interpreters/AggregationHashTable.cpp
@@ -35,7 +35,7 @@ AggregationHashTable::AggregationHashTable(std::vector<SQLTypes> key_types,
                                            int8_t* addr,
                                            uint32_t len)
     : key_types_(key_types), init_val_(addr), init_len_(len) {
-  // TODO: use agg_method to construct the specific HashTable instead of all
+  // TODO(Deegue): use agg_method to construct the specific HashTable instead of all
   agg_method_ = chooseAggregationMethod();
 }
 
@@ -123,15 +123,15 @@ AggKey AggregationHashTable::transferToAggKey(int8_t* key_addr) {
       AggKey key(is_null, key_addr + 2, 8);
       return key;
     }
-    // TODO: Support more types.
+    // TODO(Deegue): Support more types.
   }
   CIDER_THROW(CiderRuntimeException, "Unsupported Aggregation key");
-  // TODO: Multiple keys, find out if keys can be arranged to primitive types like
+  // TODO(Deegue): Multiple keys, find out if keys can be arranged to primitive types like
   // int32/int64... If not, serialize the key and set the key type to Type::serialized.
 }
 
 // Dump all value of the HashTable.
-// TODO: Here need to be discussed, what to return?
+// TODO(Deegue): Here need to be discussed, what to return?
 // std::vector<AggregateDataPtr> dump() {
 //   std::vector<AggregateDataPtr> res(key_set_.size());
 //   for (auto key : key_set_) {
@@ -161,9 +161,9 @@ AggregationMethod::Type AggregationHashTable::chooseAggregationMethod() {
     } else if (SQLTypes::kBIGINT == key_types_[0]) {
       return AggregationMethod::Type::INT64;
     }
-    // TODO: Support more types.
+    // TODO(Deegue): Support more types.
   }
-  // TODO: Support multiple keys.
+  // TODO(Deegue): Support multiple keys.
   return AggregationMethod::Type::EMPTY;
 }
 }  // namespace cider::hashtable

--- a/cpp/src/cider/common/interpreters/AggregationHashTable.h
+++ b/cpp/src/cider/common/interpreters/AggregationHashTable.h
@@ -155,7 +155,7 @@ class AggregationHashTable final {
   AggKey transferToAggKey(int8_t* key_addr);
 
   // Dump all value of the HashTable.
-  // TODO: Here need to be discussed, what to return?
+  // TODO(Deegue): Here need to be discussed, what to return?
   // std::vector<AggregateDataPtr> dump() {
   //   std::vector<AggregateDataPtr> res(key_set_.size());
   //   for (auto key : key_set_) {

--- a/cpp/src/cider/tests/CMakeLists.txt
+++ b/cpp/src/cider/tests/CMakeLists.txt
@@ -46,7 +46,6 @@ add_executable(StringHeapTest StringHeapTest.cpp)
 
 set(EXECUTE_TEST_LIBS
     cider
-    cider_hashtable
     gtest
     test_utils
     fmt::fmt
@@ -58,8 +57,10 @@ set(EXECUTE_TEST_LIBS
 target_link_libraries(CodeGeneratorTest ${EXECUTE_TEST_LIBS})
 target_link_libraries(CompileWorkUnitTest ${EXECUTE_TEST_LIBS})
 target_link_libraries(CiderAggHashTableTest ${EXECUTE_TEST_LIBS})
-target_link_libraries(CiderNewHashTableTest ${EXECUTE_TEST_LIBS})
-target_link_libraries(CiderNewAggHashTableTest ${EXECUTE_TEST_LIBS})
+target_link_libraries(CiderNewHashTableTest ${EXECUTE_TEST_LIBS}
+                      cider_hashtable)
+target_link_libraries(CiderNewAggHashTableTest ${EXECUTE_TEST_LIBS}
+                      cider_hashtable)
 target_link_libraries(CiderNongroupbyAggTest ${EXECUTE_TEST_LIBS})
 target_link_libraries(CiderCompileModuleTest ${EXECUTE_TEST_LIBS})
 target_link_libraries(CiderRuntimeModuleTest ${EXECUTE_TEST_LIBS})


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Now UTs fail due to conflicts between hash_table library and old codegen libraries. Move hash_table library out of global scope.
2. Revise TODOs.
3. Replace `cout` by `CiderException`.


### Why are the changes needed?
Fix and improve.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.

### Which label does this PR belong to?
<!-- 
If the label supposed to be bug, coderefactor or infra. Please use the UPPER case of these three words. For other labels: 
veloxIntegration, cider, documentation, CICD, test, benchmark, publicApi,  they are not need to be specified here. And try to ensure that the capitalization of the above three words does not appear in the PR as much as possible.
-->
