### PR TITLE
[POAE7-2878] Add FixedJoinHashMap for Int8 and Int16 to JoinHashTable

### DIFF
--- a/cpp/src/cider/common/hashtable/FixedHashMap.h
+++ b/cpp/src/cider/common/hashtable/FixedHashMap.h
@@ -23,7 +23,9 @@
 #pragma once
 
 #include <common/hashtable/FixedHashTable.h>
+#include <common/hashtable/FixedJoinHashTable.h>
 #include <common/hashtable/HashMap.h>
+#include <vector>
 
 namespace cider::hashtable {
 template <typename Key, typename TMapped, typename TState = HashTableNoState>
@@ -116,6 +118,52 @@ struct FixedHashMapImplicitZeroCell {
   };
 };
 
+// In case when we can encode empty cells with zero mapped values.
+template <typename Key, typename TMapped, typename TState = HashTableNoState>
+struct FixedJoinHashMapCell {
+  using Mapped = TMapped;
+  using State = TState;
+
+  using value_type = PairNoInit<Key, std::vector<Mapped>>;
+  using mapped_type = TMapped;
+
+  std::vector<Mapped> mapped;
+
+  FixedJoinHashMapCell() {}
+  FixedJoinHashMapCell(const Key&, const State&) {}
+  FixedJoinHashMapCell(const value_type& value_, const State&) : mapped(value_.second) {}
+
+  const VoidKey getKey() const { return {}; }
+  std::vector<Mapped> getMapped() { return mapped; }
+  const std::vector<Mapped> getMapped() const { return mapped; }
+
+  void put(Mapped value) { mapped.emplace_back(value); }
+
+  bool isZero(const State&) const { return mapped.size() == 0; }
+  void setZero() { mapped.clear(); }
+
+  // Similar to FixedHashSetCell except that we need to contain a pointer to the Mapped
+  // field.
+  // Note that we have to assemble a continuous layout for the value_type on each call
+  // of getValue().
+  struct CellExt {
+    CellExt() {}
+    CellExt(Key&& key_, const FixedJoinHashMapCell* ptr_)
+        : key(key_), ptr(const_cast<FixedJoinHashMapCell*>(ptr_)) {}
+    void update(Key&& key_, const FixedJoinHashMapCell* ptr_) {
+      key = key_;
+      ptr = const_cast<FixedJoinHashMapCell*>(ptr_);
+    }
+    Key key;
+    FixedJoinHashMapCell* ptr;
+
+    const Key& getKey() const { return key; }
+    std::vector<Mapped> getMapped() { return ptr->mapped; }
+    const std::vector<Mapped> getMapped() const { return ptr->mapped; }
+    const value_type getValue() const { return {key, ptr->mapped}; }
+  };
+};
+
 template <typename Key,
           typename Mapped,
           typename Cell = FixedHashMapCell<Key, Mapped>,
@@ -173,6 +221,72 @@ class FixedHashMap : public FixedHashTable<Key, Cell, Size, Allocator> {
   }
 };
 
