### PR TITLE
Fix core dump when HashTable is enabled in codegen

### DIFF
--- a/cpp/src/cider/exec/nextgen/context/CodegenContext.h
+++ b/cpp/src/cider/exec/nextgen/context/CodegenContext.h
@@ -21,6 +21,7 @@
 #ifndef NEXTGEN_CONTEXT_CODEGENCONTEXT_H
 #define NEXTGEN_CONTEXT_CODEGENCONTEXT_H
 
+#include "common/interpreters/AggregationHashTable.h"
 #include "exec/nextgen/context/Buffer.h"
 #include "exec/nextgen/context/CiderSet.h"
 #include "exec/nextgen/jitlib/JITLib.h"


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Remove some `boost` dependencies.
2. Enable `AggregationHashTable` in codegen.


### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.

### Which label does this PR belong to?

