### PR TITLE
[POAE7-2864] Implementation of HashTable Arena and StringRef

### DIFF
--- a/cpp/src/cider/common/Arena.h
+++ b/cpp/src/cider/common/Arena.h
@@ -22,11 +22,25 @@
 
 #pragma once
 
+#include <../include/cider/CiderAllocator.h>
+#include <boost/noncopyable.hpp>
+
+#include <unistd.h>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <vector>
 
-#include <boost/noncopyable.hpp>
+#if !defined(likely)
+#define likely(x) (__builtin_expect(!!(x), 1))
+#endif
+#if !defined(unlikely)
+#define unlikely(x) (__builtin_expect(!!(x), 0))
+#endif
+
+#define PADDING_FOR_SIMD 64
+
+#define NO_INLINE __attribute__((__noinline__))
 
 namespace cider::hashtable {
 
@@ -40,27 +54,126 @@ namespace cider::hashtable {
  */
 class Arena : private boost::noncopyable {
  private:
-  static size_t roundUpToPageSize(size_t s, size_t page_size) { return 0; }
+  static constexpr size_t pad_right = PADDING_FOR_SIMD - 1;
 
-  /// If MemoryChunks size is less than 'linear_growth_threshold', then use exponential
-  /// growth, otherwise - linear growth
-  ///  (to not allocate too much excessive memory).
-  size_t nextSize(size_t min_next_size) const { return 0; }
+  // Contiguous MemoryChunk of memory and pointer to free space inside it. Member of
+  // single-linked list.
+  struct alignas(16) MemoryChunk : private CiderDefaultAllocator {
+    char* begin;
+    char* pos;
+    char* end;  // does not include padding.
 
-  /// Add next contiguous MemoryChunk of memory with size not less than specified.
-  void addMemoryChunk(size_t min_size) {}
+    MemoryChunk* prev;
+
+    MemoryChunk(size_t size_, MemoryChunk* prev_) {
+      begin = reinterpret_cast<char*>(CiderDefaultAllocator::allocate(size_));
+      pos = begin;
+      end = begin + size_ - pad_right;
+      prev = prev_;
+    }
+
+    ~MemoryChunk() {
+      CiderDefaultAllocator::deallocate(reinterpret_cast<int8_t*>(begin), size());
+      delete prev;
+    }
+
+    size_t size() const { return end + pad_right - begin; }
+    size_t remaining() const { return end - pos; }
+  };
+
+  size_t growth_factor;
+  size_t linear_growth_threshold;
+
+  // Last contiguous MemoryChunk of memory.
+  MemoryChunk* head;
+  size_t size_in_bytes;
+  size_t page_size;
+
+  static size_t roundUpToPageSize(size_t s, size_t page_size) {
+    return (s + page_size - 1) / page_size * page_size;
+  }
+
+  // If MemoryChunks size is less than 'linear_growth_threshold', then use exponential
+  // growth, otherwise - linear growth
+  //  (to not allocate too much excessive memory).
+  size_t nextSize(size_t min_next_size) const {
+    size_t size_after_grow = 0;
+
+    if (head->size() < linear_growth_threshold) {
+      size_after_grow = std::max(min_next_size, head->size() * growth_factor);
+    } else {
+      // allocContinue() combined with linear growth results in quadratic
+      // behavior: we append the data by small amounts, and when it
+      // doesn't fit, we create a new MemoryChunk and copy all the previous data
+      // into it. The number of times we do this is directly proportional
+      // to the total size of data that is going to be serialized. To make
+      // the copying happen less often, round the next size up to the
+      // linear_growth_threshold.
+      size_after_grow =
+          ((min_next_size + linear_growth_threshold - 1) / linear_growth_threshold) *
+          linear_growth_threshold;
+    }
+
+    return roundUpToPageSize(size_after_grow, page_size);
+  }
+
+  // Add next contiguous MemoryChunk of memory with size not less than specified.
+  void NO_INLINE addMemoryChunk(size_t min_size) {
+    head = new MemoryChunk(nextSize(min_size + pad_right), head);
+    size_in_bytes += head->size();
+  }
+
+  friend class ArenaAllocator;
+  template <size_t>
+  friend class AlignedArenaAllocator;
 
  public:
-  /// Get piece of memory, without alignment.
-  char* alloc(size_t size) { return nullptr; }
+  explicit Arena(size_t initial_size_ = 4096,
+                 size_t growth_factor_ = 2,
+                 size_t linear_growth_threshold_ = 128 * 1024 * 1024)
+      : growth_factor(growth_factor_)
+      , linear_growth_threshold(linear_growth_threshold_)
+      , head(new MemoryChunk(initial_size_, nullptr))
+      , size_in_bytes(head->size()) {
+    page_size = sysconf(_SC_PAGESIZE);
+    if (page_size < 0) {
+      abort();
+    }
+  }
 
-  /// Get piece of memory with alignment
-  char* alignedAlloc(size_t size, size_t alignment) { return nullptr; }
+  ~Arena() { delete head; }
 
-  // TODO(Deegue): Implement and enable later
+  // Get piece of memory, without alignment.
+  char* alloc(size_t size) {
+    if (unlikely(static_cast<std::ptrdiff_t>(size) > head->end - head->pos)) {
+      addMemoryChunk(size);
+    }
+
+    char* res = head->pos;
+    head->pos += size;
+    return res;
+  }
+
+  // Get piece of memory with alignment
+  char* alignedAlloc(size_t size, size_t alignment) {
+    do {
+      void* head_pos = head->pos;
+      size_t space = head->end - head->pos;
+
+      auto* res = static_cast<char*>(std::align(alignment, size, head_pos, space));
+      if (res) {
+        head->pos = static_cast<char*>(head_pos);
+        head->pos += size;
+        return res;
+      }
+
+      addMemoryChunk(size + alignment);
+    } while (true);
+  }
+
   template <typename T>
   T* alloc() {
-    return nullptr;
+    return reinterpret_cast<T*>(alignedAlloc(sizeof(T), alignof(T)));
   }
 
   /** Rollback just performed allocation.
@@ -68,7 +181,10 @@ class Arena : private boost::noncopyable {
    * Return the resulting head pointer, so that the caller can assert that
    * the allocation it intended to roll back was indeed the last one.
    */
-  void* rollback(size_t size) { return nullptr; }
+  void* rollback(size_t size) {
+    head->pos -= size;
+    return head->pos;
+  }
 
   /** Begin or expand a contiguous range of memory.
    * 'range_start' is the start of range. If nullptr, a new range is
@@ -85,38 +201,87 @@ class Arena : private boost::noncopyable {
   char* allocContinue(size_t additional_bytes,
                       char const*& range_start,
                       size_t start_alignment = 0) {
-    // TODO(Deegue): Implement and enable later
-    return nullptr;
+    if (!range_start) {
+      // Start a new memory range.
+      char* result = start_alignment ? alignedAlloc(additional_bytes, start_alignment)
+                                     : alloc(additional_bytes);
+
+      range_start = result;
+      return result;
+    }
+
+    if (head->pos + additional_bytes <= head->end) {
+      // The new size fits into the last MemoryChunk, so just alloc the
+      // additional size. We can alloc without alignment here, because it
+      // only applies to the start of the range, and we don't change it.
+      return alloc(additional_bytes);
+    }
+
+    // New range doesn't fit into this MemoryChunk, will copy to a new one.
+    //
+    // Note: among other things, this method is used to provide a hack-ish
+    // implementation of realloc over Arenas in ArenaAllocators. It wastes a
+    // lot of memory -- quadratically so when we reach the linear allocation
+    // threshold. This deficiency is intentionally left as is, and should be
+    // solved not by complicating this method, but by rethinking the
+    // approach to memory management for aggregate function states, so that
+    // we can provide a proper realloc().
+    const size_t existing_bytes = head->pos - range_start;
+    const size_t new_bytes = existing_bytes + additional_bytes;
+    const char* old_range = range_start;
+
+    char* new_range =
+        start_alignment ? alignedAlloc(new_bytes, start_alignment) : alloc(new_bytes);
+
+    memcpy(new_range, old_range, existing_bytes);
+
+    range_start = new_range;
+    return new_range + existing_bytes;
   }
 
-  // TODO(Deegue): Implement and enable later
-  /// NOTE Old memory region is wasted.
+  // NOTE Old memory region is wasted.
   char* realloc(const char* old_data, size_t old_size, size_t new_size) {
-    return nullptr;
+    char* res = alloc(new_size);
+    if (old_data) {
+      memcpy(res, old_data, old_size);
+    }
+    return res;
   }
 
-  // TODO(Deegue): Implement and enable later
   char* alignedRealloc(const char* old_data,
                        size_t old_size,
                        size_t new_size,
                        size_t alignment) {
-    return nullptr;
+    char* res = alignedAlloc(new_size, alignment);
+    if (old_data) {
+      memcpy(res, old_data, old_size);
+    }
+    return res;
   }
 
-  /// Insert string without alignment.
-  const char* insert(const char* data, size_t size) { return nullptr; }
+  // Insert string without alignment.
+  const char* insert(const char* data, size_t size) {
+    char* res = alloc(size);
+    memcpy(res, data, size);
+    return res;
+  }
 
   const char* alignedInsert(const char* data, size_t size, size_t alignment) {
-    return nullptr;
+    char* res = alignedAlloc(size, alignment);
+    memcpy(res, data, size);
+    return res;
   }
 
   /// Size of MemoryChunks in bytes.
-  size_t size() const { return 0; }
+  size_t size() const { return size_in_bytes; }
 
   /// Bad method, don't use it -- the MemoryChunks are not your business, the entire
   /// purpose of the arena code is to manage them for you, so if you find
   /// yourself having to use this method, probably you're doing something wrong.
-  size_t remainingSpaceInCurrentMemoryChunk() const { return 0; }
+  size_t remainingSpaceInCurrentMemoryChunk() const { return head->remaining(); }
 };
+
+using ArenaPtr = std::shared_ptr<Arena>;
+using Arenas = std::vector<ArenaPtr>;
 
 }  // namespace cider::hashtable

--- a/cpp/src/cider/common/Arena.h
+++ b/cpp/src/cider/common/Arena.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <../include/cider/CiderAllocator.h>
+#include <cider/CiderAllocator.h>
 #include <boost/noncopyable.hpp>
 
 #include <unistd.h>

--- a/cpp/src/cider/common/base/StringRef.cpp
+++ b/cpp/src/cider/common/base/StringRef.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ * Copyright (c) 2016-2022 ClickHouse, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <ostream>
+
+#include "StringRef.h"
+
+namespace cider::hashtable {
+
+std::ostream& operator<<(std::ostream& os, const StringRef& str) {
+  if (str.data) {
+    os.write(str.data, str.size);
+  }
+
+  return os;
+}
+}  // namespace cider::hashtable

--- a/cpp/src/cider/common/base/StringRef.cpp
+++ b/cpp/src/cider/common/base/StringRef.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright(c) 2022-2023 Intel Corporation.
  * Copyright (c) 2016-2022 ClickHouse, Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/cpp/src/cider/common/base/StringRef.h
+++ b/cpp/src/cider/common/base/StringRef.h
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ * Copyright (c) 2016-2022 ClickHouse, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <functional>
+#include <iosfwd>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <common/base/unaligned.h>
+#include <common/contrib/cityhash102/include/city.h>
+
+#include <emmintrin.h>
+#include <nmmintrin.h>
+#include <smmintrin.h>
+
+namespace cider::hashtable {
+
+/**
+ * The std::string_view-like container to avoid creating strings to find substrings in the
+ * hash table.
+ */
+struct StringRef {
+  const char* data = nullptr;
+  size_t size = 0;
+
+  // Non-constexpr due to reinterpret_cast.
+  template <typename CharT>
+  StringRef(const CharT* data_, size_t size_)
+      : data(reinterpret_cast<const char*>(data_)), size(size_) {
+    // Sanity check for overflowed values.
+    assert(size < 0x8000000000000000ULL);
+  }
+
+  constexpr StringRef(const char* data_, size_t size_) : data(data_), size(size_) {}
+
+  StringRef(const std::string& s) : data(s.data()), size(s.size()) {}  /// NOLINT
+  constexpr explicit StringRef(std::string_view s) : data(s.data()), size(s.size()) {}
+  constexpr StringRef(const char* data_)
+      : StringRef(std::string_view{data_}) {}  /// NOLINT
+  constexpr StringRef() = default;
+
+  bool empty() const { return size == 0; }
+
+  std::string toString() const { return std::string(data, size); }
+  explicit operator std::string() const { return toString(); }
+
+  std::string_view toView() const { return std::string_view(data, size); }
+  constexpr explicit operator std::string_view() const {
+    return std::string_view(data, size);
+  }
+};
+
+using StringRefs = std::vector<StringRef>;
+
+/** Compare strings for equality.
+ * The approach is controversial and does not win in all cases.
+ * For more information, see hash_map_string_2.cpp
+ */
+inline bool compareSSE2(const char* p1, const char* p2) {
+  return 0xFFFF == _mm_movemask_epi8(_mm_cmpeq_epi8(
+                       _mm_loadu_si128(reinterpret_cast<const __m128i*>(p1)),
+                       _mm_loadu_si128(reinterpret_cast<const __m128i*>(p2))));
+}
+
+inline bool compareSSE2x4(const char* p1, const char* p2) {
+  return 0xFFFF ==
+         _mm_movemask_epi8(_mm_and_si128(
+             _mm_and_si128(
+                 _mm_cmpeq_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(p1)),
+                                _mm_loadu_si128(reinterpret_cast<const __m128i*>(p2))),
+                 _mm_cmpeq_epi8(
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(p1) + 1),
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(p2) + 1))),
+             _mm_and_si128(
+                 _mm_cmpeq_epi8(
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(p1) + 2),
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(p2) + 2)),
+                 _mm_cmpeq_epi8(
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(p1) + 3),
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(p2) + 3)))));
+}
+
+inline bool memequalSSE2Wide(const char* p1, const char* p2, size_t size) {
+  /** The order of branches and the trick with overlapping comparisons
+   * are the same as in memcpy implementation.
+   */
+  if (size <= 16) {
+    // TODO(Deegue): Add 17..24 bytes support
+    if (size >= 8) {
+      // Chunks of 8..16 bytes.
+      return unalignedLoad<uint64_t>(p1) == unalignedLoad<uint64_t>(p2) &&
+             unalignedLoad<uint64_t>(p1 + size - 8) ==
+                 unalignedLoad<uint64_t>(p2 + size - 8);
+    } else if (size >= 4) {
+      // Chunks of 4..7 bytes.
+      return unalignedLoad<uint32_t>(p1) == unalignedLoad<uint32_t>(p2) &&
+             unalignedLoad<uint32_t>(p1 + size - 4) ==
+                 unalignedLoad<uint32_t>(p2 + size - 4);
+    } else if (size >= 2) {
+      // Chunks of 2..3 bytes.
+      return unalignedLoad<uint16_t>(p1) == unalignedLoad<uint16_t>(p2) &&
+             unalignedLoad<uint16_t>(p1 + size - 2) ==
+                 unalignedLoad<uint16_t>(p2 + size - 2);
+    } else if (size >= 1) {
+      // A single byte.
+      return *p1 == *p2;
+    }
+    return true;
+  }
+
+  while (size >= 64) {
+    if (compareSSE2x4(p1, p2)) {
+      p1 += 64;
+      p2 += 64;
+      size -= 64;
+    } else {
+      return false;
+    }
+  }
+
+  switch (size / 16) {
+    case 3:
+      if (!compareSSE2(p1 + 32, p2 + 32))
+        return false;
+      [[fallthrough]];
+    case 2:
+      if (!compareSSE2(p1 + 16, p2 + 16))
+        return false;
+      [[fallthrough]];
+    case 1:
+      if (!compareSSE2(p1, p2))
+        return false;
+  }
+
+  return compareSSE2(p1 + size - 16, p2 + size - 16);
+}
+
+inline bool operator==(StringRef lhs, StringRef rhs) {
+  if (lhs.size != rhs.size)
+    return false;
+
+  if (lhs.size == 0)
+    return true;
+
+  return memequalSSE2Wide(lhs.data, rhs.data, lhs.size);
+}
+
+inline bool operator!=(StringRef lhs, StringRef rhs) {
+  return !(lhs == rhs);
+}
+
+inline bool operator<(StringRef lhs, StringRef rhs) {
+  int cmp = memcmp(lhs.data, rhs.data, std::min(lhs.size, rhs.size));
+  return cmp < 0 || (cmp == 0 && lhs.size < rhs.size);
+}
+
+inline bool operator>(StringRef lhs, StringRef rhs) {
+  int cmp = memcmp(lhs.data, rhs.data, std::min(lhs.size, rhs.size));
+  return cmp > 0 || (cmp == 0 && lhs.size > rhs.size);
+}
+
+struct StringRefHash64 {
+  size_t operator()(StringRef x) const {
+    return CityHash_v1_0_2::CityHash64(x.data, x.size);
+  }
+};
+
+// Parts are taken from CityHash.
+
+inline uint64_t hashLen16(uint64_t u, uint64_t v) {
+  return CityHash_v1_0_2::Hash128to64(CityHash_v1_0_2::uint128(u, v));
+}
+
+inline uint64_t shiftMix(uint64_t val) {
+  return val ^ (val >> 47);
+}
+
+inline uint64_t rotateByAtLeast1(uint64_t val, uint8_t shift) {
+  return (val >> shift) | (val << (64 - shift));
+}
+
+inline size_t hashLessThan8(const char* data, size_t size) {
+  static constexpr uint64_t k2 = 0x9ae16a3b2f90404fULL;
+  static constexpr uint64_t k3 = 0xc949d7c7509e6557ULL;
+
+  if (size >= 4) {
+    uint64_t a = unalignedLoad<uint32_t>(data);
+    return hashLen16(size + (a << 3), unalignedLoad<uint32_t>(data + size - 4));
+  }
+
+  if (size > 0) {
+    uint8_t a = data[0];
+    uint8_t b = data[size >> 1];
+    uint8_t c = data[size - 1];
+    uint32_t y = static_cast<uint32_t>(a) + (static_cast<uint32_t>(b) << 8);
+    uint32_t z = static_cast<uint32_t>(size) + (static_cast<uint32_t>(c) << 2);
+    return shiftMix(y * k2 ^ z * k3) * k2;
+  }
+
+  return k2;
+}
+
+inline size_t hashLessThan16(const char* data, size_t size) {
+  if (size > 8) {
+    uint64_t a = unalignedLoad<uint64_t>(data);
+    uint64_t b = unalignedLoad<uint64_t>(data + size - 8);
+    return hashLen16(a, rotateByAtLeast1(b + size, static_cast<uint8_t>(size))) ^ b;
+  }
+
+  return hashLessThan8(data, size);
+}
+
+struct CRC32Hash {
+  unsigned operator()(StringRef x) const {
+    const char* pos = x.data;
+    size_t size = x.size;
+
+    if (size == 0) {
+      return 0;
+    }
+
+    if (size < 8) {
+      return static_cast<unsigned>(hashLessThan8(x.data, x.size));
+    }
+
+    const char* end = pos + size;
+    unsigned res = -1U;
+
+    do {
+      uint64_t word = unalignedLoad<uint64_t>(pos);
+      res = static_cast<unsigned>(_mm_crc32_u64(res, word));
+
+      pos += 8;
+    } while (pos + 8 < end);
+
+    uint64_t word = unalignedLoad<uint64_t>(end - 8);  // I'm not sure if this is normal.
+    res = static_cast<unsigned>(_mm_crc32_u64(res, word));
+
+    return res;
+  }
+};
+
+struct StringRefHash : CRC32Hash {};
+
+namespace ZeroTraits {
+inline bool check(const StringRef& x) {
+  return 0 == x.size;
+}
+inline void set(StringRef& x) {
+  x.size = 0;
+}
+}  // namespace ZeroTraits
+
+std::ostream& operator<<(std::ostream& os, const StringRef& str);
+
+}  // namespace cider::hashtable