+template <typename Key,
+          typename Mapped,
+          typename Cell = FixedJoinHashMapCell<Key, Mapped>,
+          typename Size = FixedJoinHashTableStoredSize<Cell>,
+          typename Allocator = HashTableAllocator>
+class FixedJoinHashMap : public FixedJoinHashTable<Key, Cell, Size, Allocator> {
+ public:
+  using Base = FixedJoinHashTable<Key, Cell, Size, Allocator>;
+  using Self = FixedJoinHashMap;
+  using LookupResult = typename Base::LookupResult;
+
+  using Base::Base;
+
+  template <typename Func, bool>
+  void ALWAYS_INLINE mergeToViaEmplace(Self& that, Func&& func) {
+    for (auto it = this->begin(), end = this->end(); it != end; ++it) {
+      typename Self::LookupResult res_it;
+      bool inserted;
+      that.emplace(it->getKey(), res_it, inserted, it.getHash());
+      func(res_it->getMapped(), it->getMapped(), inserted);
+    }
+  }
+
+  template <typename Func>
+  void ALWAYS_INLINE mergeToViaFind(Self& that, Func&& func) {
+    for (auto it = this->begin(), end = this->end(); it != end; ++it) {
+      auto res_it = that.find(it->getKey(), it.getHash());
+      if (!res_it)
+        func(it->getMapped(), it->getMapped(), false);
+      else
+        func(res_it->getMapped(), it->getMapped(), true);
+    }
+  }
+
+  void ALWAYS_INLINE merge_other_hashtables(Self& that) {
+    for (auto it = this->begin(), end = this->end(); it != end; ++it) {
+      auto res_it = that.find(it->getKey(), it.getHash());
+
+      if (res_it) {
+        std::vector<Mapped> res_mapped = res_it->getMapped();
+        std::vector<Mapped> it_mapped = it->getMapped();
+        it_mapped.insert(it_mapped.begin(), res_mapped.begin(), res_mapped.end());
+      }
+    }
+  }
+
+  template <typename Func>
+  void forEachValue(Func&& func) {
+    for (auto& v : *this)
+      func(v.getKey(), v.getMapped());
+  }
+
+  template <typename Func>
+  void forEachMapped(Func&& func) {
+    for (auto& v : *this)
+      func(v.getMapped());
+  }
+
+  void insert(const Key& x, const Mapped& v) {
+    LookupResult it;
+    bool inserted;
+    this->emplace(x, it, inserted);
+    it->getMapped().emplace_back(v);
+  }
+};
+
 // It is mainly used for 1-bytes key, like int8 etc.
 template <typename Key, typename Mapped, typename Allocator = HashTableAllocator>
 using FixedImplicitZeroHashMapWithStoredSize =
@@ -190,5 +304,23 @@ using FixedImplicitZeroHashMapWithCalculatedSize =
                  FixedHashMapImplicitZeroCell<Key, Mapped>,
                  FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<Key, Mapped>>,
                  Allocator>;
+
+// It is mainly used for 1-bytes key, like int8 etc.
+template <typename Key, typename Mapped, typename Allocator = HashTableAllocator>
+using FixedJoinHashMapWithStoredSize =
+    FixedJoinHashMap<Key,
+                     Mapped,
+                     FixedJoinHashMapCell<Key, Mapped>,
+                     FixedJoinHashTableStoredSize<FixedJoinHashMapCell<Key, Mapped>>,
+                     Allocator>;
+
+// It is mainly used for 2-bytes key, like int16 etc.
+template <typename Key, typename Mapped, typename Allocator = HashTableAllocator>
+using FixedJoinHashMapWithCalculatedSize =
+    FixedJoinHashMap<Key,
+                     Mapped,
+                     FixedJoinHashMapCell<Key, Mapped>,
+                     FixedJoinHashTableCalculatedSize<FixedJoinHashMapCell<Key, Mapped>>,
+                     Allocator>;
 
 }  // namespace cider::hashtable

--- a/cpp/src/cider/common/hashtable/FixedJoinHashTable.h
+++ b/cpp/src/cider/common/hashtable/FixedJoinHashTable.h
@@ -355,14 +355,16 @@ class FixedJoinHashTable : private boost::noncopyable,
     return !buf[x].isZero(*this) ? &buf[x] : nullptr;
   }
 
-  ConstLookupResult ALWAYS_INLINE find(const Key& x) const { return *this->find(x); }
+  ConstLookupResult ALWAYS_INLINE find(const Key& x) const {
+    return const_cast<Self*>(this)->find(x);
+  }
 
   LookupResult ALWAYS_INLINE find(const Key&, size_t hash_value) {
     return !buf[hash_value].isZero(*this) ? &buf[hash_value] : nullptr;
   }
 
   ConstLookupResult ALWAYS_INLINE find(const Key& key, size_t hash_value) const {
-    return *this->find(key, hash_value);
+    return const_cast<Self*>(this)->find(key, hash_value);
   }
 
   bool ALWAYS_INLINE contains(const Key& x) const { return !buf[x].isZero(*this); }

