### PR TITLE
[POAE7-2797] jitlib decimal type(int128) support

### DIFF
--- a/cpp/src/cider/exec/nextgen/jitlib/base/ValueTypes.h
+++ b/cpp/src/cider/exec/nextgen/jitlib/base/ValueTypes.h
@@ -34,6 +34,7 @@ enum class JITTypeTag {
   INT16,
   INT32,
   INT64,
+  INT128,
   FLOAT,
   DOUBLE,
   POINTER,
@@ -108,6 +109,16 @@ struct JITTypeTraits<JITTypeTag::INT64> {
   static constexpr uint64_t bits = sizeof(NativeType) * 8;
   static constexpr JITTypeTag tag = JITTypeTag::INT64;
   static constexpr const char* name = "INT64";
+};
+
+template <>
+struct JITTypeTraits<JITTypeTag::INT128> {
+  using NativeType = __int128_t;
+  static constexpr bool isFixedWidth = true;
+  static constexpr uint64_t width = sizeof(NativeType);
+  static constexpr uint64_t bits = sizeof(NativeType) * 8;
+  static constexpr JITTypeTag tag = JITTypeTag::INT128;
+  static constexpr const char* name = "INT128";
 };
 
 template <>
@@ -188,6 +199,8 @@ inline const char* getJITTypeName(JITTypeTag type_tag) {
       return JITTypeTraits<JITTypeTag::TUPLE>::name;
     case JITTypeTag::STRUCT:
       return JITTypeTraits<JITTypeTag::STRUCT>::name;
+    case JITTypeTag::INT128:
+      return JITTypeTraits<JITTypeTag::INT128>::name;
     default:
       LOG(ERROR) << "Invalid JITType in getJITTypeName";
   }
@@ -206,6 +219,8 @@ inline uint64_t getJITTypeSize(JITTypeTag type_tag) {
       return JITTypeTraits<JITTypeTag::INT32>::width;
     case JITTypeTag::INT64:
       return JITTypeTraits<JITTypeTag::INT64>::width;
+    case JITTypeTag::INT128:
+      return JITTypeTraits<JITTypeTag::INT128>::width;
     case JITTypeTag::FLOAT:
       return JITTypeTraits<JITTypeTag::FLOAT>::width;
     case JITTypeTag::DOUBLE:
@@ -232,6 +247,8 @@ inline std::any castLiteral(JITTypeTag target_type, T value) {
     case JITTypeTag::INT64:
     case JITTypeTag::POINTER:
       return static_cast<JITTypeTraits<JITTypeTag::INT64>::NativeType>(value);
+    case JITTypeTag::INT128:
+      return static_cast<JITTypeTraits<JITTypeTag::INT128>::NativeType>(value);
     case JITTypeTag::FLOAT:
       return static_cast<JITTypeTraits<JITTypeTag::FLOAT>::NativeType>(value);
     case JITTypeTag::DOUBLE:

--- a/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITFunction.cpp
+++ b/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITFunction.cpp
@@ -122,11 +122,8 @@ llvm::Value* createConstantImpl(llvm::LLVMContext& context, const std::any& valu
   NativeType actual_value = std::any_cast<NativeType>(value);
   if constexpr (std::is_floating_point_v<NativeType>) {
     return getLLVMConstantFP(actual_value, type_tag, context);
-  } else if (JITTypeTraits<type_tag>::bits > 64) {
-    CHECK(JITTypeTraits<type_tag>::bits == 128);
-    return getLLVMConstantInt128(actual_value, type_tag, context);
   } else {
-    return getLLVMConstantInt(actual_value, type_tag, context);
+    return getLLVMConstantInt<type_tag>(actual_value, context);
   }
 }
 
@@ -309,7 +306,7 @@ JITValuePointer LLVMJITFunction::packJITValuesImpl(
 
   llvm::AllocaInst* allocated_memory = ir_builder_->CreateAlloca(
       llvm::Type::getInt8Ty(getLLVMContext()),
-      getLLVMConstantInt(memory_count, JITTypeTag::INT64, getLLVMContext()));
+      getLLVMConstantInt<JITTypeTag::INT64>(memory_count, getLLVMContext()));
   auto start_address = allocated_memory;
   auto start_val = makeJITValuePointer<LLVMJITValue>(JITTypeTag::POINTER,
                                                      *this,

--- a/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITFunction.cpp
+++ b/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITFunction.cpp
@@ -122,6 +122,9 @@ llvm::Value* createConstantImpl(llvm::LLVMContext& context, const std::any& valu
   NativeType actual_value = std::any_cast<NativeType>(value);
   if constexpr (std::is_floating_point_v<NativeType>) {
     return getLLVMConstantFP(actual_value, type_tag, context);
+  } else if (JITTypeTraits<type_tag>::bits > 64) {
+    CHECK(JITTypeTraits<type_tag>::bits == 128);
+    return getLLVMConstantInt128(actual_value, type_tag, context);
   } else {
     return getLLVMConstantInt(actual_value, type_tag, context);
   }
@@ -158,6 +161,9 @@ JITValuePointer LLVMJITFunction::createLiteralImpl(JITTypeTag type_tag,
       type_tag = JITTypeTag::INT64;
     case JITTypeTag::INT64:
       llvm_value = createConstantImpl<JITTypeTag::INT64>(getLLVMContext(), value);
+      break;
+    case JITTypeTag::INT128:
+      llvm_value = createConstantImpl<JITTypeTag::INT128>(getLLVMContext(), value);
       break;
     case JITTypeTag::FLOAT:
       llvm_value = createConstantImpl<JITTypeTag::FLOAT>(getLLVMContext(), value);

--- a/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITUtils.h
+++ b/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITUtils.h
@@ -41,6 +41,8 @@ inline llvm::Type* getLLVMType(JITTypeTag tag, llvm::LLVMContext& ctx) {
       return llvm::Type::getInt32Ty(ctx);
     case JITTypeTag::INT64:
       return llvm::Type::getInt64Ty(ctx);
+    case JITTypeTag::INT128:
+      return llvm::Type::getInt128Ty(ctx);
     case JITTypeTag::FLOAT:
       return llvm::Type::getFloatTy(ctx);
     case JITTypeTag::DOUBLE:
@@ -85,6 +87,13 @@ inline llvm::Value* getLLVMConstantInt(uint64_t value,
     default:
       return nullptr;
   }
+}
+
+inline llvm::Value* getLLVMConstantInt128(__int128_t value,
+                                          JITTypeTag tag,
+                                          llvm::LLVMContext& ctx) {
+  return llvm::ConstantInt::get(
+      ctx, ((llvm::APInt(128, value >> 64) << 64) | llvm::APInt(128, (uint64_t)value)));
 }
 
 inline llvm::Value* getLLVMConstantFP(double value,

--- a/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITUtils.h
+++ b/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITUtils.h
@@ -73,27 +73,24 @@ inline llvm::PointerType* getLLVMPtrType(JITTypeTag sub_tag, llvm::LLVMContext& 
   }
 }
 
-inline llvm::Value* getLLVMConstantInt(uint64_t value,
-                                       JITTypeTag tag,
-                                       llvm::LLVMContext& ctx) {
-  llvm::Type* type = getLLVMType(tag, ctx);
-  switch (tag) {
+template <JITTypeTag type_tag,
+          typename NativeType = typename JITTypeTraits<type_tag>::NativeType>
+inline llvm::Value* getLLVMConstantInt(NativeType value, llvm::LLVMContext& ctx) {
+  llvm::Type* type = getLLVMType(type_tag, ctx);
+  switch (type_tag) {
     case JITTypeTag::BOOL:
     case JITTypeTag::INT8:
     case JITTypeTag::INT16:
     case JITTypeTag::INT32:
     case JITTypeTag::INT64:
-      return llvm::ConstantInt::get(type, value, true);
+      return llvm::ConstantInt::get(type, (uint64_t)value, true);
+    case JITTypeTag::INT128:
+      return llvm::ConstantInt::get(
+          ctx,
+          ((llvm::APInt(128, value >> 64) << 64) | llvm::APInt(128, (uint64_t)value)));
     default:
       return nullptr;
   }
-}
-
-inline llvm::Value* getLLVMConstantInt128(__int128_t value,
-                                          JITTypeTag tag,
-                                          llvm::LLVMContext& ctx) {
-  return llvm::ConstantInt::get(
-      ctx, ((llvm::APInt(128, value >> 64) << 64) | llvm::APInt(128, (uint64_t)value)));
 }
 
 inline llvm::Value* getLLVMConstantFP(double value,

--- a/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
+++ b/cpp/src/cider/exec/nextgen/jitlib/llvmjit/LLVMJITValue.cpp
@@ -108,6 +108,7 @@ JITValuePointer LLVMJITValue::uminus() {
     case JITTypeTag::INT16:
     case JITTypeTag::INT32:
     case JITTypeTag::INT64:
+    case JITTypeTag::INT128:
       ans = getFunctionBuilder(parent_function_).CreateNeg(load());
       break;
     case JITTypeTag::FLOAT:
@@ -132,6 +133,7 @@ JITValuePointer LLVMJITValue::mod(JITValue& rh) {
     case JITTypeTag::INT16:
     case JITTypeTag::INT32:
     case JITTypeTag::INT64:
+    case JITTypeTag::INT128:
       ans = getFunctionBuilder(parent_function_).CreateSRem(load(), llvm_rh.load());
       break;
     case JITTypeTag::FLOAT:
@@ -173,6 +175,7 @@ JITValuePointer LLVMJITValue::div(JITValue& rh) {
     case JITTypeTag::INT16:
     case JITTypeTag::INT32:
     case JITTypeTag::INT64:
+    case JITTypeTag::INT128:
       ans = getFunctionBuilder(parent_function_).CreateSDiv(load(), llvm_rh.load());
       break;
     case JITTypeTag::FLOAT:
@@ -214,6 +217,7 @@ JITValuePointer LLVMJITValue::mul(JITValue& rh) {
     case JITTypeTag::INT16:
     case JITTypeTag::INT32:
     case JITTypeTag::INT64:
+    case JITTypeTag::INT128:
       ans = getFunctionBuilder(parent_function_).CreateMul(load(), llvm_rh.load());
       break;
     case JITTypeTag::FLOAT:
@@ -280,6 +284,7 @@ JITValuePointer LLVMJITValue::sub(JITValue& rh) {
     case JITTypeTag::INT16:
     case JITTypeTag::INT32:
     case JITTypeTag::INT64:
+    case JITTypeTag::INT128:
       ans = getFunctionBuilder(parent_function_).CreateSub(load(), llvm_rh.load());
       break;
     case JITTypeTag::FLOAT:
@@ -356,6 +361,7 @@ JITValuePointer LLVMJITValue::add(JITValue& rh) {
     case JITTypeTag::INT16:
     case JITTypeTag::INT32:
     case JITTypeTag::INT64:
+    case JITTypeTag::INT128:
       ans = getFunctionBuilder(parent_function_).CreateAdd(load(), llvm_rh.load());
       break;
     case JITTypeTag::FLOAT:
@@ -448,6 +454,7 @@ JITValuePointer LLVMJITValue::createCmpInstruction(llvm::CmpInst::Predicate ICmp
     case JITTypeTag::INT16:
     case JITTypeTag::INT32:
     case JITTypeTag::INT64:
+    case JITTypeTag::INT128:
       ans = getFunctionBuilder(parent_function_)
                 .CreateICmp(ICmpType, load(), llvm_rh.load());
       break;

--- a/cpp/src/cider/tests/nextgen/jitlib/JITLibTest.cpp
+++ b/cpp/src/cider/tests/nextgen/jitlib/JITLibTest.cpp
@@ -764,6 +764,39 @@ TEST_F(JITLibTests, PackJITValueTest) {
   EXPECT_EQ(result, true);
 }
 
+TEST_F(JITLibTests, DecimalMathOpTest) {
+  int64_t a_dec_arr[2] = {1, 1};
+  int64_t b_dec_arr[2] = {2, 2};
+  int64_t c_dec_arr[2] = {3, 3};
+  __int128_t a = (__int128_t(a_dec_arr[0]) << 64) | a_dec_arr[1];
+  __int128_t b = (__int128_t(b_dec_arr[0]) << 64) | b_dec_arr[1];
+  __int128_t c = (__int128_t(c_dec_arr[0]) << 64) | c_dec_arr[1];
+  // variable a, constant b, expected c
+  executeBinaryOp<JITTypeTag::INT128>(
+      a, b, c, [](JITValue& a, JITValue& b) { return a + b; });
+
+  executeBinaryOp<JITTypeTag::INT128>(
+      a, b, __int128_t(1), [](JITValue& a, JITValue& b) { return -b + 2 * a + 1; });
+
+  executeBinaryOp<JITTypeTag::INT128>(
+      a, b, __int128_t(1), [](JITValue& a, JITValue& b) { return b / 2 - a + 1; });
+}
+
+TEST_F(JITLibTests, DecimalCmpOpTest) {
+  int64_t a_dec_arr[2] = {1, 1};
+  int64_t b_dec_arr[2] = {2, 2};
+  __int128_t a = (__int128_t(a_dec_arr[0]) << 64) | a_dec_arr[1];
+  __int128_t b = (__int128_t(b_dec_arr[0]) << 64) | b_dec_arr[1];
+  executeCompareOp<JITTypeTag::INT128>(
+      a, b, true, [](JITValue& a, JITValue& b) { return b == a * 2; });
+
+  executeCompareOp<JITTypeTag::INT128>(
+      a, b, false, [](JITValue& a, JITValue& b) { return b / 2 != a; });
+
+  executeCompareOp<JITTypeTag::INT128>(
+      a, b, true, [](JITValue& a, JITValue& b) { return 0 == b % a; });
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://wiki.ith.intel.com/display/MOIN/How+to+contribute#Howtocontribute-CodeDevelopment&Review
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][POAE7-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation MIP, please add the link. https://wiki.ith.intel.com/display/MOIN/MIP+template
  4. If there is a discussion in the mailing list, please add the link.
-->
arrow decimal type(int128) & base ops(math/cmp）support in jitlib level

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Use llvm Int128 type to impl the underlying calculation of decimal type
complete steps including：
- Aligns the decimal points of lvalue and rvalue by adjusting to the same scale.
- **int128 basic ops**
- Place the right decimal point of the result value.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UTs
### Which label does this PR belong to?
<!-- 
If the label supposed to be bug, coderefactor or infra. Please use the UPPER case of these three words. For other labels: 
veloxIntegration, cider, documentation, CICD, test, benchmark, publicApi,  they are not need to be specified here. And try to ensure that the capitalization of the above three words does not appear in the PR as much as possible.
-->