--- a/cpp/src/cider/common/base/StringRef.h
+++ b/cpp/src/cider/common/base/StringRef.h
@@ -22,15 +22,10 @@
 
 #pragma once
 
-#include <cassert>
-#include <functional>
-#include <iosfwd>
-#include <stdexcept>
-#include <string>
-#include <vector>
-
 #include <common/base/unaligned.h>
 #include <common/contrib/cityhash102/include/city.h>
+#include <cassert>
+#include <string>
 
 #include <emmintrin.h>
 #include <nmmintrin.h>
@@ -72,8 +67,6 @@ struct StringRef {
     return std::string_view(data, size);
   }
 };
-
-using StringRefs = std::vector<StringRef>;
 
 /** Compare strings for equality.
  * The approach is controversial and does not win in all cases.

--- a/cpp/src/cider/common/base/StringRef.h
+++ b/cpp/src/cider/common/base/StringRef.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright(c) 2022-2023 Intel Corporation.
  * Copyright (c) 2016-2022 ClickHouse, Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/cpp/src/cider/common/hashtable/HashTableKeyHolder.h
+++ b/cpp/src/cider/common/hashtable/HashTableKeyHolder.h
@@ -20,11 +20,11 @@
  * under the License.
  */
 
+#pragma once
+
 #include <common/Arena.h>
 #include <common/base/StringRef.h>
 #include "type/data/funcannotations.h"