--- a/cpp/src/cider/common/hashtable/FixedJoinHashTable.h
+++ b/cpp/src/cider/common/hashtable/FixedJoinHashTable.h
@@ -1,0 +1,517 @@
+/*
+ * Copyright(c) 2022-2023 Intel Corporation.
+ * Copyright (c) 2016-2022 ClickHouse, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <common/hashtable/HashTable.h>
+
+namespace cider::hashtable {
+namespace ErrorCodes {
+extern const int NO_AVAILABLE_DATA;
+}
+
+// template <typename Key, typename TState = HashTableNoState>
+// struct FixedJoinHashTableCell {
+//   using State = TState;
+
+//   using value_type = Key;
+//   using mapped_type = VoidMapped;
+//   bool empty;
+
+//   FixedJoinHashTableCell() {}
+//   FixedJoinHashTableCell(const Key&, const State&) : empty(false) {}
+
+//   const VoidKey getKey() const { return {}; }
+//   VoidMapped getMapped() const { return {}; }
+
+//   bool isZero(const State&) const { return empty; }
+//   void setZero() { empty = true; }
+//   static constexpr bool need_zero_value_storage = false;
+
+//   /// This Cell is only stored inside an iterator. It's used to accommodate the fact
+//   ///  that the iterator based API always provide a reference to a continuous memory
+//   ///  containing the Key. As a result, we have to instantiate a real Key field.
+//   /// All methods that return a mutable reference to the Key field are named with
+//   ///  -Mutable suffix, indicating this is uncommon usage. As this is only for lookup
+//   ///  tables, it's totally fine to discard the Key mutations.
+//   struct CellExt {
+//     Key key;
+
+//     const VoidKey getKey() const { return {}; }
+//     VoidMapped getMapped() const { return {}; }
+//     const value_type& getValue() const { return key; }
+//     void update(Key&& key_, FixedJoinHashTableCell*) { key = key_; }
+//   };
+// };
+
+/// How to obtain the size of the table.
+
+template <typename Cell>
+struct FixedJoinHashTableStoredSize {
+  size_t m_size = 0;
+
+  size_t getSize(const Cell*, const typename Cell::State&, size_t) const {
+    return m_size;
+  }
+  bool isEmpty(const Cell*, const typename Cell::State&, size_t) const {
+    return m_size == 0;
+  }
+
+  void increaseSize() { ++m_size; }
+  void clearSize() { m_size = 0; }
+  void setSize(size_t to) { m_size = to; }
+};
+
+template <typename Cell>
+struct FixedJoinHashTableCalculatedSize {
+  size_t getSize(const Cell* buf,
+                 const typename Cell::State& state,
+                 size_t num_cells) const {
+    if (!buf)
+      return 0;
+
+    size_t res = 0;
+    for (const Cell* end = buf + num_cells; buf != end; ++buf)
+      if (!buf->isZero(state))
+        ++res;
+    return res;
+  }
+
+  bool isEmpty(const Cell* buf,
+               const typename Cell::State& state,
+               size_t num_cells) const {
+    if (!buf)
+      return true;
+
+    for (const Cell* end = buf + num_cells; buf != end; ++buf)
+      if (!buf->isZero(state))
+        return false;
+    return true;
+  }
+
+  void increaseSize() {}
+  void clearSize() {}
+  void setSize(size_t) {}
+};
+
+/** Used as a lookup table for small keys such as uint8_t, uint16_t. It's different
+ *  than a HashTable in that keys are not stored in the Cell buf, but inferred
+ *  inside each iterator. There are a bunch of to make it faster than using
+ *  HashTable: a) It doesn't have a conflict chain; b) There is no key
+ *  comparison; c) The number of cycles for checking cell empty is halved; d)
+ *  Memory layout is tighter, especially the Clearable variants.
+ *
+ * NOTE: For Set variants this should always be better. For Map variants
+ *  however, as we need to assemble the real cell inside each iterator, there
+ *  might be some cases we fall short.
+ *
+ * TODO: Deprecate the cell API so that end users don't rely on the structure
+ *  of cell. Instead iterator should be used for operations such as cell
+ *  transfer, key updates (f.g. StringRef) and serde. This will allow
+ *  TwoLevelHashSet(Map) to contain different type of sets(maps).
+ */
+template <typename Key, typename Cell, typename Size, typename Allocator>
+class FixedJoinHashTable : private boost::noncopyable,
+                           protected Allocator,
+                           protected Cell::State,
+                           protected Size {
+  static constexpr size_t NUM_CELLS = 1ULL << (sizeof(Key) * 8);
+
+ protected:
+  friend class const_iterator;
+  friend class iterator;
+  friend class Reader;
+
+  using Self = FixedJoinHashTable;
+
+  Cell* buf;  /// A piece of memory for all elements.
+
+  void alloc() {
+    int8_t* cell_array = Allocator::allocate(NUM_CELLS * sizeof(Cell));
+    // Initialize all bits to mark as empty.
+    std::memset(cell_array, 0, NUM_CELLS * sizeof(Cell));
+    buf = reinterpret_cast<Cell*>(cell_array);
+  }
+
+  void free() {
+    if (buf) {
+      Allocator::deallocate(reinterpret_cast<int8_t*>(buf), getBufferSizeInBytes());
+      buf = nullptr;
+    }
+  }
+
+  void destroyElements() {
+    if (!std::is_trivially_destructible_v<Cell>) {
+      for (iterator it = begin(), it_end = end(); it != it_end; ++it) {
+        it.ptr->~Cell();
+      }
+    }
+  }
+
+  template <typename Derived, bool is_const>
+  class iterator_base {
+    using Container = std::conditional_t<is_const, const Self, Self>;
+    using cell_type = std::conditional_t<is_const, const Cell, Cell>;
+
+    Container* container;
+    cell_type* ptr;
+
+    friend class FixedJoinHashTable;
+
+   public:
+    iterator_base() {}
+    iterator_base(Container* container_, cell_type* ptr_)
+        : container(container_), ptr(ptr_) {
+      cell.update(ptr - container->buf, ptr);
+    }
+
+    bool operator==(const iterator_base& rhs) const { return ptr == rhs.ptr; }
+    bool operator!=(const iterator_base& rhs) const { return ptr != rhs.ptr; }
+
+    Derived& operator++() {
+      ++ptr;
+
+      /// Skip empty cells in the main buffer.
+      const auto* buf_end = container->buf + container->NUM_CELLS;
+      while (ptr < buf_end && ptr->isZero(*container))
+        ++ptr;
+
+      return static_cast<Derived&>(*this);
+    }
+
+    auto& operator*() {
+      if (cell.key != ptr - container->buf)
+        cell.update(ptr - container->buf, ptr);
+      return cell;
+    }
+    auto* operator-> () {
+      if (cell.key != ptr - container->buf)
+        cell.update(ptr - container->buf, ptr);
+      return &cell;
+    }
+
+    auto getPtr() const { return ptr; }
+    size_t getHash() const { return ptr - container->buf; }
+    size_t getCollisionChainLength() const { return 0; }
+    typename cell_type::CellExt cell;
+  };
+
+ public:
+  using key_type = Key;
+  using mapped_type = typename Cell::mapped_type;
+  using value_type = typename Cell::value_type;
+  using cell_type = Cell;
+
+  using LookupResult = Cell*;
+  using ConstLookupResult = const Cell*;
+
+  size_t hash(const Key& x) const { return x; }
+
+  FixedJoinHashTable() { alloc(); }
+
+  FixedJoinHashTable(FixedJoinHashTable&& rhs) noexcept : buf(nullptr) {
+    *this = std::move(rhs);
+  }
+
+  ~FixedJoinHashTable() {
+    destroyElements();
+    free();
+  }
+
+  FixedJoinHashTable& operator=(FixedJoinHashTable&& rhs) noexcept {
+    destroyElements();
+    free();
+
+    std::swap(buf, rhs.buf);
+    this->setSize(rhs.size());
+
+    Allocator::operator=(std::move(rhs));
+    Cell::State::operator=(std::move(rhs));
+
+    return *this;
+  }
+
+  // TODO(Deegue): refactor and enable later
+  // class Reader final : private Cell::State
+  // {
+  // public:
+  //     explicit Reader(DB::ReadBuffer & in_) : in(in_) {}
+
+  //     Reader(const Reader &) = delete;
+  //     Reader & operator=(const Reader &) = delete;
+
+  //     bool next()
+  //     {
+  //         if (!is_initialized)
+  //         {
+  //             Cell::State::read(in);
+  //             DB::readVarUInt(size, in);
+  //             is_initialized = true;
+  //         }
+
+  //         if (read_count == size)
+  //         {
+  //             is_eof = true;
+  //             return false;
+  //         }
+
+  //         cell.read(in);
+  //         ++read_count;
+
+  //         return true;
+  //     }
+
+  //     inline const value_type & get() const
+  //     {
+  //         if (!is_initialized || is_eof)
+  //             throw DB::Exception("No available data",
+  //             DB::ErrorCodes::NO_AVAILABLE_DATA);
+
+  //         return cell.getValue();
+  //     }
+
+  // private:
+  //     DB::ReadBuffer & in;
+  //     Cell cell;
+  //     size_t read_count = 0;
+  //     size_t size = 0;
+  //     bool is_eof = false;
+  //     bool is_initialized = false;
+  // };
+
+  class iterator : public iterator_base<iterator, false> {
+   public:
+    using iterator_base<iterator, false>::iterator_base;
+  };
+
+  class const_iterator : public iterator_base<const_iterator, true> {
+   public:
+    using iterator_base<const_iterator, true>::iterator_base;
+  };
+
+  const_iterator begin() const {
+    if (!buf)
+      return end();
+
+    const Cell* ptr = buf;
+    auto buf_end = buf + NUM_CELLS;
+    while (ptr < buf_end && ptr->isZero(*this))
+      ++ptr;
+
+    return const_iterator(this, ptr);
+  }
+
+  const_iterator cbegin() const { return begin(); }
+
+  iterator begin() {
+    if (!buf)
+      return end();
+
+    Cell* ptr = buf;
+    auto buf_end = buf + NUM_CELLS;
+    while (ptr < buf_end && ptr->isZero(*this))
+      ++ptr;
+
+    return iterator(this, ptr);
+  }
+
+  const_iterator end() const {
+    /// Avoid UBSan warning about adding zero to nullptr. It is valid in C++20 (and
+    /// earlier) but not valid in C.
+    return const_iterator(this, buf ? buf + NUM_CELLS : buf);
+  }
+
+  const_iterator cend() const { return end(); }
+
+  iterator end() { return iterator(this, buf ? buf + NUM_CELLS : buf); }
+
+  /// The last parameter is unused but exists for compatibility with HashTable interface.
+  void ALWAYS_INLINE emplace(const Key& x,
+                             LookupResult& it,
+                             bool& inserted,
+                             size_t /* hash */ = 0) {
+    it = &buf[x];
+
+    if (!buf[x].isZero(*this)) {
+      return;
+    }
+    new (&buf[x]) Cell(x, *this);
+    inserted = true;
+    this->increaseSize();
+  }
+
+  std::pair<LookupResult, bool> ALWAYS_INLINE insert(const value_type& x) {
+    std::pair<LookupResult, bool> res;
+    emplace(Cell::getKey(x), res.first, res.second);
+    if (res.second)
+      insertSetMapped(res.first->getMapped(), x);
+
+    return res;
+  }
+
+  std::vector<mapped_type> ALWAYS_INLINE findAll(const Key& key) {
+    return buf[key].getMapped();
+  }
+
+  LookupResult ALWAYS_INLINE find(const Key& x) {
+    return !buf[x].isZero(*this) ? &buf[x] : nullptr;
+  }
+
+  ConstLookupResult ALWAYS_INLINE find(const Key& x) const {
+    return const_cast<std::decay_t<decltype(*this)>*>(this)->find(x);
+  }
+
+  LookupResult ALWAYS_INLINE find(const Key&, size_t hash_value) {
+    return !buf[hash_value].isZero(*this) ? &buf[hash_value] : nullptr;
+  }
+
+  ConstLookupResult ALWAYS_INLINE find(const Key& key, size_t hash_value) const {
+    return const_cast<std::decay_t<decltype(*this)>*>(this)->find(key, hash_value);
+  }
+
+  bool ALWAYS_INLINE contains(const Key& x) const { return !buf[x].isZero(*this); }
+  bool ALWAYS_INLINE contains(const Key&, size_t hash_value) const {
+    return !buf[hash_value].isZero(*this);
+  }
+
+  // TODO(Deegue): Implement and enable later
+  // void write(DB::WriteBuffer & wb) const
+  // {
+  //     Cell::State::write(wb);
+  //     DB::writeVarUInt(size(), wb);
+
+  //     if (!buf)
+  //         return;
+
+  //     for (auto ptr = buf, buf_end = buf + NUM_CELLS; ptr < buf_end; ++ptr)
+  //     {
+  //         if (!ptr->isZero(*this))
+  //         {
+  //             DB::writeVarUInt(ptr - buf);
+  //             ptr->write(wb);
+  //         }
+  //     }
+  // }
+
+  // void writeText(DB::WriteBuffer & wb) const
+  // {
+  //     Cell::State::writeText(wb);
+  //     DB::writeText(size(), wb);
+
+  //     if (!buf)
+  //         return;
+
+  //     for (auto ptr = buf, buf_end = buf + NUM_CELLS; ptr < buf_end; ++ptr)
+  //     {
+  //         if (!ptr->isZero(*this))
+  //         {
+  //             DB::writeChar(',', wb);
+  //             DB::writeText(ptr - buf, wb);
+  //             DB::writeChar(',', wb);
+  //             ptr->writeText(wb);
+  //         }
+  //     }
+  // }
+
+  // void read(DB::ReadBuffer & rb)
+  // {
+  //     Cell::State::read(rb);
+  //     destroyElements();
+  //     size_t m_size;
+  //     DB::readVarUInt(m_size, rb);
+  //     this->setSize(m_size);
+  //     free();
+  //     alloc();
+
+  //     for (size_t i = 0; i < m_size; ++i)
+  //     {
+  //         size_t place_value = 0;
+  //         DB::readVarUInt(place_value, rb);
+  //         Cell x;
+  //         x.read(rb);
+  //         new (&buf[place_value]) Cell(x, *this);
+  //     }
+  // }
+
+  // void readText(DB::ReadBuffer & rb)
+  // {
+  //     Cell::State::readText(rb);
+  //     destroyElements();
+  //     size_t m_size;
+  //     DB::readText(m_size, rb);
+  //     this->setSize(m_size);
+  //     free();
+  //     alloc();
+
+  //     for (size_t i = 0; i < m_size; ++i)
+  //     {
+  //         size_t place_value = 0;
+  //         DB::assertChar(',', rb);
+  //         DB::readText(place_value, rb);
+  //         Cell x;
+  //         DB::assertChar(',', rb);
+  //         x.readText(rb);
+  //         new (&buf[place_value]) Cell(x, *this);
+  //     }
+  // }
+
+  size_t size() const { return this->getSize(buf, *this, NUM_CELLS); }
+  bool empty() const { return this->isEmpty(buf, *this, NUM_CELLS); }
+
+  void clear() {
+    destroyElements();
+    this->clearSize();
+
+    memset(static_cast<void*>(buf), 0, NUM_CELLS * sizeof(*buf));
+  }
+
+  /// After executing this function, the table can only be destroyed,
+  ///  and also you can use the methods `size`, `empty`, `begin`, `end`.
+  void clearAndShrink() {
+    destroyElements();
+    this->clearSize();
+    free();
+  }
+
+  size_t getBufferSizeInBytes() const { return NUM_CELLS * sizeof(Cell); }
+
+  size_t getBufferSizeInCells() const { return NUM_CELLS; }
+
+  /// Return offset for result in internal buffer.
+  /// Result can have value up to `getBufferSizeInCells() + 1`
+  /// because offset for zero value considered to be 0
+  /// and for other values it will be `offset in buffer + 1`
+  size_t offsetInternal(ConstLookupResult ptr) const {
+    if (ptr->isZero(*this))
+      return 0;
+    return ptr - buf + 1;
+  }
+
+  const Cell* data() const { return buf; }
+  Cell* data() { return buf; }
+
+  size_t getCollisions() const { return 0; }
+};
+
+}  // namespace cider::hashtable

