### PR TITLE
[POAE7-2890] Fix core dump and improvement of HashMap

### DIFF
--- a/cpp/src/cider/benchmarks/HashMapBenchmark.cpp
+++ b/cpp/src/cider/benchmarks/HashMapBenchmark.cpp
@@ -151,5 +151,4 @@ BENCHMARK(BM_Optimized_Lookup<uint8_t>)->RangeMultiplier(10)->Range(100, 10000);
 BENCHMARK(BM_Baseline_Lookup<uint16_t>)->RangeMultiplier(10)->Range(100, 10000);
 BENCHMARK(BM_Optimized_Lookup<uint16_t>)->RangeMultiplier(10)->Range(100, 10000);
 
-
 BENCHMARK_MAIN();

--- a/cpp/src/cider/benchmarks/HashMapBenchmark.cpp
+++ b/cpp/src/cider/benchmarks/HashMapBenchmark.cpp
@@ -113,11 +113,11 @@ static std::tuple<std::vector<T>, std::vector<bool>> generateAndFillVector(
 
 template <typename KeyType, typename HashTableType>
 static void BM_Lookup(benchmark::State& state) {
-  size_t row_num = 100;
+  size_t row_num = state.range(0);
   KeyType value_min = std::numeric_limits<KeyType>::min();
   KeyType value_max = std::numeric_limits<KeyType>::max();
   size_t null_chance = 0;
-  GeneratePattern pattern = GeneratePattern::Random;
+  GeneratePattern pattern = GeneratePattern::Sequence;
   std::vector<KeyType> data(row_num);
   std::vector<bool> data_null;
   {
@@ -128,10 +128,8 @@ static void BM_Lookup(benchmark::State& state) {
                   row_num, pattern, null_chance, value_min, value_max);
   }
   for (auto _ : state) {
-    for (int64_t i = state.range(0); i--;) {
-      auto collisions = bench<KeyType, HashTableType>(data);
-      state.counters["Collisions"] = collisions;
-    }
+    auto collisions = bench<KeyType, HashTableType>(data);
+    state.counters["Collisions"] = collisions;
   }
 }
 
@@ -147,10 +145,11 @@ static void BM_Optimized_Lookup(benchmark::State& state) {
   BM_Lookup<KeyType, OptimizedLookup>(state);
 }
 
-BENCHMARK(BM_Baseline_Lookup<uint8_t>)->RangeMultiplier(10)->Range(10, 1000);
-BENCHMARK(BM_Optimized_Lookup<uint8_t>)->RangeMultiplier(10)->Range(10, 1000);
+BENCHMARK(BM_Baseline_Lookup<uint8_t>)->RangeMultiplier(10)->Range(100, 10000);
+BENCHMARK(BM_Optimized_Lookup<uint8_t>)->RangeMultiplier(10)->Range(100, 10000);
 
-BENCHMARK(BM_Baseline_Lookup<uint16_t>)->RangeMultiplier(10)->Range(10, 1000);
-BENCHMARK(BM_Optimized_Lookup<uint16_t>)->RangeMultiplier(10)->Range(10, 1000);
+BENCHMARK(BM_Baseline_Lookup<uint16_t>)->RangeMultiplier(10)->Range(100, 10000);
+BENCHMARK(BM_Optimized_Lookup<uint16_t>)->RangeMultiplier(10)->Range(100, 10000);
+
 
 BENCHMARK_MAIN();

--- a/cpp/src/cider/tests/CMakeLists.txt
+++ b/cpp/src/cider/tests/CMakeLists.txt
@@ -23,8 +23,8 @@ include_directories(${CMAKE_SOURCE_DIR}/tests ${CMAKE_CURRENT_BINARY_DIR})
 set(TEST_BASE_PATH "./tmp")
 add_definitions("-DBASE_PATH=\"${TEST_BASE_PATH}\"")
 
-# add_executable(CiderNewHashTableTest CiderNewHashTableTest.cpp)
-# add_executable(CiderNewAggHashTableTest CiderNewAggHashTableTest.cpp)
+add_executable(CiderNewHashTableTest CiderNewHashTableTest.cpp)
+add_executable(CiderNewAggHashTableTest CiderNewAggHashTableTest.cpp)
 add_executable(Substrait2IRTest Substrait2IRTest.cpp)
 # add_executable(ExpressionEvalTest ExpressionEvalTest.cpp)
 # add_executable(CiderAllocatorTest CiderAllocatorTest.cpp)
@@ -42,9 +42,8 @@ set(EXECUTE_TEST_LIBS
     dl
     cider_hashtable_join)
 
-# target_link_libraries(CiderNewHashTableTest ${EXECUTE_TEST_LIBS}
-# cider_hashtable) target_link_libraries(CiderNewAggHashTableTest
-# ${EXECUTE_TEST_LIBS} cider_hashtable)
+target_link_libraries(CiderNewHashTableTest ${EXECUTE_TEST_LIBS} cider_hashtable)
+target_link_libraries(CiderNewAggHashTableTest ${EXECUTE_TEST_LIBS} cider_hashtable)
 target_link_libraries(Substrait2IRTest cider_plan_parser ${EXECUTE_TEST_LIBS})
 # target_link_libraries(ExpressionEvalTest ${EXECUTE_TEST_LIBS}
 # cider_expr_builder) target_link_libraries(CiderAllocatorTest
@@ -53,8 +52,8 @@ target_link_libraries(Substrait2IRTest cider_plan_parser ${EXECUTE_TEST_LIBS})
 # target_link_libraries(StringHeapTest ${EXECUTE_TEST_LIBS})
 
 set(TEST_ARGS "--gtest_output=xml:../")
-# add_test(CiderNewHashTableTest CiderNewHashTableTest ${TEST_ARGS})
-# add_test(CiderNewAggHashTableTest CiderNewAggHashTableTest ${TEST_ARGS})
+add_test(CiderNewHashTableTest CiderNewHashTableTest ${TEST_ARGS})
+add_test(CiderNewAggHashTableTest CiderNewAggHashTableTest ${TEST_ARGS})
 add_test(Substrait2IRTest Substrait2IRTest ${TEST_ARGS})
 # add_test(ExpressionEvalTest ExpressionEvalTest ${TEST_ARGS})
 # add_test(CiderAllocatorTest CiderAllocatorTest ${TEST_ARGS})

--- a/cpp/src/cider/tests/CMakeLists.txt
+++ b/cpp/src/cider/tests/CMakeLists.txt
@@ -42,8 +42,10 @@ set(EXECUTE_TEST_LIBS
     dl
     cider_hashtable_join)
 
-target_link_libraries(CiderNewHashTableTest ${EXECUTE_TEST_LIBS} cider_hashtable)
-target_link_libraries(CiderNewAggHashTableTest ${EXECUTE_TEST_LIBS} cider_hashtable)
+target_link_libraries(CiderNewHashTableTest ${EXECUTE_TEST_LIBS}
+                      cider_hashtable)
+target_link_libraries(CiderNewAggHashTableTest ${EXECUTE_TEST_LIBS}
+                      cider_hashtable)
 target_link_libraries(Substrait2IRTest cider_plan_parser ${EXECUTE_TEST_LIBS})
 # target_link_libraries(ExpressionEvalTest ${EXECUTE_TEST_LIBS}
 # cider_expr_builder) target_link_libraries(CiderAllocatorTest

--- a/cpp/src/cider/tests/CiderNewHashTableTest.cpp
+++ b/cpp/src/cider/tests/CiderNewHashTableTest.cpp
@@ -493,7 +493,6 @@ TEST_F(CiderNewHashTableTest, aggUInt64LargeDatasetTest) {
     keys.emplace_back(i);
     values.emplace_back(10);
   }
-
   for (int i = 0; i < keys.size(); i++) {
     Block& block = ht_uint64[keys[i]];
     block.add(values[i]);
@@ -510,7 +509,6 @@ TEST_F(CiderNewHashTableTest, aggUInt64LargeDatasetTest) {
     keys2.emplace_back(i);
     values2.emplace_back(40);
   }
-
   for (int i = 0; i < keys2.size(); i++) {
     Block& block = ht_uint64[keys2[i]];
     block.add(values2[i]);

--- a/cpp/src/cider/tests/CiderNewHashTableTest.cpp
+++ b/cpp/src/cider/tests/CiderNewHashTableTest.cpp
@@ -482,6 +482,47 @@ TEST_F(CiderNewHashTableTest, aggDoubleTest) {
   }
 }
 
+// Large data set test cases
+TEST_F(CiderNewHashTableTest, aggUInt64LargeDatasetTest) {
+  using AggregatedHashTableForUInt64Key = HashMap<uint64_t, Block, HashCRC32<uint64_t>>;
+  AggregatedHashTableForUInt64Key ht_uint64;
+
+  std::vector<uint64_t> keys;
+  std::vector<int64_t> values;
+  for (int i = 0; i < 5000; i++) {
+    keys.emplace_back(i);
+    values.emplace_back(10);
+  }
+
+  for (int i = 0; i < keys.size(); i++) {
+    Block& block = ht_uint64[keys[i]];
+    block.add(values[i]);
+  }
+
+  for (int i = 0; i < keys.size(); i++) {
+    CHECK_EQ(ht_uint64[keys[i]].getSum(), values[i]);
+    CHECK_EQ(ht_uint64[keys[i]].getCount(), 1);
+  }
+
+  std::vector<uint64_t> keys2;
+  std::vector<int64_t> values2;
+  for (int i = 0; i < 5000; i++) {
+    keys2.emplace_back(i);
+    values2.emplace_back(40);
+  }
+
+  for (int i = 0; i < keys2.size(); i++) {
+    Block& block = ht_uint64[keys2[i]];
+    block.add(values2[i]);
+  }
+
+  for (int i = 0; i < keys.size(); i++) {
+    CHECK_EQ(ht_uint64[keys[i]].getSum(), 50);
+    CHECK_EQ(ht_uint64[keys[i]].getCount(), 2);
+    CHECK_EQ(ht_uint64[keys[i]].getAvg(), 25);
+  }
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Fix core dump when doing `resize()`.
2. Set default size of HashMap to 1 << 12.
3. Optimize HashTableBenchmark with larger number of input rows, and get the performance result:

![image](https://user-images.githubusercontent.com/25916266/221567393-adcbb1d7-241a-471a-ac9b-3646598c1a3d.png)



### Why are the changes needed?
Fix & improve.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.

### Which label does this PR belong to?