-
-using namespace cider::hashtable;
 
 /**
  * In some aggregation scenarios, when adding a key to the hash table, we
@@ -100,8 +100,6 @@ struct ArenaKeyHolder {
   Arena& pool;
 };
 
-}  // namespace cider::hashtable
-
 inline StringRef& ALWAYS_INLINE keyHolderGetKey(ArenaKeyHolder& holder) {
   return holder.key;
 }
@@ -114,8 +112,6 @@ inline void ALWAYS_INLINE keyHolderPersistKey(ArenaKeyHolder& holder) {
 
 inline void ALWAYS_INLINE keyHolderDiscardKey(ArenaKeyHolder&) {}
 
-namespace cider::hashtable {
-
 /** SerializedKeyHolder is a key holder for a StringRef key that is already
  * serialized to an Arena. The key must be the last allocation in this Arena,
  * and is discarded by rolling back the allocation.
@@ -124,8 +120,6 @@ struct SerializedKeyHolder {
   StringRef key;
   Arena& pool;
 };
-
-}  // namespace cider::hashtable
 
 inline StringRef& ALWAYS_INLINE keyHolderGetKey(SerializedKeyHolder& holder) {
   return holder.key;
@@ -139,3 +133,4 @@ inline void ALWAYS_INLINE keyHolderDiscardKey(SerializedKeyHolder& holder) {
   holder.key.data = nullptr;
   holder.key.size = 0;
 }
+}  // namespace cider::hashtable

--- a/cpp/src/cider/common/hashtable/HashTableKeyHolder.h
+++ b/cpp/src/cider/common/hashtable/HashTableKeyHolder.h
@@ -20,12 +20,11 @@
  * under the License.
  */
 