--- a/cpp/src/cider/exec/operator/join/CiderJoinHashTable.h
+++ b/cpp/src/cider/exec/operator/join/CiderJoinHashTable.h
@@ -32,18 +32,6 @@ namespace cider::exec::processor {
 struct BatchAndOffset {
   cider::exec::nextgen::context::Batch* batch_ptr;
   int64_t batch_offset;
-
-  BatchAndOffset() {}
-
-  BatchAndOffset(BatchAndOffset* other) {
-    this->batch_ptr = other->batch_ptr;
-    this->batch_offset = other->batch_offset;
-  }
-
-  BatchAndOffset(cider::exec::nextgen::context::Batch* ptr, int64_t offset) {
-    this->batch_ptr = ptr;
-    this->batch_offset = offset;
-  }
 };
 
 using CiderJoinBaseKey = cider_hashtable::HT_Row;

--- a/cpp/src/cider/exec/operator/join/CiderJoinHashTable.h
+++ b/cpp/src/cider/exec/operator/join/CiderJoinHashTable.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include <common/hashtable/FixedHashMap.h>
 #include "exec/nextgen/context/Batch.h"
 #include "exec/operator/join/CiderChainedHashTable.h"
 #include "exec/operator/join/CiderLinearProbingHashTable.h"
@@ -31,6 +32,18 @@ namespace cider::exec::processor {
 struct BatchAndOffset {
   cider::exec::nextgen::context::Batch* batch_ptr;
   int64_t batch_offset;
+
+  BatchAndOffset() {}
+
+  BatchAndOffset(BatchAndOffset* other) {
+    this->batch_ptr = other->batch_ptr;
+    this->batch_offset = other->batch_offset;
+  }
+
+  BatchAndOffset(cider::exec::nextgen::context::Batch* ptr, int64_t offset) {
+    this->batch_ptr = ptr;
+    this->batch_offset = offset;
+  }
 };
 
 using CiderJoinBaseKey = cider_hashtable::HT_Row;
@@ -51,6 +64,12 @@ using JoinLPHashTable = cider_hashtable::BaseHashTable<LP_TEMPLATE>;
 
 using JoinChainedHashTable = cider_hashtable::BaseHashTable<CHAINED_TEMPLATE>;
 
+using JoinUInt8HashTable =
+    cider::hashtable::FixedJoinHashMapWithCalculatedSize<uint8_t, BatchAndOffset>;
+
+using JoinUInt16HashTable =
+    cider::hashtable::FixedJoinHashMapWithStoredSize<uint16_t, BatchAndOffset>;
+
 class JoinHashTable {
  public:
   JoinHashTable(cider_hashtable::HashTableType hashTableType =
@@ -61,6 +80,12 @@ class JoinHashTable {
   std::shared_ptr<JoinLPHashTable> getLPHashTable() { return LPHashTableInstance_; }
   std::shared_ptr<JoinChainedHashTable> getChainedHashTable() {
     return chainedHashTableInstance_;
+  }
+  std::shared_ptr<JoinUInt8HashTable> getUInt8HashTable() {
+    return uInt8HashTableInstance_;
+  }
+  std::shared_ptr<JoinUInt16HashTable> getUInt16HashTable() {
+    return uInt16HashTableInstance_;
   }
 
   void merge_other_hashtables(
@@ -78,6 +103,8 @@ class JoinHashTable {
   cider_hashtable::HashTableType hashTableType_;
   std::shared_ptr<JoinLPHashTable> LPHashTableInstance_;
   std::shared_ptr<JoinChainedHashTable> chainedHashTableInstance_;
+  std::shared_ptr<JoinUInt8HashTable> uInt8HashTableInstance_;
+  std::shared_ptr<JoinUInt16HashTable> uInt16HashTableInstance_;
 };
 
 using JoinHashTablePtr = std::shared_ptr<JoinHashTable>;

--- a/cpp/src/cider/exec/operator/join/HashTableSelector.h
+++ b/cpp/src/cider/exec/operator/join/HashTableSelector.h
@@ -30,7 +30,7 @@ namespace cider_hashtable {
 // To be added
 // This enum is used for cider internal only
 // Outside cider will need to define their own enum
-enum HashTableType { LINEAR_PROBING, CHAINED, CK_INT8 };
+enum HashTableType { LINEAR_PROBING, CHAINED, FIXED_INT8, FIXED_INT16 };
 
 template <typename Key,
           typename Value,


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Integrate `JoinHashTable` with optimized `FixedHashMap` (aka `FixedJoinHashMap `), which supports Int8 and Int16 as join keys.
2. More test cases should be added after `JoinRel` can be well handled, meanwhile, add `JoinHashTable` selection algorithm. Currently, we assume that the input key type is always int32. 


### Why are the changes needed?
Improvement.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.

### Which label does this PR belong to?

