### PR TITLE
[POAE7-2849] Enable dictionary encoding string for nextgen query engine.

### DIFF
--- a/cpp/src/cider/exec/nextgen/context/CodegenContext.cpp
+++ b/cpp/src/cider/exec/nextgen/context/CodegenContext.cpp
@@ -263,6 +263,21 @@ jitlib::JITValuePointer getArrowArrayChild(jitlib::JITValuePointer& arrow_array,
   return ret;
 }
 
+jitlib::JITValuePointer getArrowArrayDictionary(jitlib::JITValuePointer& arrow_array) {
+  CHECK(arrow_array->getValueTypeTag() == JITTypeTag::POINTER);
+  CHECK(arrow_array->getValueSubTypeTag() == JITTypeTag::INT8);
+
+  auto& func = arrow_array->getParentJITFunction();
+  auto ret = func.emitRuntimeFunctionCall(
+      "extract_arrow_array_dictionary",
+      JITFunctionEmitDescriptor{.ret_type = JITTypeTag::POINTER,
+                                .ret_sub_type = JITTypeTag::INT8,
+                                .params_vector = {arrow_array.get()}});
+
+  ret->setName("child_dictionary");
+  return ret;
+}
+
 jitlib::JITValuePointer allocateArrowArrayBuffer(jitlib::JITValuePointer& arrow_array,
                                                  int64_t index,
                                                  jitlib::JITValuePointer& bytes) {

--- a/cpp/src/cider/exec/nextgen/context/CodegenContext.h
+++ b/cpp/src/cider/exec/nextgen/context/CodegenContext.h
@@ -248,6 +248,8 @@ jitlib::JITValuePointer getArrowArrayBuffer(jitlib::JITValuePointer& arrow_array
 jitlib::JITValuePointer getArrowArrayChild(jitlib::JITValuePointer& arrow_array,
                                            int64_t index);
 
+jitlib::JITValuePointer getArrowArrayDictionary(jitlib::JITValuePointer& arrow_array);
+
 jitlib::JITValuePointer allocateArrowArrayBuffer(jitlib::JITValuePointer& arrow_array,
                                                  int64_t index,
                                                  jitlib::JITValuePointer& bytes);

--- a/cpp/src/cider/exec/nextgen/context/ContextRuntimeFunctions.h
+++ b/cpp/src/cider/exec/nextgen/context/ContextRuntimeFunctions.h
@@ -61,9 +61,9 @@ extern "C" ALWAYS_INLINE void* extract_arrow_array_child(int8_t* arrow_pointer,
   return reinterpret_cast<void*>(array->children[index]);
 }
 
-extern "C" ALWAYS_INLINE void* extract_arrow_array_dictionary(int8_t* arrow_pointer) {
+extern "C" ALWAYS_INLINE int8_t* extract_arrow_array_dictionary(int8_t* arrow_pointer) {
   ArrowArray* array = reinterpret_cast<ArrowArray*>(arrow_pointer);
-  return reinterpret_cast<void*>(array->dictionary);
+  return reinterpret_cast<int8_t*>(array->dictionary);
 }
 
 extern "C" ALWAYS_INLINE int64_t extract_arrow_array_len(int8_t* arrow_pointer) {

--- a/cpp/src/cider/exec/nextgen/context/ContextRuntimeFunctions.h
+++ b/cpp/src/cider/exec/nextgen/context/ContextRuntimeFunctions.h
@@ -61,6 +61,11 @@ extern "C" ALWAYS_INLINE void* extract_arrow_array_child(int8_t* arrow_pointer,
   return reinterpret_cast<void*>(array->children[index]);
 }
 
+extern "C" ALWAYS_INLINE void* extract_arrow_array_dictionary(int8_t* arrow_pointer) {
+  ArrowArray* array = reinterpret_cast<ArrowArray*>(arrow_pointer);
+  return reinterpret_cast<void*>(array->dictionary);
+}
+
 extern "C" ALWAYS_INLINE int64_t extract_arrow_array_len(int8_t* arrow_pointer) {
   ArrowArray* array = reinterpret_cast<ArrowArray*>(arrow_pointer);
   return array->length;

--- a/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
@@ -68,13 +68,9 @@ class ColumnReader {
   void readVariableSizeTypeCol() {
     auto&& [batch, buffers] = context_.getArrowArrayValues(expr_->getLocalIndex());
     utils::VarSizeJITExprValue varsize_values(buffers);
-
     auto& func = batch->getParentJITFunction();
-
     auto dictionary =
         varsize_values.getDictionary()->castPointerSubType(JITTypeTag::INT8);
-
-    auto ifBuilder = func.createIfBuilder();
 
     JITValuePointer len = func.emitRuntimeFunctionCall(
         "get_str_length_from_dictionary_or_buffer",

--- a/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/ColumnToRowNode.cpp
@@ -71,14 +71,65 @@ class ColumnReader {
 
     auto& func = batch->getParentJITFunction();
 
-    // offset buffer
-    auto offset_pointer =
-        varsize_values.getLength()->castPointerSubType(JITTypeTag::INT32);
-    auto len = offset_pointer[index_ + 1] - offset_pointer[index_];
-    auto cur_offset = offset_pointer[index_];
-    // data buffer
-    auto value_pointer = varsize_values.getValue()->castPointerSubType(JITTypeTag::INT8);
-    auto row_data = value_pointer + cur_offset;  // still char*
+    auto dictionary =
+        varsize_values.getDictionary()->castPointerSubType(JITTypeTag::INT8);
+
+    auto ifBuilder = func.createIfBuilder();
+    JITValuePointer len;
+    JITValuePointer row_data;
+
+    ifBuilder
+        ->condition([&]() {  // check whether have dictionary
+          auto isDictionaryEncoded = func.emitRuntimeFunctionCall(
+              "check_dictionary_is_null",
+              JITFunctionEmitDescriptor{.ret_type = JITTypeTag::BOOL,
+                                        .params_vector = {dictionary.get()}});
+          return isDictionaryEncoded;
+        })
+        ->ifFalse([&]() {
+          if (for_null) {
+            if (expr_->get_type_info().get_notnull()) {
+              expr_->set_expr_null(func.createLiteral(JITTypeTag::BOOL, false));
+            } else {
+              auto row_null_data = varsize_values.getNull()[index_];
+              expr_->set_expr_null(row_null_data);
+            }
+            return;
+          }
+
+          len = func.emitRuntimeFunctionCall(
+              "get_str_length_from_dictionary",
+              JITFunctionEmitDescriptor{
+                  .ret_type = JITTypeTag::INT32,
+                  .params_vector = {{dictionary.get(), index_.get()}}});
+          row_data = func.emitRuntimeFunctionCall(
+              "get_str_ptr_from_dictionary",
+              JITFunctionEmitDescriptor{
+                  .ret_type = JITTypeTag::POINTER,
+                  .params_vector = {{dictionary.get(), index_.get()}}});
+        })
+        ->ifTrue([&]() {
+          if (for_null) {
+            if (expr_->get_type_info().get_notnull()) {
+              expr_->set_expr_null(func.createLiteral(JITTypeTag::BOOL, false));
+            } else {
+              auto row_null_data = varsize_values.getNull()[index_];
+              expr_->set_expr_null(row_null_data);
+            }
+            return;
+          }
+
+          // offset buffer
+          auto offset_pointer =
+              varsize_values.getLength()->castPointerSubType(JITTypeTag::INT32);
+          len = offset_pointer[index_ + 1] - offset_pointer[index_];  //
+          auto cur_offset = offset_pointer[index_];
+          // data buffer
+          auto value_pointer =
+              varsize_values.getValue()->castPointerSubType(JITTypeTag::INT8);
+          row_data = value_pointer + cur_offset;  // still char*//
+        })
+        ->build();
 
     if (expr_->get_type_info().get_notnull()) {
       expr_->set_expr_value(func.createLiteral(JITTypeTag::BOOL, false), len, row_data);

--- a/cpp/src/cider/exec/nextgen/operators/QueryFuncInitializer.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/QueryFuncInitializer.cpp
@@ -75,10 +75,16 @@ void QueryFuncInitializerTranslator::codegen(context::CodegenContext& context) {
       }
     }
 
-    // append dictionary buffer as last element.
-    buffer_values.append(func->createLocalJITValue([&child_array]() {
-      return context::codegen_utils::getArrowArrayDictionary(child_array);
-    }));
+    if (col_var_expr->get_type_info().get_type() == kTEXT ||
+        col_var_expr->get_type_info().get_type() == kVARCHAR ||
+        col_var_expr->get_type_info().get_type() == kCHAR) {
+      // append dictionary buffer as last element if this is a string column, and if
+      // string dictionary is valid, the second pointer will be index in dictionary, the
+      // third pointer will be invalid.
+      buffer_values.append(func->createLocalJITValue([&child_array]() {
+        return context::codegen_utils::getArrowArrayDictionary(child_array);
+      }));
+    }
 
     // All ArrowArray related JITValues will be saved in CodegenContext, and associate
     // with exprs with local_offset.

--- a/cpp/src/cider/exec/nextgen/operators/QueryFuncInitializer.cpp
+++ b/cpp/src/cider/exec/nextgen/operators/QueryFuncInitializer.cpp
@@ -75,6 +75,11 @@ void QueryFuncInitializerTranslator::codegen(context::CodegenContext& context) {
       }
     }
 
+    // append dictionary buffer as last element.
+    buffer_values.append(func->createLocalJITValue([&child_array]() {
+      return context::codegen_utils::getArrowArrayDictionary(child_array);
+    }));
+
     // All ArrowArray related JITValues will be saved in CodegenContext, and associate
     // with exprs with local_offset.
     size_t local_offset =

--- a/cpp/src/cider/exec/nextgen/utils/JITExprValue.h
+++ b/cpp/src/cider/exec/nextgen/utils/JITExprValue.h
@@ -109,11 +109,14 @@ class FixSizeJITExprValue : public JITExprValueAdaptor {
 class VarSizeJITExprValue : public JITExprValueAdaptor {
  public:
   explicit VarSizeJITExprValue(JITExprValue& values) : JITExprValueAdaptor(values) {
-    values_.resize(3);
+    values_.resize(4);
   }
   jitlib::JITValuePointer& getLength() { return values_[1]; }
 
   jitlib::JITValuePointer& getValue() { return values_[2]; }
+
+  // For dictionary
+  jitlib::JITValuePointer& getDictionary() { return values_[3]; }
 };
 
 class VarSizeArrayExprValue : public JITExprValueAdaptor {

--- a/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
+++ b/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
@@ -1439,7 +1439,6 @@ extern "C" bool check_interrupt_init(unsigned command) {
 
 extern "C" ALWAYS_INLINE bool check_dictionary_is_null(int8_t* dictionary) {
   bool ret = dictionary == nullptr;
-  printf("is null: %d\n", ret);
   return ret;
 }
 
@@ -1462,28 +1461,31 @@ extern "C" ALWAYS_INLINE const int8_t* get_str_ptr_from_dictionary(int8_t* dicti
 
 extern "C" ALWAYS_INLINE const int32_t
 get_str_length_from_dictionary_or_buffer(int8_t* dictionary,
-                               uint64_t index,
-                               int32_t* offset_buffer) {
+                                         uint64_t index,
+                                         int32_t* offset_buffer) {
   if (dictionary) {
     const int32_t* actual_offset_buffer = reinterpret_cast<const int32_t*>(
         reinterpret_cast<ArrowArray*>(dictionary)->buffers[1]);
-    return actual_offset_buffer[index + 1] - actual_offset_buffer[index];
+    int32_t index_in_dict = offset_buffer[index];
+    int len = actual_offset_buffer[index_in_dict + 1] - actual_offset_buffer[index_in_dict];
+    return len;
   } else {
     return offset_buffer[index + 1] - offset_buffer[index];
   }
 }
 
-extern "C" ALWAYS_INLINE const int8_t* get_str_ptr_from_dictionary_or_buffer(int8_t* dictionary,
-                                                                   uint64_t index,
-                                                                   int32_t* offset_buffer,
-                                                                   int8_t* data_buffer) {
+extern "C" ALWAYS_INLINE const int8_t* get_str_ptr_from_dictionary_or_buffer(
+    int8_t* dictionary,
+    uint64_t index,
+    int32_t* offset_buffer,
+    int8_t* data_buffer) {
   if (dictionary) {
+    int32_t index_in_dict = offset_buffer[index];
     const int32_t* actual_offset_buffer = reinterpret_cast<const int32_t*>(
         reinterpret_cast<ArrowArray*>(dictionary)->buffers[1]);
     const int8_t* actual_data_buffer = reinterpret_cast<const int8_t*>(
         reinterpret_cast<ArrowArray*>(dictionary)->buffers[2]);
-
-    return actual_data_buffer + actual_offset_buffer[index];
+    return actual_data_buffer + actual_offset_buffer[index_in_dict];
   } else {
     return data_buffer + offset_buffer[index];
   }

--- a/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
+++ b/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
@@ -20,11 +20,11 @@
  * under the License.
  */
 
-#include "function/scalar/RuntimeFunctions.h"
 #include "exec/template/BufferCompaction.h"
 #include "exec/template/HyperLogLogRank.h"
 #include "exec/template/TypePunning.h"
 #include "function/hash/MurmurHash.h"
+#include "function/scalar/RuntimeFunctions.h"
 #include "type/data/funcannotations.h"
 #include "util/CiderBitUtils.h"
 #include "util/quantile.h"
@@ -1435,6 +1435,29 @@ extern "C" bool check_interrupt_init(unsigned command) {
     return false;
   }
   return false;
+}
+
+extern "C" ALWAYS_INLINE bool check_dictionary_is_null(int8_t* dictionary) {
+  bool ret = dictionary == nullptr;
+  printf("is null: %d\n", ret);
+  return ret;
+}
+
+extern "C" ALWAYS_INLINE int get_str_length_from_dictionary(int8_t* dictionary,
+                                                            uint64_t index) {
+  const int32_t* offset_buffer = reinterpret_cast<const int32_t*>(
+      reinterpret_cast<ArrowArray*>(dictionary)->buffers[1]);
+  return offset_buffer[index + 1] - offset_buffer[index];
+}
+
+extern "C" ALWAYS_INLINE const int8_t* get_str_ptr_from_dictionary(int8_t* dictionary,
+                                                                   uint64_t index) {
+  const int32_t* offset_buffer = reinterpret_cast<const int32_t*>(
+      reinterpret_cast<ArrowArray*>(dictionary)->buffers[1]);
+  const int8_t* data_buffer = reinterpret_cast<const int8_t*>(
+      reinterpret_cast<ArrowArray*>(dictionary)->buffers[2]);
+
+  return data_buffer + offset_buffer[index];
 }
 
 extern "C" ALWAYS_INLINE bool check_bit_vector_set(uint8_t* bit_vector, uint64_t index) {

--- a/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
+++ b/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
@@ -1460,6 +1460,35 @@ extern "C" ALWAYS_INLINE const int8_t* get_str_ptr_from_dictionary(int8_t* dicti
   return data_buffer + offset_buffer[index];
 }
 
+extern "C" ALWAYS_INLINE const int32_t
+get_str_length_from_dictionary_or_buffer(int8_t* dictionary,
+                               uint64_t index,
+                               int32_t* offset_buffer) {
+  if (dictionary) {
+    const int32_t* actual_offset_buffer = reinterpret_cast<const int32_t*>(
+        reinterpret_cast<ArrowArray*>(dictionary)->buffers[1]);
+    return actual_offset_buffer[index + 1] - actual_offset_buffer[index];
+  } else {
+    return offset_buffer[index + 1] - offset_buffer[index];
+  }
+}
+
+extern "C" ALWAYS_INLINE const int8_t* get_str_ptr_from_dictionary_or_buffer(int8_t* dictionary,
+                                                                   uint64_t index,
+                                                                   int32_t* offset_buffer,
+                                                                   int8_t* data_buffer) {
+  if (dictionary) {
+    const int32_t* actual_offset_buffer = reinterpret_cast<const int32_t*>(
+        reinterpret_cast<ArrowArray*>(dictionary)->buffers[1]);
+    const int8_t* actual_data_buffer = reinterpret_cast<const int8_t*>(
+        reinterpret_cast<ArrowArray*>(dictionary)->buffers[2]);
+
+    return actual_data_buffer + actual_offset_buffer[index];
+  } else {
+    return data_buffer + offset_buffer[index];
+  }
+}
+
 extern "C" ALWAYS_INLINE bool check_bit_vector_set(uint8_t* bit_vector, uint64_t index) {
   return CiderBitUtils::isBitSetAt(bit_vector, index);
 }

--- a/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
+++ b/cpp/src/cider/function/scalar/RuntimeFunctions.cpp
@@ -20,11 +20,11 @@
  * under the License.
  */
 
+#include "function/scalar/RuntimeFunctions.h"
 #include "exec/template/BufferCompaction.h"
 #include "exec/template/HyperLogLogRank.h"
 #include "exec/template/TypePunning.h"
 #include "function/hash/MurmurHash.h"
-#include "function/scalar/RuntimeFunctions.h"
 #include "type/data/funcannotations.h"
 #include "util/CiderBitUtils.h"
 #include "util/quantile.h"
@@ -1467,7 +1467,8 @@ get_str_length_from_dictionary_or_buffer(int8_t* dictionary,
     const int32_t* actual_offset_buffer = reinterpret_cast<const int32_t*>(
         reinterpret_cast<ArrowArray*>(dictionary)->buffers[1]);
     int32_t index_in_dict = offset_buffer[index];
-    int len = actual_offset_buffer[index_in_dict + 1] - actual_offset_buffer[index_in_dict];
+    int len =
+        actual_offset_buffer[index_in_dict + 1] - actual_offset_buffer[index_in_dict];
     return len;
   } else {
     return offset_buffer[index + 1] - offset_buffer[index];

--- a/cpp/src/cider/tests/nextgen/functional/StringTest.cpp
+++ b/cpp/src/cider/tests/nextgen/functional/StringTest.cpp
@@ -481,13 +481,12 @@ class CiderTrimOpTestNextGen : public CiderNextgenTestBase {
                                                "   3456789",
                                                "   3      ",
                                                "   3      ",
-                                                 "",
+                                               "",
                                                "",
                                                "0123456   ",
                                                "0123456   ",
                                                "xxx3456   ",
-                                               "xxx3456   "
-                                             };
+                                               "xxx3456   "};
     auto is_null = std::vector<bool>{
         false, true, false, true, false, true, false, true, false, true, false, true};
     auto [vc_data, vc_offsets] =

--- a/cpp/src/cider/tests/nextgen/functional/StringTest.cpp
+++ b/cpp/src/cider/tests/nextgen/functional/StringTest.cpp
@@ -481,12 +481,12 @@ class CiderTrimOpTestNextGen : public CiderNextgenTestBase {
                                                "   3456789",
                                                "   3      ",
                                                "   3      ",
-                                               "",
-                                               "",
                                                "0123456   ",
                                                "0123456   ",
                                                "xxx3456   ",
-                                               "xxx3456   "};
+                                               "xxx3456   ",
+                                               "",
+                                               ""};
     auto is_null = std::vector<bool>{
         false, true, false, true, false, true, false, true, false, true, false, true};
     auto [vc_data, vc_offsets] =

--- a/cpp/src/cider/tests/utils/DuckDbQueryRunner.cpp
+++ b/cpp/src/cider/tests/utils/DuckDbQueryRunner.cpp
@@ -305,9 +305,18 @@ template <>
         CIDER_THROW(CiderException, "not supported time type to gen duck value");        \
       }                                                                                  \
       case 'u': {                                                                        \
-        return duckValueVarcharAt(static_cast<const int8_t*>(child_array->buffers[2]),   \
-                                  static_cast<const int32_t*>(child_array->buffers[1]),  \
-                                  row_idx);                                              \
+        if (child_array->dictionary) {                                                   \
+          int32_t offset = ((int32_t*)(child_array->buffers[1]))[row_idx];               \
+          return duckValueVarcharAt(                                                     \
+              static_cast<const int8_t*>(child_array->dictionary->buffers[2]),           \
+              static_cast<const int32_t*>(child_array->dictionary->buffers[1]),          \
+              offset);                                                                   \
+        } else {                                                                         \
+          return duckValueVarcharAt(                                                     \
+              static_cast<const int8_t*>(child_array->buffers[2]),                       \
+              static_cast<const int32_t*>(child_array->buffers[1]),                      \
+              row_idx);                                                                  \
+        }                                                                                \
       }                                                                                  \
       default:                                                                           \
         CIDER_THROW(CiderException, "not supported type to gen duck value");             \


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://wiki.ith.intel.com/display/MOIN/How+to+contribute#Howtocontribute-CodeDevelopment&Review
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][POAE7-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation MIP, please add the link. https://wiki.ith.intel.com/display/MOIN/MIP+template
  4. If there is a discussion in the mailing list, please add the link.
-->
Enable dictionary encoding string for nextgen query engine. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In e2e test, velox will convert dictionary encoded row vector to dictionary encoded arrow array which are not supported in nextgen column reader before.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT.
### Which label does this PR belong to?
<!-- 
If the label supposed to be bug, coderefactor or infra. Please use the UPPER case of these three words. For other labels: 
veloxIntegration, cider, documentation, CICD, test, benchmark, publicApi,  they are not need to be specified here. And try to ensure that the capitalization of the above three words does not appear in the PR as much as possible.
-->
