### PR TITLE
[POAE7-2909] Add std::map, std::unordered_map and folly::F14FastMap to HashTable benchmark

### DIFF
--- a/cpp/src/cider/benchmarks/CMakeLists.txt
+++ b/cpp/src/cider/benchmarks/CMakeLists.txt
@@ -30,5 +30,8 @@ if(CIDER_ENABLE_AVX512)
 endif()
 
 target_compile_options(jitlib_benchmark PRIVATE ${JITlibBenchmarkCompileFlag})
+target_compile_options(HashMapBenchmark PRIVATE -msse4.2 -msse2)
+
 target_link_libraries(jitlib_benchmark ${DEP_LIBS} folly fmt::fmt)
-target_link_libraries(HashMapBenchmark benchmark::benchmark cider_hashtable)
+target_link_libraries(HashMapBenchmark benchmark::benchmark ${DEP_LIBS} folly
+                      cider_hashtable)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add std::map, std::unordered_map and folly::F14FastMap to the benchmark of HashTable.
The performance will be better if we use more efficient allocator in the future.

The conclusion is cider optimized HashTable for int8 and int16 gains
**10x-16x** performance better than folly::F14FastMap,
**15x-25x** better than cider basic HashTable,
**36x-100x** better than std::map.

The result shows below:

![image](https://user-images.githubusercontent.com/25916266/224930574-f06242a9-d02b-4f21-b705-0b553bb8adcf.png)


### Why are the changes needed?
Improvement.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.


### Which label does this PR belong to?