-#pragma once
-
 #include <common/Arena.h>
+#include <common/base/StringRef.h>
 #include "type/data/funcannotations.h"
 
-namespace cider::hashtable {
+using namespace cider::hashtable;
 
 /**
  * In some aggregation scenarios, when adding a key to the hash table, we
@@ -72,6 +71,8 @@ namespace cider::hashtable {
  * Returns the key. Can return the temporary key initially.
  * After the call to keyHolderPersistKey(), must return the persistent key.
  */
+namespace cider::hashtable {
+
 template <typename Key>
 inline Key& ALWAYS_INLINE keyHolderGetKey(Key&& key) {
   return key;
@@ -89,4 +90,52 @@ inline void ALWAYS_INLINE keyHolderPersistKey(Key&&) {}
  */
 template <typename Key>
 inline void ALWAYS_INLINE keyHolderDiscardKey(Key&&) {}
+
+/**
+ * ArenaKeyHolder is a key holder for hash tables that serializes a StringRef
+ * key to an Arena.
+ */
+struct ArenaKeyHolder {
+  StringRef key;
+  Arena& pool;
+};
+
 }  // namespace cider::hashtable
+
+inline StringRef& ALWAYS_INLINE keyHolderGetKey(ArenaKeyHolder& holder) {
+  return holder.key;
+}
+
+inline void ALWAYS_INLINE keyHolderPersistKey(ArenaKeyHolder& holder) {
+  // Hash table shouldn't ask us to persist a zero key
+  assert(holder.key.size > 0);
+  holder.key.data = holder.pool.insert(holder.key.data, holder.key.size);
+}
+
+inline void ALWAYS_INLINE keyHolderDiscardKey(ArenaKeyHolder&) {}
+
+namespace cider::hashtable {
+
+/** SerializedKeyHolder is a key holder for a StringRef key that is already
+ * serialized to an Arena. The key must be the last allocation in this Arena,
+ * and is discarded by rolling back the allocation.
+ */
+struct SerializedKeyHolder {
+  StringRef key;
+  Arena& pool;
+};
+
+}  // namespace cider::hashtable
+
+inline StringRef& ALWAYS_INLINE keyHolderGetKey(SerializedKeyHolder& holder) {
+  return holder.key;
+}
+
+inline void ALWAYS_INLINE keyHolderPersistKey(SerializedKeyHolder&) {}
+
+inline void ALWAYS_INLINE keyHolderDiscardKey(SerializedKeyHolder& holder) {
+  [[maybe_unused]] void* new_head = holder.pool.rollback(holder.key.size);
+  assert(new_head == holder.key.data);
+  holder.key.data = nullptr;
+  holder.key.size = 0;
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add `Arena.h` based on allocators, `MemoryChunk` is the memory unit. Memory is aligned to `_SC_PAGESIZE` of operation system, and it is padded to `PADDING_FOR_SIMD` for better SIMD performance and memory efficiency.
2. Add `StringRef.h` to preserve strings. It provides high performance for strings comparison through `SSE2` instruction set, which is important for HashTable when the key type is string.
3. Add `CRC32Hash` for String, which is under `SSE4.2` instruction set.
4. Add `StringRef` and `SerializedKeyHolder` to `HashTableKeyHolder` for multiple keys support.


### Why are the changes needed?
Add Arena and StringRef.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.

### Which label does this PR belong to?

