### PR TITLE
[POAE7-2928] Add simple join benchmark to tpch framework

### DIFF
--- a/cpp/src/cider-velox/benchmark/tpch/TpchInMemBenchmark.cpp
+++ b/cpp/src/cider-velox/benchmark/tpch/TpchInMemBenchmark.cpp
@@ -174,6 +174,9 @@ BENCHMARK_GROUP(18);
 BENCHMARK_GROUP(19);
 // BENCHMARK_GROUP(22);
 
+// Simple Join benchmark
+// BENCHMARK_GROUP(23);
+
 int main(int argc, char** argv) {
   folly::init(&argc, &argv, false);
 

--- a/cpp/src/cider-velox/benchmark/tpch/TpchInMemBuilder.h
+++ b/cpp/src/cider-velox/benchmark/tpch/TpchInMemBuilder.h
@@ -56,6 +56,7 @@ class TpchInMemBuilder {
   TpchPlan getQ18Plan(double scaleFactor) const;
   TpchPlan getQ19Plan(double scaleFactor) const;
   TpchPlan getQ22Plan(double scaleFactor) const;
+  TpchPlan getQ23Plan(double scaleFactor) const;
 
   std::unique_ptr<memory::ScopedMemoryPool> pool_ = memory::getDefaultScopedMemoryPool();
 };

--- a/cpp/src/cider/exec/operator/join/CiderJoinHashTable.cpp
+++ b/cpp/src/cider/exec/operator/join/CiderJoinHashTable.cpp
@@ -29,13 +29,19 @@ JoinHashTable::JoinHashTable(cider_hashtable::HashTableType hashTableType) {
     case cider_hashtable::HashTableType::LINEAR_PROBING:
       LPHashTableInstance_ =
           std::make_shared<cider_hashtable::LinearProbeHashTable<LP_TEMPLATE>>();
+      break;
     case cider_hashtable::HashTableType::CHAINED:
       chainedHashTableInstance_ =
           std::make_shared<cider_hashtable::ChainedHashTable<CHAINED_TEMPLATE>>();
+      break;
     case cider_hashtable::HashTableType::FIXED_INT8:
       uInt8HashTableInstance_ = std::make_shared<JoinUInt8HashTable>();
+      break;
     case cider_hashtable::HashTableType::FIXED_INT16:
       uInt16HashTableInstance_ = std::make_shared<JoinUInt16HashTable>();
+      break;
+    default:
+      break;
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add join query based on tpc-h, `nation.n_nationkey ⋈ customer.c_nationkey`.
We can run this query by following steps:
1. Turn ENABLE_BENCHMARK on under cpp/src/cider-velox/CMakeLists.txt
2. make release
3. Cider: `/TpchInMemBenchmark -nopartial_agg_pattern -left_deep_join_pattern -run_query_verbose=23 -scale_factor=1`. 
4. Velox: `./TpchInMemBenchmark -nopartial_agg_pattern -run_query_verbose=23 -scale_factor=1`.


### Why are the changes needed?
Improvement.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.

### Which label does this PR belong to?
