### PR TITLE
[POAE7-2917]resolve duplicated compile in multi drivers

### DIFF
--- a/cpp/src/cider-velox/src/CiderPlanNode.h
+++ b/cpp/src/cider-velox/src/CiderPlanNode.h
@@ -38,19 +38,29 @@ class CiderPlanNode : public core::PlanNode {
   explicit CiderPlanNode(const core::PlanNodeId& id,
                          const core::PlanNodePtr& source,
                          const RowTypePtr& outputType,
-                         const ::substrait::Plan& plan)
+                         const ::substrait::Plan& plan,
+                         bool precompile = false)
       : core::PlanNode(id), sources_({source}), plan_(plan), outputType_(outputType) {
-    auto translator = generator::SubstraitToRelAlgExecutionUnit(plan);
-    RelAlgExecutionUnit ra_exe_unit = translator.createRelAlgExecutionUnit();
-    codegen_context_ = cider::exec::nextgen::compile(ra_exe_unit);
+    if (precompile) {
+      auto translator = generator::SubstraitToRelAlgExecutionUnit(plan);
+      RelAlgExecutionUnit ra_exe_unit = translator.createRelAlgExecutionUnit();
+      codegen_context_ = cider::exec::nextgen::compile(ra_exe_unit);
+    }
   }
 
   explicit CiderPlanNode(const core::PlanNodeId& id,
                          const core::PlanNodePtr& left,
                          const core::PlanNodePtr& right,
                          const RowTypePtr& outputType,
-                         const ::substrait::Plan& plan)
-      : PlanNode(id), sources_({left, right}), plan_(plan), outputType_(outputType) {}
+                         const ::substrait::Plan& plan,
+                         bool precompile = false)
+      : PlanNode(id), sources_({left, right}), plan_(plan), outputType_(outputType) {
+    if (precompile) {
+      auto translator = generator::SubstraitToRelAlgExecutionUnit(plan);
+      RelAlgExecutionUnit ra_exe_unit = translator.createRelAlgExecutionUnit();
+      codegen_context_ = cider::exec::nextgen::compile(ra_exe_unit);
+    }
+  }
 
   const cider::exec::nextgen::context::CodegenCtxPtr& codegenCtx() const {
     return codegen_context_;

--- a/cpp/src/cider-velox/src/CiderPlanNode.h
+++ b/cpp/src/cider-velox/src/CiderPlanNode.h
@@ -25,6 +25,10 @@
 #include "velox/core/PlanNode.h"
 #include "velox/type/Type.h"
 
+#include "exec/nextgen/Nextgen.h"
+#include "exec/nextgen/context/CodegenContext.h"
+#include "exec/plan/parser/SubstraitToRelAlgExecutionUnit.h"
+
 namespace facebook::velox::plugin {
 
 enum class CiderPlanNodeKind { kJoin, kAggregation };
@@ -35,7 +39,11 @@ class CiderPlanNode : public core::PlanNode {
                          const core::PlanNodePtr& source,
                          const RowTypePtr& outputType,
                          const ::substrait::Plan& plan)
-      : core::PlanNode(id), sources_({source}), plan_(plan), outputType_(outputType) {}
+      : core::PlanNode(id), sources_({source}), plan_(plan), outputType_(outputType) {
+    auto translator = generator::SubstraitToRelAlgExecutionUnit(plan);
+    RelAlgExecutionUnit ra_exe_unit = translator.createRelAlgExecutionUnit();
+    codegen_context_ = cider::exec::nextgen::compile(ra_exe_unit);
+  }
 
   explicit CiderPlanNode(const core::PlanNodeId& id,
                          const core::PlanNodePtr& left,
@@ -43,6 +51,10 @@ class CiderPlanNode : public core::PlanNode {
                          const RowTypePtr& outputType,
                          const ::substrait::Plan& plan)
       : PlanNode(id), sources_({left, right}), plan_(plan), outputType_(outputType) {}
+
+  const cider::exec::nextgen::context::CodegenCtxPtr& codegenCtx() const {
+    return codegen_context_;
+  }
 
   const RowTypePtr& outputType() const override;
 
@@ -58,13 +70,16 @@ class CiderPlanNode : public core::PlanNode {
 
  private:
   void addDetails(std::stringstream& stream) const override {
-    stream << "CiderPlanNode: " << plan_.DebugString();
+    stream << "CiderPlanNode: " << plan_.ShortDebugString();
   }
 
   // TODO: will support multiple source?
   const std::vector<core::PlanNodePtr> sources_;
   const ::substrait::Plan plan_;
   const RowTypePtr outputType_;
+
+  // just compile once, and save the compiled result here
+  cider::exec::nextgen::context::CodegenCtxPtr codegen_context_;
 };
 
 }  // namespace facebook::velox::plugin

--- a/cpp/src/cider-velox/src/ciderTransformer/CiderPlanTransformerOptions.cpp
+++ b/cpp/src/cider-velox/src/ciderTransformer/CiderPlanTransformerOptions.cpp
@@ -25,6 +25,6 @@ DEFINE_bool(left_deep_join_pattern, false, "Enable LeftDeepJoinPattern ");
 DEFINE_bool(compound_pattern, false, "Enable CompoundPattern ");
 DEFINE_bool(filter_pattern, true, "Enable FilterPattern ");
 DEFINE_bool(project_pattern, true, "Enable ProjectPattern ");
-DEFINE_bool(partial_agg_pattern, true, "Enable PartialAggPattern ");
+DEFINE_bool(partial_agg_pattern, false, "Enable PartialAggPattern ");
 DEFINE_bool(top_n_pattern, false, "Enable TopNPattern ");
 DEFINE_bool(order_by_pattern, false, "Enable OrderByPattern ");

--- a/cpp/src/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
+++ b/cpp/src/cider-velox/src/ciderTransformer/CiderPlanUtil.cpp
@@ -37,7 +37,8 @@ std::shared_ptr<CiderPlanNode> CiderPlanUtil::toCiderPlanNode(
   return std::make_shared<CiderPlanNode>(planSection.target.nodePtr->id(),
                                          source.nodePtr,
                                          planSection.target.nodePtr->outputType(),
-                                         *sPlan);
+                                         *sPlan,
+                                         true);
 }
 
 std::shared_ptr<CiderPlanNode> CiderPlanUtil::toCiderPlanNode(
@@ -63,7 +64,8 @@ std::shared_ptr<CiderPlanNode> CiderPlanUtil::toCiderPlanNode(
                                         leftSource,
                                         rightSource,
                                         planSection.target.nodePtr->outputType(),
-                                        *sPlan);
+                                        *sPlan,
+                                        true);
     return ciderPlanNode;
   } else {
     VELOX_FAIL(

--- a/cpp/src/cider-velox/test/CiderOperatorTest.cpp
+++ b/cpp/src/cider-velox/test/CiderOperatorTest.cpp
@@ -44,7 +44,7 @@ using namespace facebook::velox::plugin::plantransformer::test;
 
 class CiderOperatorTest : public OperatorTestBase {
   void SetUp() override {
-    FLAGS_partial_agg_pattern = true;
+    // FLAGS_partial_agg_pattern = true;
     vectors = generator_.generate(rowType_, 10, 100, false);
     createDuckDbTable(vectors);
     CiderVeloxPluginCtx::init();
@@ -474,8 +474,14 @@ TEST_F(CiderOperatorTest, partial_avg_null) {
   // FIXME: For partial avg, duckdb returns a row (null, 0) while velox returns a null row
   // when input is an all null column.
   // assertQuery(veloxPlan, duckdbSql); // fail to assert
+  FLAGS_partial_agg_pattern = true;
+  CiderVeloxPluginCtx::init();
   auto resultPtr = CiderVeloxPluginCtx::transformVeloxPlan(veloxPlan);
   assertQuery(resultPtr, duckdbSql);
+
+  // tear down partial_agg_pattern
+  FLAGS_partial_agg_pattern = false;
+  CiderVeloxPluginCtx::init();
 }
 
 TEST_F(CiderOperatorTest, partial_avg_notAllNull) {

--- a/cpp/src/cider-velox/test/CiderOperatorTestBase.h
+++ b/cpp/src/cider-velox/test/CiderOperatorTestBase.h
@@ -30,7 +30,7 @@ class CiderOperatorTestBase : public facebook::velox::exec::test::OperatorTestBa
  protected:
   void SetUp() override {
     FLAGS_left_deep_join_pattern = true;
-    FLAGS_partial_agg_pattern = true;
+    // FLAGS_partial_agg_pattern = true;
     FLAGS_compound_pattern = true;
     // TODO: Enable this after feature fully supported. So that we could enable all
     // supported patterns in our tests.

--- a/cpp/src/cider/exec/nextgen/context/CodegenContext.h
+++ b/cpp/src/cider/exec/nextgen/context/CodegenContext.h
@@ -96,6 +96,9 @@ class CodegenContext {
  public:
   CodegenContext() : jit_func_(nullptr) {}
 
+  // we can reuse the compiled func, but create RuntimeCtx for every driver.
+  RuntimeCtxPtr generateRuntimeCTX(const CiderAllocatorPtr& allocator) const;
+
   void setJITFunction(jitlib::JITFunctionPointer& jit_func) {
     CHECK(nullptr == jit_func_);
     jit_func_ = jit_func;
@@ -179,9 +182,6 @@ class CodegenContext {
   jitlib::JITValuePointer registerCiderSet(const std::string& name,
                                            const SQLTypeInfo& type,
                                            CiderSetPtr c_set);
-
-  RuntimeCtxPtr generateRuntimeCTX(const CiderAllocatorPtr& allocator) const;
-
   struct BatchDescriptor {
     int64_t ctx_id;
     std::string name;

--- a/cpp/src/cider/exec/processor/DefaultBatchProcessor.cpp
+++ b/cpp/src/cider/exec/processor/DefaultBatchProcessor.cpp
@@ -50,6 +50,7 @@ std::string getErrorMessageFromErrCode(const cider::jitlib::ERROR_CODE error_cod
   }
 }
 
+// This API compile from substrait plan everytime.
 DefaultBatchProcessor::DefaultBatchProcessor(
     const plan::SubstraitPlanPtr& plan,
     const BatchProcessorContextPtr& context,
@@ -65,6 +66,7 @@ DefaultBatchProcessor::DefaultBatchProcessor(
           ->getFunctionPointer<int32_t, int8_t*, int8_t*>());
 }
 
+// This API use the precompiled codegen_ctx.
 DefaultBatchProcessor::DefaultBatchProcessor(const plan::SubstraitPlanPtr& plan,
                                              const BatchProcessorContextPtr& context,
                                              const CodegenCtxPtr& codegen_ctx)
@@ -78,6 +80,7 @@ DefaultBatchProcessor::DefaultBatchProcessor(const plan::SubstraitPlanPtr& plan,
           ->getFunctionPointer<int32_t, int8_t*, int8_t*>());
 }
 
+// This API compile from substrait plan everytime.
 DefaultBatchProcessor::DefaultBatchProcessor(
     const substrait::ExtendedExpression& extendedExpression,
     const BatchProcessorContextPtr& context,

--- a/cpp/src/cider/exec/processor/DefaultBatchProcessor.cpp
+++ b/cpp/src/cider/exec/processor/DefaultBatchProcessor.cpp
@@ -55,25 +55,27 @@ DefaultBatchProcessor::DefaultBatchProcessor(
     const BatchProcessorContextPtr& context,
     const cider::exec::nextgen::context::CodegenOptions& codegen_options)
     : context_(context) {
-  auto allocator = context->getAllocator();
-  if (plan->hasJoinRel()) {
-    // TODO: currently we can't distinguish the joinRel is either a hashJoin rel
-    // or a mergeJoin rel, just hard-code as HashJoinHandler for now and will refactor to
-    // initialize joinHandler accordingly once the
-    joinHandler_ = std::make_shared<HashProbeHandler>(shared_from_this());
-    this->state_ = BatchProcessorState::kWaiting;
-  } else if (plan->hasCrossRel()) {
-    joinHandler_ = std::make_shared<CrossProbeHandler>(shared_from_this());
-    this->state_ = BatchProcessorState::kWaiting;
-  }
-
-  auto translator =
-      std::make_shared<generator::SubstraitToRelAlgExecutionUnit>(plan->getPlan());
-  RelAlgExecutionUnit ra_exe_unit = translator->createRelAlgExecutionUnit();
+  initJoinHandler(plan);
+  auto translator = generator::SubstraitToRelAlgExecutionUnit(plan->getPlan());
+  RelAlgExecutionUnit ra_exe_unit = translator.createRelAlgExecutionUnit();
   codegen_context_ = nextgen::compile(ra_exe_unit, codegen_options);
-  runtime_context_ = codegen_context_->generateRuntimeCTX(allocator);
+  runtime_context_ = codegen_context_->generateRuntimeCTX(context_->getAllocator());
   query_func_ = reinterpret_cast<nextgen::QueryFunc>(
-      codegen_context_->getJITFunction()->getFunctionPointer<void, int8_t*, int8_t*>());
+      codegen_context_->getJITFunction()
+          ->getFunctionPointer<int32_t, int8_t*, int8_t*>());
+}
+
+DefaultBatchProcessor::DefaultBatchProcessor(const plan::SubstraitPlanPtr& plan,
+                                             const BatchProcessorContextPtr& context,
+                                             const CodegenCtxPtr& codegen_ctx)
+    : context_(context) {
+  initJoinHandler(plan);
+  // Copy CodegenContext cause JoinHandler will modify it.
+  codegen_context_ = std::make_unique<CodegenContext>(*codegen_ctx);
+  runtime_context_ = codegen_context_->generateRuntimeCTX(context_->getAllocator());
+  query_func_ = reinterpret_cast<nextgen::QueryFunc>(
+      codegen_context_->getJITFunction()
+          ->getFunctionPointer<int32_t, int8_t*, int8_t*>());
 }
 
 DefaultBatchProcessor::DefaultBatchProcessor(
@@ -153,6 +155,19 @@ void DefaultBatchProcessor::feedCrossBuildData(const std::shared_ptr<Batch>& cro
   codegen_context_->setBuildTable(crossData);
 }
 
+void DefaultBatchProcessor::initJoinHandler(const plan::SubstraitPlanPtr& plan) {
+  if (plan->hasJoinRel()) {
+    // TODO: currently we can't distinguish the joinRel is either a hashJoin rel
+    // or a mergeJoin rel, just hard-code as HashJoinHandler for now and will refactor to
+    // initialize joinHandler accordingly once the
+    joinHandler_ = std::make_shared<HashProbeHandler>(shared_from_this());
+    state_ = BatchProcessorState::kWaiting;
+  } else if (plan->hasCrossRel()) {
+    joinHandler_ = std::make_shared<CrossProbeHandler>(shared_from_this());
+    state_ = BatchProcessorState::kWaiting;
+  }
+}
+
 std::unique_ptr<BatchProcessor> BatchProcessor::Make(
     const substrait::Plan& plan,
     const BatchProcessorContextPtr& context,
@@ -162,6 +177,17 @@ std::unique_ptr<BatchProcessor> BatchProcessor::Make(
     return std::make_unique<StatefulProcessor>(substraitPlan, context, codegen_options);
   } else {
     return std::make_unique<StatelessProcessor>(substraitPlan, context, codegen_options);
+  }
+}
+
+std::unique_ptr<BatchProcessor> BatchProcessor::Make(
+    const plan::SubstraitPlanPtr& plan,
+    const BatchProcessorContextPtr& context,
+    const CodegenCtxPtr& codegen_ctx) {
+  if (plan->hasAggregateRel()) {
+    return std::make_unique<StatefulProcessor>(plan, context, codegen_ctx);
+  } else {
+    return std::make_unique<StatelessProcessor>(plan, context, codegen_ctx);
   }
 }
 }  // namespace cider::exec::processor

--- a/cpp/src/cider/exec/processor/DefaultBatchProcessor.h
+++ b/cpp/src/cider/exec/processor/DefaultBatchProcessor.h
@@ -32,12 +32,16 @@ namespace cider::exec::processor {
 
 class DefaultBatchProcessor : public BatchProcessor {
  public:
-  explicit DefaultBatchProcessor(
+  DefaultBatchProcessor(
       const plan::SubstraitPlanPtr& plan,
       const BatchProcessorContextPtr& context,
       const cider::exec::nextgen::context::CodegenOptions& codegen_options = {});
 
-  explicit DefaultBatchProcessor(
+  DefaultBatchProcessor(const plan::SubstraitPlanPtr& plan,
+                        const BatchProcessorContextPtr& context,
+                        const CodegenCtxPtr& codegen_ctx);
+
+  DefaultBatchProcessor(
       const substrait::ExtendedExpression& extendedExpression,
       const BatchProcessorContextPtr& context,
       const cider::exec::nextgen::context::CodegenOptions& codegen_options = {});
@@ -76,6 +80,9 @@ class DefaultBatchProcessor : public BatchProcessor {
   nextgen::context::CodegenCtxPtr codegen_context_;
   nextgen::context::RuntimeCtxPtr runtime_context_;
   nextgen::QueryFunc query_func_;
+
+ private:
+  void initJoinHandler(const plan::SubstraitPlanPtr& plan);
 };
 
 }  // namespace cider::exec::processor

--- a/cpp/src/cider/exec/processor/StatefulProcessor.cpp
+++ b/cpp/src/cider/exec/processor/StatefulProcessor.cpp
@@ -29,9 +29,14 @@ StatefulProcessor::StatefulProcessor(
     const plan::SubstraitPlanPtr& plan,
     const BatchProcessorContextPtr& context,
     const cider::exec::nextgen::context::CodegenOptions& codegen_options)
-    : DefaultBatchProcessor(plan, context, codegen_options) {
-  has_groupby_ = plan->hasGroupingAggregateRel();
-}
+    : DefaultBatchProcessor(plan, context, codegen_options)
+    , has_groupby_(plan->hasGroupingAggregateRel()) {}
+
+StatefulProcessor::StatefulProcessor(const plan::SubstraitPlanPtr& plan,
+                                     const BatchProcessorContextPtr& context,
+                                     const CodegenCtxPtr& codegen_ctx)
+    : DefaultBatchProcessor(plan, context, codegen_ctx)
+    , has_groupby_(plan->hasGroupingAggregateRel()) {}
 
 void StatefulProcessor::getResult(struct ArrowArray& array, struct ArrowSchema& schema) {
   if (!no_more_batch_ || !has_result_) {

--- a/cpp/src/cider/exec/processor/StatefulProcessor.h
+++ b/cpp/src/cider/exec/processor/StatefulProcessor.h
@@ -31,6 +31,9 @@ class StatefulProcessor : public DefaultBatchProcessor {
   StatefulProcessor(const plan::SubstraitPlanPtr& plan,
                     const BatchProcessorContextPtr& context,
                     const cider::exec::nextgen::context::CodegenOptions& codegen_options);
+  StatefulProcessor(const plan::SubstraitPlanPtr& plan,
+                    const BatchProcessorContextPtr& context,
+                    const CodegenCtxPtr& codegen_ctx);
 
   void getResult(struct ArrowArray& array, struct ArrowSchema& schema) override;
 

--- a/cpp/src/cider/include/cider/processor/BatchProcessor.h
+++ b/cpp/src/cider/include/cider/processor/BatchProcessor.h
@@ -27,6 +27,7 @@
 #include "cider/processor/BatchProcessorContext.h"
 #include "cider/processor/JoinHashTableBuilder.h"
 #include "exec/nextgen/context/CodegenContext.h"
+#include "exec/plan/substrait/SubstraitPlan.h"
 #include "substrait/plan.pb.h"
 
 struct ArrowArray;
@@ -74,6 +75,10 @@ class BatchProcessor : public std::enable_shared_from_this<BatchProcessor> {
       const substrait::Plan& plan,
       const BatchProcessorContextPtr& context,
       const nextgen::context::CodegenOptions& codegen_options = {});
+
+  static std::unique_ptr<BatchProcessor> Make(const plan::SubstraitPlanPtr& plan,
+                                              const BatchProcessorContextPtr& context,
+                                              const CodegenCtxPtr& codegen_ctx);
 };
 
 using BatchProcessorPtr = std::shared_ptr<BatchProcessor>;


### PR DESCRIPTION
### What changes were proposed in this pull request?
compile in ciderplannode's constructor, and use the cached codegen context for every driver.


### Why are the changes needed?
resolve duplicated compile in multi drivers


### Does this PR introduce _any_ user-facing change?
keep the old API, but use the new one internally.


### How was this patch tested?
benchmark

### Which label does this PR belong to?
INFRA
